### PR TITLE
fix: convert requiredLength from cm to metres in frontend availability calculations

### DIFF
--- a/packages/web/src/components/DesignUpdateForm/index.tsx
+++ b/packages/web/src/components/DesignUpdateForm/index.tsx
@@ -91,7 +91,7 @@ const DesignUpdateForm: React.FC<IDesignUpdateFormProps> = ({ design, onSuccess,
             switch (material.type) {
                 case MaterialType.WIRE:
                 case MaterialType.CHAIN: {
-                    required = (requiredMaterial as any).requiredLength;
+                    required = (requiredMaterial as any).requiredLength / 100;
                     available = (material as any).totalLength;
                     unit = 'm';
                     break;
@@ -158,7 +158,7 @@ const DesignUpdateForm: React.FC<IDesignUpdateFormProps> = ({ design, onSuccess,
             switch (material.type) {
                 case MaterialType.WIRE:
                 case MaterialType.CHAIN: {
-                    required = (requiredMaterial as any).requiredLength;
+                    required = (requiredMaterial as any).requiredLength / 100;
                     available = (material as any).totalLength;
                     unit = 'm';
                     break;

--- a/packages/web/src/components/VariantSelector/index.tsx
+++ b/packages/web/src/components/VariantSelector/index.tsx
@@ -22,7 +22,7 @@ function getRequiredAndAvailable(
         case MaterialType.WIRE:
         case MaterialType.CHAIN:
             return {
-                required: (requiredMaterial as any).requiredLength,
+                required: (requiredMaterial as any).requiredLength / 100,
                 available: (material as any).totalLength,
                 unit: 'm',
             };


### PR DESCRIPTION
## Summary

- `DesignUpdateForm` was comparing `requiredLength` (stored in cm) directly against `totalLength` (stored in metres), causing the "Can Make" count to always show 0 for wire/chain materials and the estimated deduction preview to display values 100× too large
- `VariantSelector` had the same issue in `getRequiredAndAvailable`, making per-variant "Can Make" counts wrong for wire/chain materials
- Both components now divide `requiredLength` by 100 before use, matching the existing conversion in `getPriceOfMaterials`

## Test plan

- [ ] Add a wire/chain material with e.g. 5m stock
- [ ] Create a design requiring 20cm of that material
- [ ] Open the design's update/produce form — "Required/Design" should show `0.20 m`, "In Stock" `5.00 m`, "Can Make" `25`
- [ ] Estimated deduction preview should show `5.00 m → 4.80 m (-0.20 m)` when producing 1
- [ ] For variant designs, the variant selector table should show correct "Can Make" counts for wire/chain variant materials

https://claude.ai/code/session_01FRmDeJGR2L1G8jaLt45gyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRmDeJGR2L1G8jaLt45gyE)_