### PR TITLE
feat: display app version next to logo and title in NavBar

### DIFF
--- a/packages/web/src/components/NavBar/index.tsx
+++ b/packages/web/src/components/NavBar/index.tsx
@@ -35,7 +35,12 @@ const NavBar = () => {
                         className="w-16 h-16 object-scale-down cursor-pointer"
                         onClick={() => navigate(HOME_PAGE.route)}
                     />
-                    <h1 className="text-3xl font-bold leading-[80px] truncate">Jewellery Catalogue</h1>
+                    <div className="flex flex-col justify-center">
+                        <h1 className="text-3xl font-bold truncate">Jewellery Catalogue</h1>
+                        {typeof __APP_VERSION__ !== 'undefined' && __APP_VERSION__ && (
+                            <span className="text-xs text-muted-foreground select-none">v{__APP_VERSION__}</span>
+                        )}
+                    </div>
                 </div>
             </header>
 

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+declare const __IS_PROD__: boolean;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,9 +1,12 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {
     const isDev = mode === 'development';
+    const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    const appVersion = process.env.APP_VERSION || packageJson.version || (isDev ? 'localhost' : '');
 
     return {
         plugins: [react()],
@@ -14,7 +17,7 @@ export default defineConfig(({ mode }) => {
             },
         },
         define: {
-            __APP_VERSION__: JSON.stringify(process.env.APP_VERSION || (isDev ? 'localhost' : '')),
+            __APP_VERSION__: JSON.stringify(appVersion),
             __IS_PROD__: JSON.stringify(!isDev),
         },
         build: {


### PR DESCRIPTION
Reads version from package.json (with APP_VERSION env var override),
injects it as __APP_VERSION__ at build time, and renders it below the
"Jewellery Catalogue" h1 in the top-left header.