### PR TITLE
Allow floating point low stock threshold for materials

### DIFF
--- a/packages/types/src/baseMaterial/index.ts
+++ b/packages/types/src/baseMaterial/index.ts
@@ -10,7 +10,7 @@ export const baseMaterialSchema = z.object({
     materialCode: z.string().optional(),
     type: z.enum(MaterialType),
     dateAdded: z.string().datetime(),
-    lowStockThreshold: z.number().int().nonnegative().optional(),
+    lowStockThreshold: z.number().nonnegative().optional(),
 });
 
 export type BaseMaterial = z.infer<typeof baseMaterialSchema>;

--- a/packages/types/src/formMaterial/index.ts
+++ b/packages/types/src/formMaterial/index.ts
@@ -18,7 +18,7 @@ const baseFormMaterialSchema = z.object({
         .number({ message: 'Please enter the number of packs' })
         .int()
         .positive('Number of packs must be at least 1'),
-    lowStockThreshold: z.number().int().nonnegative().optional(),
+    lowStockThreshold: z.number().nonnegative().optional(),
 });
 
 export const formWireSchema = baseFormMaterialSchema.extend({

--- a/packages/types/src/updateMaterial/index.ts
+++ b/packages/types/src/updateMaterial/index.ts
@@ -12,7 +12,7 @@ const baseUpdateMaterialSchema = z.object({
         .positive('Price must be greater than 0')
         .optional(),
     addPacks: z.number().int().positive('Number of packs must be at least 1').optional(),
-    lowStockThreshold: z.number().int().nonnegative().optional(),
+    lowStockThreshold: z.number().nonnegative().optional(),
 });
 
 // Wire update schema

--- a/packages/web/src/components/MaterialFormResolver/Forms/Bead/index.tsx
+++ b/packages/web/src/components/MaterialFormResolver/Forms/Bead/index.tsx
@@ -85,9 +85,9 @@ const AddBeadForm: React.FC<IMaterialFormProps> = ({ form }) => {
                             <InputGroup className="max-w-[150px]">
                                 <InputGroupInput
                                     type="number"
-                                    step="1"
+                                    step="any"
                                     min="0"
-                                    placeholder="e.g., 2"
+                                    placeholder="e.g., 1.5"
                                     {...field}
                                     value={field.value ?? ''}
                                     onChange={(e) => {

--- a/packages/web/src/components/MaterialFormResolver/Forms/Chain/index.tsx
+++ b/packages/web/src/components/MaterialFormResolver/Forms/Chain/index.tsx
@@ -131,9 +131,9 @@ const AddChainForm: React.FC<IMaterialFormProps> = ({ form }) => {
                             <InputGroup className="max-w-[150px]">
                                 <InputGroupInput
                                     type="number"
-                                    step="1"
+                                    step="any"
                                     min="0"
-                                    placeholder="e.g., 2"
+                                    placeholder="e.g., 1.5"
                                     {...field}
                                     value={field.value ?? ''}
                                     onChange={(e) => {

--- a/packages/web/src/components/MaterialFormResolver/Forms/EarHook/index.tsx
+++ b/packages/web/src/components/MaterialFormResolver/Forms/EarHook/index.tsx
@@ -98,9 +98,9 @@ const AddEarHookForm: React.FC<IMaterialFormProps> = ({ form }) => {
                             <Input
                                 className="max-w-[150px]"
                                 type="number"
-                                step="1"
+                                step="any"
                                 min="0"
-                                placeholder="e.g., 2"
+                                placeholder="e.g., 1.5"
                                 {...field}
                                 value={field.value ?? ''}
                                 onChange={(e) => {

--- a/packages/web/src/components/MaterialFormResolver/Forms/Wire/index.tsx
+++ b/packages/web/src/components/MaterialFormResolver/Forms/Wire/index.tsx
@@ -131,9 +131,9 @@ const AddWireForm: React.FC<IMaterialFormProps> = ({ form }) => {
                             <InputGroup className="max-w-[150px]">
                                 <InputGroupInput
                                     type="number"
-                                    step="1"
+                                    step="any"
                                     min="0"
-                                    placeholder="e.g., 2"
+                                    placeholder="e.g., 1.5"
                                     {...field}
                                     value={field.value ?? ''}
                                     onChange={(e) => {

--- a/packages/web/src/components/MaterialUpdateForm/index.tsx
+++ b/packages/web/src/components/MaterialUpdateForm/index.tsx
@@ -240,9 +240,9 @@ const MaterialUpdateForm: React.FC<IMaterialUpdateFormProps> = ({ material, onSu
                                         <Input
                                             className="max-w-[150px]"
                                             type="number"
-                                            step="1"
+                                            step="any"
                                             min="0"
-                                            placeholder="e.g., 2"
+                                            placeholder="e.g., 1.5"
                                             {...field}
                                             value={field.value ?? ''}
                                             onChange={(e) => {


### PR DESCRIPTION
Removes the .int() constraint from all material Zod schemas and changes
form inputs from step="1" to step="any" so users can set fractional
thresholds like 1.5 packs.

https://claude.ai/code/session_01DtxC53BT7Nz5PLB1AEwLFS