### PR TITLE
feat: add price calculation breakdown with editable margin and wage

### DIFF
--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -251,9 +251,7 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                                                     />
                                                 </InputGroup>
                                             </FormControl>
-                                            <FormDescription>
-                                                Auto-calculated above. Edit to override.
-                                            </FormDescription>
+                                            <FormDescription>Auto-calculated above. Edit to override.</FormDescription>
                                             <FormMessage />
                                         </FormItem>
                                     )}

--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -15,15 +15,14 @@ import makeEditDesignRequest from '../../api/endpoints/editDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
 import ImageUpload from '../../components/ImageUpload';
+import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
 import TimeInput from '../../components/TimeInput';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
+import { usePriceSettings } from '../../hooks/usePriceSettings';
 import { getTotalMaterialCosts } from '../../utils/getPriceOfMaterials';
 import { getWageCosts } from '../../utils/getWageCost';
-
-const PROFIT_COEFFICIENT = 1.15;
-const HOURLY_WAGE = 10;
 
 interface DesignEditFormProps {
     design: Design;
@@ -49,6 +48,7 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
 
     const { accessToken, login, logout } = useAuth();
     const [isMakingRequest, setIsMakingRequest] = useState(false);
+    const { hourlyWage, profitMargin, updateHourlyWage, updateProfitMargin } = usePriceSettings();
 
     const { data } = useQuery({
         ...getMaterialsQuery(() => accessToken, login, logout),
@@ -97,15 +97,13 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
         if (!data) return;
 
         const materialsCost = selectedMaterials.length > 0 ? getTotalMaterialCosts(selectedMaterials) : 0;
-
-        const timeSpentCost = parseFloat((getWageCosts(currentTimeRequired) * HOURLY_WAGE).toFixed(2));
-
-        const totalCosts = materialsCost + timeSpentCost;
-        const finalPrice = parseFloat((totalCosts * PROFIT_COEFFICIENT).toFixed(2));
+        const timeSpentCost = parseFloat((getWageCosts(currentTimeRequired) * hourlyWage).toFixed(2));
+        const subtotal = materialsCost + timeSpentCost;
+        const finalPrice = parseFloat((subtotal * (1 + profitMargin / 100)).toFixed(2));
 
         form.setValue('totalMaterialCosts', materialsCost);
         form.setValue('price', finalPrice);
-    }, [selectedMaterials, currentTimeRequired, data, form]);
+    }, [selectedMaterials, currentTimeRequired, hourlyWage, profitMargin, data, form]);
 
     if (!data) {
         return null;
@@ -221,34 +219,46 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                         <h2 className="text-lg font-medium text-center">Set Price</h2>
                     </div>
                     <div className="col-span-8">
-                        <FormField
-                            control={form.control}
-                            name="price"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Price</FormLabel>
-                                    <FormControl>
-                                        <InputGroup className="max-w-[180px]">
-                                            <InputGroupAddon align="inline-start">
-                                                <InputGroupText>£</InputGroupText>
-                                            </InputGroupAddon>
-                                            <InputGroupInput
-                                                type="number"
-                                                step="0.01"
-                                                placeholder="0.00"
-                                                {...field}
-                                                value={field.value ?? ''}
-                                                onChange={(e) => {
-                                                    const value = e.target.value;
-
-                                                    field.onChange(value === '' ? undefined : Number(value));
-                                                }}
-                                            />
-                                        </InputGroup>
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
+                        <PriceBreakdown
+                            materialsCost={form.watch('totalMaterialCosts') ?? 0}
+                            timeRequired={currentTimeRequired}
+                            hourlyWage={hourlyWage}
+                            profitMargin={profitMargin}
+                            onHourlyWageChange={updateHourlyWage}
+                            onProfitMarginChange={updateProfitMargin}
+                            priceField={
+                                <FormField
+                                    control={form.control}
+                                    name="price"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Final Price</FormLabel>
+                                            <FormControl>
+                                                <InputGroup className="max-w-[180px]">
+                                                    <InputGroupAddon align="inline-start">
+                                                        <InputGroupText>£</InputGroupText>
+                                                    </InputGroupAddon>
+                                                    <InputGroupInput
+                                                        type="number"
+                                                        step="0.01"
+                                                        placeholder="0.00"
+                                                        {...field}
+                                                        value={field.value ?? ''}
+                                                        onChange={(e) => {
+                                                            const value = e.target.value;
+                                                            field.onChange(value === '' ? undefined : Number(value));
+                                                        }}
+                                                    />
+                                                </InputGroup>
+                                            </FormControl>
+                                            <FormDescription>
+                                                Auto-calculated above. Edit to override.
+                                            </FormDescription>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            }
                         />
                     </div>
                 </div>

--- a/packages/web/src/components/PriceBreakdown/index.tsx
+++ b/packages/web/src/components/PriceBreakdown/index.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from 'react';
+
+import { Input } from '@/components/ui/input';
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+
+import { getWageCosts } from '../../utils/getWageCost';
+
+interface PriceBreakdownProps {
+    materialsCost: number;
+    timeRequired: string;
+    hourlyWage: number;
+    profitMargin: number;
+    onHourlyWageChange: (value: number) => void;
+    onProfitMarginChange: (value: number) => void;
+    priceField: ReactNode;
+}
+
+const formatTime = (timeRequired: string): string => {
+    const [hoursStr, minutesStr] = timeRequired.split(':');
+    const hours = parseInt(hoursStr, 10);
+    const minutes = parseInt(minutesStr, 10);
+
+    if (isNaN(hours) || isNaN(minutes)) return '0 min';
+
+    const parts: string[] = [];
+    if (hours > 0) parts.push(`${hours} hr`);
+    if (minutes > 0) parts.push(`${minutes} min`);
+    return parts.length > 0 ? parts.join(' ') : '0 min';
+};
+
+const PriceBreakdown: React.FC<PriceBreakdownProps> = ({
+    materialsCost,
+    timeRequired,
+    hourlyWage,
+    profitMargin,
+    onHourlyWageChange,
+    onProfitMarginChange,
+    priceField,
+}) => {
+    const labourHours = timeRequired ? getWageCosts(timeRequired) : 0;
+    const labourCost = parseFloat((labourHours * hourlyWage).toFixed(2));
+    const subtotal = parseFloat((materialsCost + labourCost).toFixed(2));
+    const profitAmount = parseFloat((subtotal * (profitMargin / 100)).toFixed(2));
+    const calculatedPrice = parseFloat((subtotal + profitAmount).toFixed(2));
+
+    const timeDisplay = timeRequired ? formatTime(timeRequired) : '0 min';
+
+    return (
+        <div className="space-y-4">
+            {/* Editable settings row */}
+            <div className="flex gap-6">
+                <div className="space-y-1.5">
+                    <Label className="text-sm">Hourly Wage</Label>
+                    <InputGroup className="max-w-[140px]">
+                        <InputGroupAddon align="inline-start">
+                            <InputGroupText>£</InputGroupText>
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            type="number"
+                            min="0"
+                            step="0.50"
+                            value={hourlyWage}
+                            onChange={(e) => {
+                                const v = parseFloat(e.target.value);
+                                if (!isNaN(v) && v >= 0) onHourlyWageChange(v);
+                            }}
+                        />
+                        <InputGroupAddon align="inline-end">
+                            <InputGroupText>/hr</InputGroupText>
+                        </InputGroupAddon>
+                    </InputGroup>
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-sm">Profit Margin</Label>
+                    <InputGroup className="max-w-[120px]">
+                        <InputGroupInput
+                            type="number"
+                            min="0"
+                            step="1"
+                            value={profitMargin}
+                            onChange={(e) => {
+                                const v = parseFloat(e.target.value);
+                                if (!isNaN(v) && v >= 0) onProfitMarginChange(v);
+                            }}
+                        />
+                        <InputGroupAddon align="inline-end">
+                            <InputGroupText>%</InputGroupText>
+                        </InputGroupAddon>
+                    </InputGroup>
+                </div>
+            </div>
+
+            {/* Step-by-step breakdown */}
+            <div className="rounded-md border bg-muted/50 p-4 text-sm space-y-2">
+                <div className="flex justify-between">
+                    <span className="text-muted-foreground">Materials cost</span>
+                    <span className="font-mono">£{materialsCost.toFixed(2)}</span>
+                </div>
+                <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                        Labour cost{' '}
+                        <span className="text-xs">
+                            ({timeDisplay} × £{hourlyWage}/hr)
+                        </span>
+                    </span>
+                    <span className="font-mono">£{labourCost.toFixed(2)}</span>
+                </div>
+                <Separator />
+                <div className="flex justify-between">
+                    <span className="text-muted-foreground">Subtotal</span>
+                    <span className="font-mono">£{subtotal.toFixed(2)}</span>
+                </div>
+                <div className="flex justify-between">
+                    <span className="text-muted-foreground">Profit ({profitMargin}%)</span>
+                    <span className="font-mono">+£{profitAmount.toFixed(2)}</span>
+                </div>
+                <Separator />
+                <div className="flex justify-between font-medium">
+                    <span>Calculated Price</span>
+                    <span className="font-mono">£{calculatedPrice.toFixed(2)}</span>
+                </div>
+            </div>
+
+            {/* Final price field (manually editable override) */}
+            {priceField}
+        </div>
+    );
+};
+
+export default PriceBreakdown;

--- a/packages/web/src/components/PriceBreakdown/index.tsx
+++ b/packages/web/src/components/PriceBreakdown/index.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 
-import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
@@ -22,7 +21,7 @@ const formatTime = (timeRequired: string): string => {
     const hours = parseInt(hoursStr, 10);
     const minutes = parseInt(minutesStr, 10);
 
-    if (isNaN(hours) || isNaN(minutes)) return '0 min';
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return '0 min';
 
     const parts: string[] = [];
     if (hours > 0) parts.push(`${hours} hr`);
@@ -64,7 +63,7 @@ const PriceBreakdown: React.FC<PriceBreakdownProps> = ({
                             value={hourlyWage}
                             onChange={(e) => {
                                 const v = parseFloat(e.target.value);
-                                if (!isNaN(v) && v >= 0) onHourlyWageChange(v);
+                                if (!Number.isNaN(v) && v >= 0) onHourlyWageChange(v);
                             }}
                         />
                         <InputGroupAddon align="inline-end">
@@ -82,7 +81,7 @@ const PriceBreakdown: React.FC<PriceBreakdownProps> = ({
                             value={profitMargin}
                             onChange={(e) => {
                                 const v = parseFloat(e.target.value);
-                                if (!isNaN(v) && v >= 0) onProfitMarginChange(v);
+                                if (!Number.isNaN(v) && v >= 0) onProfitMarginChange(v);
                             }}
                         />
                         <InputGroupAddon align="inline-end">

--- a/packages/web/src/hooks/usePriceSettings.ts
+++ b/packages/web/src/hooks/usePriceSettings.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+const HOURLY_WAGE_KEY = 'jc_hourly_wage';
+const PROFIT_MARGIN_KEY = 'jc_profit_margin';
+
+const DEFAULT_HOURLY_WAGE = 10;
+const DEFAULT_PROFIT_MARGIN = 15;
+
+const readFloat = (key: string, fallback: number): number => {
+    const stored = localStorage.getItem(key);
+    if (stored === null) return fallback;
+    const parsed = parseFloat(stored);
+    return isNaN(parsed) ? fallback : parsed;
+};
+
+export const usePriceSettings = () => {
+    const [hourlyWage, setHourlyWage] = useState(() => readFloat(HOURLY_WAGE_KEY, DEFAULT_HOURLY_WAGE));
+    const [profitMargin, setProfitMargin] = useState(() => readFloat(PROFIT_MARGIN_KEY, DEFAULT_PROFIT_MARGIN));
+
+    const updateHourlyWage = (value: number) => {
+        setHourlyWage(value);
+        localStorage.setItem(HOURLY_WAGE_KEY, value.toString());
+    };
+
+    const updateProfitMargin = (value: number) => {
+        setProfitMargin(value);
+        localStorage.setItem(PROFIT_MARGIN_KEY, value.toString());
+    };
+
+    return { hourlyWage, profitMargin, updateHourlyWage, updateProfitMargin };
+};

--- a/packages/web/src/hooks/usePriceSettings.ts
+++ b/packages/web/src/hooks/usePriceSettings.ts
@@ -10,7 +10,7 @@ const readFloat = (key: string, fallback: number): number => {
     const stored = localStorage.getItem(key);
     if (stored === null) return fallback;
     const parsed = parseFloat(stored);
-    return isNaN(parsed) ? fallback : parsed;
+    return Number.isNaN(parsed) ? fallback : parsed;
 };
 
 export const usePriceSettings = () => {

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -16,15 +16,14 @@ import makeAddDesignRequest from '../../api/endpoints/addDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
 import ImageUpload from '../../components/ImageUpload';
+import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
 import TimeInput from '../../components/TimeInput';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
+import { usePriceSettings } from '../../hooks/usePriceSettings';
 import { getTotalMaterialCosts } from '../../utils/getPriceOfMaterials';
 import { getWageCosts } from '../../utils/getWageCost';
-
-const PROFIT_COEFFICIENT = 1.15;
-const HOURLY_WAGE = 10;
 
 const AddDesign: React.FC = () => {
     const form = useForm({
@@ -43,6 +42,7 @@ const AddDesign: React.FC = () => {
 
     const { accessToken, login, logout } = useAuth();
     const [isMakingRequest, setIsMakingRequest] = useState(false);
+    const { hourlyWage, profitMargin, updateHourlyWage, updateProfitMargin } = usePriceSettings();
 
     const { data } = useQuery({
         ...getMaterialsQuery(() => accessToken, login, logout),
@@ -91,15 +91,13 @@ const AddDesign: React.FC = () => {
         if (!data) return;
 
         const materialsCost = selectedMaterials.length > 0 ? getTotalMaterialCosts(selectedMaterials) : 0;
-
-        const timeSpentCost = parseFloat((getWageCosts(currentTimeRequired) * HOURLY_WAGE).toFixed(2));
-
-        const totalCosts = materialsCost + timeSpentCost;
-        const finalPrice = parseFloat((totalCosts * PROFIT_COEFFICIENT).toFixed(2));
+        const timeSpentCost = parseFloat((getWageCosts(currentTimeRequired) * hourlyWage).toFixed(2));
+        const subtotal = materialsCost + timeSpentCost;
+        const finalPrice = parseFloat((subtotal * (1 + profitMargin / 100)).toFixed(2));
 
         form.setValue('totalMaterialCosts', materialsCost);
         form.setValue('price', finalPrice);
-    }, [selectedMaterials, currentTimeRequired, data, form.setValue]);
+    }, [selectedMaterials, currentTimeRequired, hourlyWage, profitMargin, data, form.setValue]);
 
     if (!data) {
         return null;
@@ -222,34 +220,46 @@ const AddDesign: React.FC = () => {
                             <h2 className="text-lg font-medium text-center">Set Price</h2>
                         </div>
                         <div className="col-span-8">
-                            <FormField
-                                control={form.control}
-                                name="price"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Price</FormLabel>
-                                        <FormControl>
-                                            <InputGroup className="max-w-[180px]">
-                                                <InputGroupAddon align="inline-start">
-                                                    <InputGroupText>£</InputGroupText>
-                                                </InputGroupAddon>
-                                                <InputGroupInput
-                                                    type="number"
-                                                    step="0.01"
-                                                    placeholder="0.00"
-                                                    {...field}
-                                                    value={field.value ?? ''}
-                                                    onChange={(e) => {
-                                                        const value = e.target.value;
-
-                                                        field.onChange(value === '' ? undefined : Number(value));
-                                                    }}
-                                                />
-                                            </InputGroup>
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
+                            <PriceBreakdown
+                                materialsCost={form.watch('totalMaterialCosts') ?? 0}
+                                timeRequired={currentTimeRequired}
+                                hourlyWage={hourlyWage}
+                                profitMargin={profitMargin}
+                                onHourlyWageChange={updateHourlyWage}
+                                onProfitMarginChange={updateProfitMargin}
+                                priceField={
+                                    <FormField
+                                        control={form.control}
+                                        name="price"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>Final Price</FormLabel>
+                                                <FormControl>
+                                                    <InputGroup className="max-w-[180px]">
+                                                        <InputGroupAddon align="inline-start">
+                                                            <InputGroupText>£</InputGroupText>
+                                                        </InputGroupAddon>
+                                                        <InputGroupInput
+                                                            type="number"
+                                                            step="0.01"
+                                                            placeholder="0.00"
+                                                            {...field}
+                                                            value={field.value ?? ''}
+                                                            onChange={(e) => {
+                                                                const value = e.target.value;
+                                                                field.onChange(value === '' ? undefined : Number(value));
+                                                            }}
+                                                        />
+                                                    </InputGroup>
+                                                </FormControl>
+                                                <FormDescription>
+                                                    Auto-calculated above. Edit to override.
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                }
                             />
                         </div>
                     </div>

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -247,7 +247,9 @@ const AddDesign: React.FC = () => {
                                                             value={field.value ?? ''}
                                                             onChange={(e) => {
                                                                 const value = e.target.value;
-                                                                field.onChange(value === '' ? undefined : Number(value));
+                                                                field.onChange(
+                                                                    value === '' ? undefined : Number(value)
+                                                                );
                                                             }}
                                                         />
                                                     </InputGroup>


### PR DESCRIPTION
Replaces hardcoded PROFIT_COEFFICIENT and HOURLY_WAGE constants with
editable fields that persist to localStorage. A step-by-step breakdown
panel shows materials cost, labour cost, subtotal, profit amount and
calculated price so users can clearly see how the final price is derived.
The final price field remains manually editable for one-off overrides.

https://claude.ai/code/session_019aQd4Mr5DEdk8MBhdzPBri