### PR TITLE
feat: draft autosave for material and design forms

### DIFF
--- a/packages/api/src/dependencies/index.test.ts
+++ b/packages/api/src/dependencies/index.test.ts
@@ -72,11 +72,11 @@ describe('Dependencies', () => {
             expect(container.constructors?.[DependencyToken.DesignService]).toBeDefined();
         });
 
-        it('should register exactly 10 dependencies', () => {
+        it('should register exactly 12 dependencies', () => {
             registerDepdendencies();
             const container = dependencyContainer as any;
             const registeredCount = Object.keys(container.constructors || {}).length;
-            expect(registeredCount).toBe(10);
+            expect(registeredCount).toBe(12);
         });
 
         it('should register all expected tokens', () => {
@@ -95,6 +95,8 @@ describe('Dependencies', () => {
                 DependencyToken.MaterialService,
                 DependencyToken.ImageService,
                 DependencyToken.DesignService,
+                DependencyToken.DraftRepository,
+                DependencyToken.DraftService,
             ];
 
             expectedTokens.forEach((token) => {

--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -2,10 +2,12 @@
 import { DependencyContainer, Logger, MongoDbConnection, ObjectStoreConnection } from '@imapps/api-utils';
 
 import { DesignService } from '../domain/DesignService';
+import { DraftService } from '../domain/DraftService';
 import { ImageService } from '../domain/ImageService';
 import { MaterialService } from '../domain/MaterialService';
 import { BucketStore } from '../infrastructure/BucketStore';
 import { MongoDesignRepository } from '../infrastructure/MongoDesignRepository';
+import { MongoDraftRepository } from '../infrastructure/MongoDraftRepository';
 import { MongoMaterialRepository } from '../infrastructure/MongoMaterialRepository';
 import { UuidGenerator } from '../infrastructure/UuidGenerator';
 import { type Dependencies, DependencyToken } from './types';
@@ -84,6 +86,28 @@ export const registerDepdendencies = () => {
                     dependencyContainer.resolve(DependencyToken.ImageService),
                     dependencyContainer.resolve(DependencyToken.IdGenerator),
                     dependencyContainer.resolve(DependencyToken.MaterialRepository)
+                );
+            }
+        } as any
+    );
+
+    dependencyContainer.registerSingleton(
+        DependencyToken.DraftRepository,
+        class {
+            constructor() {
+                return new MongoDraftRepository(dependencyContainer.resolve(DependencyToken.Database));
+            }
+        } as any
+    );
+
+    dependencyContainer.registerSingleton(
+        DependencyToken.DraftService,
+        class {
+            constructor() {
+                return new DraftService(
+                    dependencyContainer.resolve(DependencyToken.DraftRepository),
+                    dependencyContainer.resolve(DependencyToken.ImageService),
+                    dependencyContainer.resolve(DependencyToken.IdGenerator)
                 );
             }
         } as any

--- a/packages/api/src/dependencies/types.ts
+++ b/packages/api/src/dependencies/types.ts
@@ -1,8 +1,10 @@
 import type { Logger, MongoDbConnection, ObjectStoreConnection } from '@imapps/api-utils';
-import type { Design, Material } from '@jewellery-catalogue/types';
+import type { Design, Draft, Material } from '@jewellery-catalogue/types';
 
 import type { DesignRepository } from '../domain/DesignRepository';
 import type { DesignService } from '../domain/DesignService';
+import type { DraftRepository } from '../domain/DraftRepository';
+import type { DraftService } from '../domain/DraftService';
 import type { IdGenerator } from '../domain/IdGenerator';
 import type { ImageService } from '../domain/ImageService';
 import type { ImageStore } from '../domain/ImageService/types';
@@ -13,6 +15,7 @@ import type { MaterialService } from '../domain/MaterialService';
 export type Collections = {
     [CollectionNames.Designs]: Design;
     [CollectionNames.Materials]: Material;
+    [CollectionNames.Drafts]: Draft;
 };
 
 export enum DependencyToken {
@@ -22,10 +25,12 @@ export enum DependencyToken {
     // Repositories
     DesignRepository = 'DesignRepository',
     MaterialRepository = 'MaterialRepository',
+    DraftRepository = 'DraftRepository',
     // Services
     DesignService = 'DesignService',
     MaterialService = 'MaterialService',
     ImageService = 'ImageService',
+    DraftService = 'DraftService',
     // Infrastructure
     IdGenerator = 'IdGenerator',
     ImageStore = 'ImageStore',
@@ -39,10 +44,12 @@ export type Dependencies = {
     // Repositories
     [DependencyToken.DesignRepository]: DesignRepository;
     [DependencyToken.MaterialRepository]: MaterialRepository;
+    [DependencyToken.DraftRepository]: DraftRepository;
     // Services
     [DependencyToken.DesignService]: DesignService;
     [DependencyToken.MaterialService]: MaterialService;
     [DependencyToken.ImageService]: ImageService;
+    [DependencyToken.DraftService]: DraftService;
     // Infrastructure
     [DependencyToken.IdGenerator]: IdGenerator;
     [DependencyToken.ImageStore]: ImageStore;
@@ -51,4 +58,5 @@ export type Dependencies = {
 export enum CollectionNames {
     Designs = 'designs',
     Materials = 'materials',
+    Drafts = 'drafts',
 }

--- a/packages/api/src/domain/DesignService/index.ts
+++ b/packages/api/src/domain/DesignService/index.ts
@@ -115,6 +115,68 @@ export class DesignService {
         return design;
     }
 
+    async addDesignWithImageId(designData: UploadDesign, imageId: string, userId: string): Promise<Design> {
+        if (!userId) {
+            throw Object.assign(new Error('User ID is required'), { status: 400 });
+        }
+
+        const designId = this.idGenerator.generate();
+
+        let materials: Array<RequiredMaterial>;
+
+        try {
+            materials =
+                typeof designData.materials === 'string' ? JSON.parse(designData.materials) : designData.materials;
+        } catch {
+            throw Object.assign(new Error('Invalid materials format'), { status: 400 });
+        }
+
+        let variationGroups: VariationGroup[] | undefined;
+        let variants: DesignVariant[] | undefined;
+
+        if (designData.variationGroups) {
+            try {
+                variationGroups =
+                    typeof designData.variationGroups === 'string'
+                        ? JSON.parse(designData.variationGroups)
+                        : designData.variationGroups;
+            } catch {
+                throw Object.assign(new Error('Invalid variationGroups format'), { status: 400 });
+            }
+        }
+
+        if (designData.variants) {
+            try {
+                const parsed: DesignVariant[] =
+                    typeof designData.variants === 'string' ? JSON.parse(designData.variants) : designData.variants;
+                variants = parsed.map((v) => ({ ...v, totalQuantity: 0 }));
+            } catch {
+                throw Object.assign(new Error('Invalid variants format'), { status: 400 });
+            }
+        }
+
+        const design: Design = {
+            id: designId,
+            userId,
+            name: designData.name,
+            description: designData.description,
+            timeRequired: designData.timeRequired,
+            totalMaterialCosts: designData.totalMaterialCosts,
+            price: designData.price,
+            imageId,
+            materials,
+            dateAdded: new Date(),
+            totalQuantity: 0,
+            lowStockThreshold: designData.lowStockThreshold,
+            variationGroups,
+            variants,
+        };
+
+        await this.designRepo.insert(design);
+
+        return design;
+    }
+
     async updateDesign(id: string, updates: UpdateDesign, userId: string): Promise<Design> {
         if (!id) {
             throw Object.assign(new Error('Design ID is required'), { status: 400 });

--- a/packages/api/src/domain/DraftRepository/index.ts
+++ b/packages/api/src/domain/DraftRepository/index.ts
@@ -1,0 +1,9 @@
+import type { Draft } from '@jewellery-catalogue/types';
+
+export interface DraftRepository {
+    getByUserId(userId: string): Promise<Array<Draft>>;
+    getByIdAndUserId(id: string, userId: string): Promise<Draft | null>;
+    insert(draft: Draft): Promise<void>;
+    update(id: string, draft: Draft): Promise<void>;
+    delete(id: string): Promise<void>;
+}

--- a/packages/api/src/domain/DraftService/index.ts
+++ b/packages/api/src/domain/DraftService/index.ts
@@ -1,0 +1,111 @@
+import type { Draft, DraftType } from '@jewellery-catalogue/types';
+
+import type { DraftRepository } from '../DraftRepository';
+import type { IdGenerator } from '../IdGenerator';
+import type { ImageService } from '../ImageService';
+
+export class DraftService {
+    constructor(
+        private readonly draftRepo: DraftRepository,
+        private readonly imageService: ImageService,
+        private readonly idGenerator: IdGenerator
+    ) {}
+
+    async getDraftsByUserId(userId: string, type?: DraftType): Promise<Array<Draft>> {
+        if (!userId) {
+            throw Object.assign(new Error('User ID is required'), { status: 400 });
+        }
+
+        const drafts = await this.draftRepo.getByUserId(userId);
+
+        return type ? drafts.filter((d) => d.type === type) : drafts;
+    }
+
+    async getDraft(id: string, userId: string): Promise<Draft> {
+        const draft = await this.draftRepo.getByIdAndUserId(id, userId);
+
+        if (!draft) {
+            throw Object.assign(new Error('Draft not found'), { status: 404 });
+        }
+
+        return draft;
+    }
+
+    async createDraft(userId: string, type: DraftType, name: string, data: Record<string, unknown>): Promise<Draft> {
+        if (!userId) {
+            throw Object.assign(new Error('User ID is required'), { status: 400 });
+        }
+
+        const now = new Date();
+        const draft: Draft = {
+            id: this.idGenerator.generate(),
+            userId,
+            type,
+            name: name || 'Untitled',
+            data,
+            createdAt: now,
+            updatedAt: now,
+        };
+
+        await this.draftRepo.insert(draft);
+
+        return draft;
+    }
+
+    async updateDraft(
+        id: string,
+        userId: string,
+        name: string,
+        data: Record<string, unknown>,
+        imageId?: string
+    ): Promise<Draft> {
+        const existing = await this.draftRepo.getByIdAndUserId(id, userId);
+
+        if (!existing) {
+            throw Object.assign(new Error('Draft not found'), { status: 404 });
+        }
+
+        const updated: Draft = {
+            ...existing,
+            name: name || existing.name,
+            data,
+            imageId: imageId !== undefined ? imageId : existing.imageId,
+            updatedAt: new Date(),
+        };
+
+        await this.draftRepo.update(id, updated);
+
+        return updated;
+    }
+
+    async uploadDraftImage(id: string, userId: string, imageBuffer: Buffer, contentType: string): Promise<Draft> {
+        const existing = await this.draftRepo.getByIdAndUserId(id, userId);
+
+        if (!existing) {
+            throw Object.assign(new Error('Draft not found'), { status: 404 });
+        }
+
+        const imageId = this.idGenerator.generate();
+        await this.imageService.uploadImage(imageId, imageBuffer, contentType);
+
+        const updated: Draft = {
+            ...existing,
+            imageId,
+            updatedAt: new Date(),
+        };
+
+        await this.draftRepo.update(id, updated);
+
+        return updated;
+    }
+
+    async deleteDraft(id: string, userId: string): Promise<void> {
+        const existing = await this.draftRepo.getByIdAndUserId(id, userId);
+
+        if (!existing) {
+            throw Object.assign(new Error('Draft not found'), { status: 404 });
+        }
+
+        await this.draftRepo.delete(id);
+    }
+}

--- a/packages/api/src/handlers/Design/index.ts
+++ b/packages/api/src/handlers/Design/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import type { EditDesign, PersistentFile, UploadDesign } from '@jewellery-catalogue/types';
+import type { Design, EditDesign, PersistentFile, UploadDesign } from '@jewellery-catalogue/types';
 import type { Context } from 'koa';
 
 import { dependencyContainer } from '../../dependencies';
@@ -41,14 +41,7 @@ export const getDesign = async (ctx: Context) => {
 
 export const addDesign = async (ctx: Context) => {
     const userId = ctx.state.userId;
-    const file = ctx.request.files?.file as unknown as PersistentFile;
-
-    if (!file) {
-        ctx.status = 400;
-        ctx.body = { error: 'File is required' };
-
-        return;
-    }
+    const file = ctx.request.files?.file as unknown as PersistentFile | undefined;
 
     const {
         name,
@@ -60,13 +53,17 @@ export const addDesign = async (ctx: Context) => {
         lowStockThreshold,
         variationGroups,
         variants,
-    } = ctx.request.body as Partial<UploadDesign>;
+        imageId: existingImageId,
+    } = ctx.request.body as Partial<UploadDesign> & { imageId?: string };
+
+    if (!file && !existingImageId) {
+        ctx.status = 400;
+        ctx.body = { error: 'File or imageId is required' };
+
+        return;
+    }
 
     try {
-        // Read the file from filesystem and convert to Buffer
-        const fileBuffer = fs.readFileSync(file.filepath);
-        const contentType = file.mimetype || 'application/octet-stream';
-
         const designData: UploadDesign = {
             name: name!,
             description: description!,
@@ -74,13 +71,22 @@ export const addDesign = async (ctx: Context) => {
             materials: materials!,
             totalMaterialCosts: Number(totalMaterialCosts),
             price: Number(price),
-            image: file,
+            image: file!,
             lowStockThreshold: lowStockThreshold !== undefined ? Number(lowStockThreshold) : undefined,
             variationGroups,
             variants,
         };
 
-        const design = await getDesignService().addDesign(designData, fileBuffer, contentType, userId);
+        let design: Design;
+
+        if (file) {
+            const fileBuffer = fs.readFileSync(file.filepath);
+            const contentType = file.mimetype || 'application/octet-stream';
+
+            design = await getDesignService().addDesign(designData, fileBuffer, contentType, userId);
+        } else {
+            design = await getDesignService().addDesignWithImageId(designData, existingImageId!, userId);
+        }
 
         ctx.status = 200;
         ctx.body = design;

--- a/packages/api/src/handlers/Draft/index.ts
+++ b/packages/api/src/handlers/Draft/index.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import type { DraftType, PersistentFile } from '@jewellery-catalogue/types';
+import type { Context } from 'koa';
+
+import { dependencyContainer } from '../../dependencies';
+import { DependencyToken } from '../../dependencies/types';
+import type { DraftService } from '../../domain/DraftService';
+
+const getDraftService = (): DraftService => dependencyContainer.resolve(DependencyToken.DraftService);
+
+export const getDrafts = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const type = ctx.query.type as DraftType | undefined;
+
+    try {
+        const drafts = await getDraftService().getDraftsByUserId(userId, type);
+
+        ctx.body = drafts;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const getDraft = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { id } = ctx.params;
+
+    try {
+        const draft = await getDraftService().getDraft(id, userId);
+
+        ctx.body = draft;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const createDraft = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { type, name, data } = ctx.request.body as {
+        type: DraftType;
+        name: string;
+        data: Record<string, unknown>;
+    };
+
+    try {
+        const draft = await getDraftService().createDraft(userId, type, name, data ?? {});
+
+        ctx.status = 201;
+        ctx.body = draft;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const updateDraft = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { id } = ctx.params;
+    const { name, data, imageId } = ctx.request.body as {
+        name: string;
+        data: Record<string, unknown>;
+        imageId?: string;
+    };
+
+    try {
+        const draft = await getDraftService().updateDraft(id, userId, name, data ?? {}, imageId);
+
+        ctx.body = draft;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const uploadDraftImage = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { id } = ctx.params;
+    const file = ctx.request.files?.file as unknown as PersistentFile;
+
+    if (!file) {
+        ctx.status = 400;
+        ctx.body = { error: 'File is required' };
+        return;
+    }
+
+    try {
+        const fileBuffer = fs.readFileSync(file.filepath);
+        const contentType = file.mimetype || 'application/octet-stream';
+
+        const draft = await getDraftService().uploadDraftImage(id, userId, fileBuffer, contentType);
+
+        ctx.body = draft;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const deleteDraft = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { id } = ctx.params;
+
+    try {
+        await getDraftService().deleteDraft(id, userId);
+
+        ctx.status = 200;
+        ctx.body = { message: 'Draft deleted successfully' };
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -138,6 +138,9 @@ export const onStartup = async () => {
         await designsCollection.createIndex({ id: 1, userId: 1 });
         await materialsCollection.createIndex({ userId: 1 });
         await materialsCollection.createIndex({ id: 1, userId: 1 });
+        const draftsCollection = database.getCollection('drafts' as any);
+        await draftsCollection.createIndex({ userId: 1 });
+        await draftsCollection.createIndex({ id: 1, userId: 1 });
         appLogger.info('Database indexes created');
 
         app.use(routes.routes());

--- a/packages/api/src/infrastructure/MongoDraftRepository/index.ts
+++ b/packages/api/src/infrastructure/MongoDraftRepository/index.ts
@@ -1,0 +1,34 @@
+import type { MongoDbConnection } from '@imapps/api-utils';
+import type { Draft } from '@jewellery-catalogue/types';
+
+import { CollectionNames, type Collections } from '../../dependencies/types';
+import type { DraftRepository } from '../../domain/DraftRepository';
+import { MongoRepository } from '../MongoRepository';
+
+export class MongoDraftRepository extends MongoRepository<Draft> implements DraftRepository {
+    constructor(db: MongoDbConnection<Collections>) {
+        super(db, CollectionNames.Drafts);
+    }
+
+    protected usesObjectId(): boolean {
+        return false;
+    }
+
+    async getByUserId(userId: string): Promise<Array<Draft>> {
+        return this.collection()
+            .find({ userId }, { projection: { _id: 0 } })
+            .toArray() as unknown as Array<Draft>;
+    }
+
+    async getByIdAndUserId(id: string, userId: string): Promise<Draft | null> {
+        return this.collection().findOne({ id, userId }, { projection: { _id: 0 } }) as unknown as Draft | null;
+    }
+
+    async update(id: string, draft: Draft): Promise<void> {
+        await this.collection().findOneAndReplace({ id }, draft);
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.collection().deleteOne({ id });
+    }
+}

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -3,6 +3,7 @@ import Router from 'koa-router';
 import { dependencyContainer } from '../dependencies';
 import { DependencyToken } from '../dependencies/types';
 import { addDesign, deleteDesign, editDesignProperties, getDesign, getDesigns, updateDesign } from '../handlers/Design';
+import { createDraft, deleteDraft, getDraft, getDrafts, updateDraft, uploadDraftImage } from '../handlers/Draft';
 import { getImage } from '../handlers/Image';
 import { addMaterial, deleteMaterial, getMaterial, getMaterials, updateMaterial } from '../handlers/Material';
 import { authenticate } from '../middleware/auth';
@@ -33,6 +34,14 @@ router.post('/api/materials', authenticate, addMaterial);
 router.get('/api/materials/:id', authenticate, getMaterial);
 router.put('/api/materials/:id', authenticate, updateMaterial);
 router.delete('/api/materials/:id', authenticate, deleteMaterial);
+
+// Draft routes
+router.get('/api/drafts', authenticate, getDrafts);
+router.post('/api/drafts', authenticate, createDraft);
+router.get('/api/drafts/:id', authenticate, getDraft);
+router.put('/api/drafts/:id', authenticate, updateDraft);
+router.post('/api/drafts/:id/image', authenticate, uploadDraftImage);
+router.delete('/api/drafts/:id', authenticate, deleteDraft);
 
 // Image routes
 router.get('/api/image/:name', getImage);

--- a/packages/types/src/draft/index.ts
+++ b/packages/types/src/draft/index.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const draftTypeEnum = z.enum(['material', 'design']);
+export type DraftType = z.infer<typeof draftTypeEnum>;
+
+export const draftSchema = z.object({
+    id: z.string(),
+    userId: z.string(),
+    type: draftTypeEnum,
+    name: z.string(),
+    data: z.record(z.string(), z.unknown()),
+    imageId: z.string().optional(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+});
+
+export type Draft = z.infer<typeof draftSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from './baseMaterial/index';
 export * from './design/index';
+export * from './draft/index';
 export * from './editDesign/index';
 export * from './formDesign/index';
 export * from './formMaterial/index';

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -1,2 +1,3 @@
 export const MATERIALS_ENDPOINT = '/api/materials';
 export const DESIGNS_ENDPOINT = '/api/designs';
+export const DRAFTS_ENDPOINT = '/api/drafts';

--- a/packages/web/src/api/endpoints/addDesign/index.ts
+++ b/packages/web/src/api/endpoints/addDesign/index.ts
@@ -4,7 +4,7 @@ import { DESIGNS_ENDPOINT } from '../../endpoints';
 import { makeRequestWithAutoRefresh } from '../../makeRequest';
 
 const makeAddDesignRequest = async (
-    formDesign: FormDesign,
+    formDesign: FormDesign & { imageId?: string },
     getAccessToken: () => string,
     onTokenRefresh: (newToken: string) => void,
     onTokenClear: () => void
@@ -13,10 +13,12 @@ const makeAddDesignRequest = async (
 
     for (const key in formDesign) {
         if (Object.hasOwn(formDesign, key)) {
-            const value = formDesign[key as keyof FormDesign];
+            const value = formDesign[key as keyof typeof formDesign];
 
             if (key === 'image' && value instanceof File) {
                 formData.append('file', value);
+            } else if (key === 'image') {
+                // string imageId already handled via imageId field
             } else if (
                 (key === 'materials' || key === 'variationGroups' || key === 'variants') &&
                 Array.isArray(value)
@@ -35,7 +37,7 @@ const makeAddDesignRequest = async (
             headers: {},
             operationString: 'add design',
             body: formData,
-            accessToken: '', // Will be replaced by getAccessToken()
+            accessToken: '',
         },
         getAccessToken,
         onTokenRefresh,

--- a/packages/web/src/api/endpoints/drafts/index.ts
+++ b/packages/web/src/api/endpoints/drafts/index.ts
@@ -1,0 +1,116 @@
+import type { Draft, DraftType, MethodType } from '@jewellery-catalogue/types';
+
+import { DRAFTS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+type AuthArgs = [() => string, (token: string) => void, () => void];
+
+export const makeGetDraftsRequest = async (
+    type: DraftType,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+): Promise<Array<Draft>> => {
+    return makeRequestWithAutoRefresh<Array<Draft>>(
+        {
+            pathname: `${DRAFTS_ENDPOINT}?type=${type}`,
+            method: 'GET' as unknown as MethodType,
+            operationString: 'fetch drafts',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export const getDraftsQuery = (type: DraftType, ...auth: AuthArgs) => ({
+    queryKey: ['drafts', type],
+    queryFn: async () => makeGetDraftsRequest(type, ...auth),
+});
+
+export const makeCreateDraftRequest = async (
+    payload: { type: DraftType; name: string; data: Record<string, unknown> },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+): Promise<Draft> => {
+    return makeRequestWithAutoRefresh<Draft>(
+        {
+            pathname: DRAFTS_ENDPOINT,
+            method: 'POST' as unknown as MethodType,
+            operationString: 'create draft',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export const makeUpdateDraftRequest = async (
+    id: string,
+    payload: { name: string; data: Record<string, unknown>; imageId?: string },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+): Promise<Draft> => {
+    return makeRequestWithAutoRefresh<Draft>(
+        {
+            pathname: `${DRAFTS_ENDPOINT}/${id}`,
+            method: 'PUT' as unknown as MethodType,
+            operationString: 'update draft',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export const makeUploadDraftImageRequest = async (
+    id: string,
+    file: File,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+): Promise<Draft> => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return makeRequestWithAutoRefresh<Draft>(
+        {
+            pathname: `${DRAFTS_ENDPOINT}/${id}/image`,
+            method: 'POST' as unknown as MethodType,
+            operationString: 'upload draft image',
+            body: formData,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export const makeDeleteDraftRequest = async (
+    id: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+): Promise<void> => {
+    await makeRequestWithAutoRefresh<void>(
+        {
+            pathname: `${DRAFTS_ENDPOINT}/${id}`,
+            method: 'DELETE' as unknown as MethodType,
+            operationString: 'delete draft',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};

--- a/packages/web/src/components/ImageUpload/index.tsx
+++ b/packages/web/src/components/ImageUpload/index.tsx
@@ -9,171 +9,99 @@ import { cn } from '@/lib/utils';
 
 interface ImageUploadProps {
     setImage: UseFormSetValue<FormDesign>;
+    onChange?: (value: File | undefined) => void;
     hasError?: boolean;
     value?: File | string;
 }
 
-const ImageUpload: React.FC<ImageUploadProps> = ({ setImage, hasError = false, value }) => {
+const baseClass =
+    'border-2 rounded-lg w-[300px] h-[300px] flex items-center justify-center overflow-hidden relative transition-colors';
+
+const ImageUpload: React.FC<ImageUploadProps> = ({ setImage, onChange, hasError = false, value }) => {
     const [preview, setPreview] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isDragging, setIsDragging] = useState(false);
-    const [isEditingImage, setIsEditingImage] = useState(false);
 
-    // Handle initial value (existing image or new file)
     useEffect(() => {
         if (value instanceof File) {
-            // New file selected - show preview
             const reader = new FileReader();
-            reader.onload = () => {
-                setPreview(reader.result as string);
-            };
+            reader.onload = () => setPreview(reader.result as string);
             reader.readAsDataURL(value);
-            setIsEditingImage(false);
-        } else if (typeof value === 'string' && value) {
-            // Existing image ID - don't show preview, show the existing image
-            setPreview(null);
-            setIsEditingImage(false);
         } else {
-            // No value - show upload UI
             setPreview(null);
-            setIsEditingImage(false);
         }
     }, [value]);
 
     const handleFile = (file: File) => {
         if (!file.type.startsWith('image/')) return;
-        const reader = new FileReader();
-
-        reader.onload = () => {
-            setPreview(reader.result as string);
-        };
-
-        reader.readAsDataURL(file);
-        setImage('image', file);
-        setIsEditingImage(false);
+        setImage('image', file, { shouldDirty: true });
+        onChange?.(file);
     };
 
     const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
         e.preventDefault();
         e.stopPropagation();
         setIsDragging(false);
-        if (e.dataTransfer.files?.[0]) {
-            handleFile(e.dataTransfer.files[0]);
-        }
-    };
-
-    const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        setIsDragging(true);
-    };
-
-    const handleDragLeave = () => {
-        setIsDragging(false);
-    };
-
-    const handleClick = () => {
-        fileInputRef.current?.click();
+        if (e.dataTransfer.files?.[0]) handleFile(e.dataTransfer.files[0]);
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (e.target.files?.[0]) {
-            handleFile(e.target.files[0]);
-        }
+        if (e.target.files?.[0]) handleFile(e.target.files[0]);
     };
+
+    const handleAreaClick = () => fileInputRef.current?.click();
 
     const clearImage = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         e.stopPropagation();
         setPreview(null);
-        setImage('image', undefined as any);
-        if (fileInputRef.current) {
-            fileInputRef.current.value = '';
-        }
+        setImage('image', undefined as any, { shouldDirty: true });
+        onChange?.(undefined);
+        if (fileInputRef.current) fileInputRef.current.value = '';
     };
 
-    const startEditing = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const changeImage = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         e.stopPropagation();
-        setIsEditingImage(true);
+        fileInputRef.current?.click();
     };
 
-    // Show existing image (from edit mode)
-    const hasExistingImage = typeof value === 'string' && value;
-    const showEditButton = hasExistingImage && !isEditingImage;
+    const hasImage = value instanceof File ? !!preview : !!value;
 
-    return (
-        <div
-            role="button"
-            tabIndex={showEditButton ? -1 : 0}
-            onDrop={!showEditButton ? handleDrop : undefined}
-            onDragOver={!showEditButton ? handleDragOver : undefined}
-            onDragLeave={!showEditButton ? handleDragLeave : undefined}
-            onClick={!showEditButton ? handleClick : undefined}
-            onKeyDown={(e) => {
-                if (!showEditButton && (e.key === 'Enter' || e.key === ' ')) {
-                    e.preventDefault();
-                    handleClick();
-                }
-            }}
-            className={cn(
-                'border-2 border-dashed rounded-lg w-[300px] h-[300px] cursor-pointer flex items-center justify-center overflow-hidden relative transition-colors',
-                showEditButton ? 'border-solid border-border cursor-default' : '',
-                isDragging && !showEditButton
-                    ? 'border-primary bg-muted/50'
-                    : hasError
-                      ? 'border-destructive bg-card'
-                      : 'border-border bg-card'
-            )}
-        >
-            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleChange} />
+    const hiddenInput = (
+        <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleChange} />
+    );
 
-            {/* Show new file preview */}
-            {preview ? (
-                <img src={preview} alt="Preview" className="w-full h-full object-cover absolute top-0 left-0" />
-            ) : showEditButton ? (
-                // Show existing image for edit mode
-                <div className="w-full h-full">
-                    <Image imageId={value as string} />
-                </div>
-            ) : isEditingImage ? (
-                // Show upload UI when editing existing image
-                <div className="flex flex-col items-center justify-center w-full">
-                    <ImagePlus className="w-8 h-8 text-gray-600 mb-2" />
-                    <span className="text-gray-600 text-center">Drag & Drop or Click to Upload</span>
-                </div>
-            ) : (
-                // Show upload UI for new images
-                <div className="flex flex-col items-center justify-center w-full">
-                    <ImagePlus className="w-8 h-8 text-gray-600 mb-2" />
-                    <span className="text-gray-600 text-center">Drag & Drop or Click to Upload</span>
-                </div>
-            )}
-
-            {/* Clear button for new preview */}
-            {preview && (
-                <Button
-                    variant="destructive"
-                    size="icon"
-                    onClick={clearImage}
-                    className="w-9 h-9 z-10 absolute top-0 right-0"
-                >
-                    <X className="w-4 h-4" />
-                </Button>
-            )}
-
-            {/* Edit/Clear buttons for existing image */}
-            {showEditButton && (
+    if (hasImage) {
+        return (
+            <div
+                className={cn(
+                    baseClass,
+                    'border-solid border-border cursor-default',
+                    hasError ? 'border-destructive' : 'border-border'
+                )}
+            >
+                {hiddenInput}
+                {preview ? (
+                    <img src={preview} alt="Preview" className="w-full h-full object-cover absolute inset-0" />
+                ) : (
+                    <div className="w-full h-full">
+                        <Image imageId={value as string} />
+                    </div>
+                )}
                 <div className="flex gap-2 z-10 absolute bottom-3 right-3">
                     <Button
+                        type="button"
                         variant="outline"
                         size="icon"
-                        onClick={startEditing}
+                        onClick={changeImage}
                         className="w-9 h-9 bg-card/80 backdrop-blur-sm"
                         title="Change image"
                     >
                         <ImagePlus className="w-4 h-4" />
                     </Button>
                     <Button
+                        type="button"
                         variant="destructive"
                         size="icon"
                         onClick={clearImage}
@@ -183,7 +111,42 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ setImage, hasError = false, v
                         <X className="w-4 h-4" />
                     </Button>
                 </div>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onDrop={handleDrop}
+            onDragOver={(e) => {
+                e.preventDefault();
+                setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onClick={handleAreaClick}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleAreaClick();
+                }
+            }}
+            className={cn(
+                baseClass,
+                'border-dashed cursor-pointer',
+                isDragging
+                    ? 'border-primary bg-muted/50'
+                    : hasError
+                      ? 'border-destructive bg-card'
+                      : 'border-border bg-card'
             )}
+        >
+            {hiddenInput}
+            <div className="flex flex-col items-center justify-center w-full">
+                <ImagePlus className="w-8 h-8 text-gray-600 mb-2" />
+                <span className="text-gray-600 text-center">Drag & Drop or Click to Upload</span>
+            </div>
         </div>
     );
 };

--- a/packages/web/src/components/MainLayout/index.tsx
+++ b/packages/web/src/components/MainLayout/index.tsx
@@ -1,10 +1,11 @@
-import { ArrowLeft, Search } from 'lucide-react';
+import { ArrowLeft, Loader2, Search } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 
 import { DESIGNS_PAGE } from '../../constants/routes';
+import { useDraftStatus } from '../../context/DraftStatus';
 import { SearchProvider, useSearch } from '../../context/SearchContext';
 import AppSidebar from '../AppSidebar';
 import { Button } from '../ui/button';
@@ -19,6 +20,7 @@ const MainLayoutContent = ({ children }: MainLayoutProps) => {
     const location = useLocation();
     const navigate = useNavigate();
     const { searchQuery, setSearchQuery } = useSearch();
+    const { status: draftStatus } = useDraftStatus();
     const isDesignsPage = location.pathname === '/designs';
     const isViewDesignPage = location.pathname.startsWith('/designs/') && location.pathname !== '/designs';
 
@@ -37,6 +39,20 @@ const MainLayoutContent = ({ children }: MainLayoutProps) => {
                 <header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-2 border-b bg-background px-4">
                     <SidebarTrigger className="-ml-1" />
                     <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+                    {draftStatus.hasDraft && (
+                        <span className="flex items-center gap-1.5 text-xs text-muted-foreground mr-2">
+                            {draftStatus.isSaving ? (
+                                <>
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                    Saving draft…
+                                </>
+                            ) : draftStatus.saveError ? (
+                                <span className="text-destructive">Draft save failed — will retry</span>
+                            ) : (
+                                'Draft saved'
+                            )}
+                        </span>
+                    )}
                     {isDesignsPage && (
                         <div className="relative max-w-md">
                             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />

--- a/packages/web/src/context/DraftStatus/index.tsx
+++ b/packages/web/src/context/DraftStatus/index.tsx
@@ -1,0 +1,41 @@
+import { createContext, type ReactNode, useCallback, useContext, useState } from 'react';
+
+interface DraftStatusState {
+    isSaving: boolean;
+    saveError: boolean;
+    hasDraft: boolean;
+}
+
+interface DraftStatusContextValue {
+    status: DraftStatusState;
+    setDraftStatus: (status: DraftStatusState) => void;
+    clearDraftStatus: () => void;
+}
+
+const initial: DraftStatusState = { isSaving: false, saveError: false, hasDraft: false };
+
+const DraftStatusContext = createContext<DraftStatusContextValue>({
+    status: initial,
+    setDraftStatus: () => {},
+    clearDraftStatus: () => {},
+});
+
+export const DraftStatusProvider = ({ children }: { children: ReactNode }) => {
+    const [status, setStatus] = useState<DraftStatusState>(initial);
+
+    const setDraftStatus = useCallback((next: DraftStatusState) => {
+        setStatus(next);
+    }, []);
+
+    const clearDraftStatus = useCallback(() => {
+        setStatus(initial);
+    }, []);
+
+    return (
+        <DraftStatusContext.Provider value={{ status, setDraftStatus, clearDraftStatus }}>
+            {children}
+        </DraftStatusContext.Provider>
+    );
+};
+
+export const useDraftStatus = () => useContext(DraftStatusContext);

--- a/packages/web/src/hooks/useDraftAutosave.ts
+++ b/packages/web/src/hooks/useDraftAutosave.ts
@@ -1,0 +1,153 @@
+import type { DraftType } from '@jewellery-catalogue/types';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+
+import { makeCreateDraftRequest, makeUpdateDraftRequest, makeUploadDraftImageRequest } from '../api/endpoints/drafts';
+
+const DEBOUNCE_MS = 2000;
+
+interface UseDraftAutosaveOptions {
+    form: UseFormReturn<any>;
+    type: DraftType;
+    initialDraftId?: string | null;
+    initialImageId?: string | null;
+    getAccessToken: () => string;
+    onTokenRefresh: (token: string) => void;
+    onTokenClear: () => void;
+    onStatusChange?: (status: { isSaving: boolean; saveError: boolean; hasDraft: boolean }) => void;
+}
+
+interface UseDraftAutosaveResult {
+    draftId: string | null;
+    isSaving: boolean;
+    saveError: boolean;
+    uploadedImageId: string | null;
+    clearDraft: () => void;
+}
+
+export const useDraftAutosave = ({
+    form,
+    type,
+    initialDraftId = null,
+    initialImageId = null,
+    getAccessToken,
+    onTokenRefresh,
+    onTokenClear,
+    onStatusChange,
+}: UseDraftAutosaveOptions): UseDraftAutosaveResult => {
+    const [draftId, setDraftId] = useState<string | null>(initialDraftId);
+    const [isSaving, setIsSaving] = useState(false);
+    const [saveError, setSaveError] = useState(false);
+
+    const draftIdRef = useRef<string | null>(initialDraftId);
+    const uploadedImageIdRef = useRef<string | null>(initialImageId);
+    const pendingFileRef = useRef<File | null>(null);
+    const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isSavingRef = useRef(false);
+
+    const getAccessTokenRef = useRef(getAccessToken);
+    const onTokenRefreshRef = useRef(onTokenRefresh);
+    const onTokenClearRef = useRef(onTokenClear);
+    const onStatusChangeRef = useRef(onStatusChange);
+    getAccessTokenRef.current = getAccessToken;
+    onTokenRefreshRef.current = onTokenRefresh;
+    onTokenClearRef.current = onTokenClear;
+    onStatusChangeRef.current = onStatusChange;
+
+    const clearDraft = useCallback(() => {
+        setDraftId(null);
+        draftIdRef.current = null;
+        uploadedImageIdRef.current = null;
+        pendingFileRef.current = null;
+        onStatusChangeRef.current?.({ isSaving: false, saveError: false, hasDraft: false });
+    }, []);
+
+    const save = useCallback(
+        async (values: Record<string, unknown>) => {
+            if (isSavingRef.current) return;
+
+            const name = (values.name as string) || '';
+            if (!name.trim()) return;
+
+            const imageValue = values.image;
+
+            if (imageValue instanceof File && imageValue !== pendingFileRef.current) {
+                pendingFileRef.current = imageValue;
+                uploadedImageIdRef.current = null;
+            } else if (!(imageValue instanceof File) && typeof imageValue !== 'string') {
+                pendingFileRef.current = null;
+            }
+
+            const { image: _image, ...serializableData } = values;
+
+            isSavingRef.current = true;
+            setIsSaving(true);
+            setSaveError(false);
+            onStatusChangeRef.current?.({ isSaving: true, saveError: false, hasDraft: true });
+
+            const authArgs = [getAccessTokenRef.current, onTokenRefreshRef.current, onTokenClearRef.current] as const;
+
+            try {
+                if (!draftIdRef.current) {
+                    const draft = await makeCreateDraftRequest({ type, name, data: serializableData }, ...authArgs);
+                    draftIdRef.current = draft.id;
+                    setDraftId(draft.id);
+                }
+
+                if (pendingFileRef.current && !uploadedImageIdRef.current) {
+                    const updated = await makeUploadDraftImageRequest(
+                        draftIdRef.current!,
+                        pendingFileRef.current,
+                        ...authArgs
+                    );
+                    uploadedImageIdRef.current = updated.imageId ?? null;
+                }
+
+                await makeUpdateDraftRequest(
+                    draftIdRef.current!,
+                    {
+                        name,
+                        data: serializableData,
+                        imageId: uploadedImageIdRef.current ?? undefined,
+                    },
+                    ...authArgs
+                );
+                onStatusChangeRef.current?.({ isSaving: false, saveError: false, hasDraft: true });
+            } catch {
+                setSaveError(true);
+                onStatusChangeRef.current?.({ isSaving: false, saveError: true, hasDraft: !!draftIdRef.current });
+            } finally {
+                isSavingRef.current = false;
+                setIsSaving(false);
+            }
+        },
+        [type]
+    );
+
+    useEffect(() => {
+        const subscription = form.watch((values) => {
+            if (debounceTimerRef.current) {
+                clearTimeout(debounceTimerRef.current);
+            }
+
+            debounceTimerRef.current = setTimeout(() => {
+                save(values as Record<string, unknown>);
+            }, DEBOUNCE_MS);
+        });
+
+        return () => {
+            subscription.unsubscribe();
+            if (debounceTimerRef.current) {
+                clearTimeout(debounceTimerRef.current);
+            }
+        };
+    }, [form.watch, save]);
+
+    return {
+        draftId,
+        isSaving,
+        saveError,
+        uploadedImageId: uploadedImageIdRef.current,
+        clearDraft,
+    };
+};

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -19,6 +19,7 @@ import {
     VIEW_DESIGN_PAGE,
 } from './constants/routes';
 import { AlertProvider } from './context/Alert';
+import { DraftStatusProvider } from './context/DraftStatus';
 import AddDesign from './pages/AddDesign';
 import AddMaterial from './pages/AddMaterial';
 import Designs from './pages/Designs';
@@ -128,8 +129,10 @@ const initializeApp = async () => {
                             <AuthProvider>
                                 <AppInitializer>
                                     <AlertProvider>
-                                        <GlobalAlert />
-                                        <App />
+                                        <DraftStatusProvider>
+                                            <GlobalAlert />
+                                            <App />
+                                        </DraftStatusProvider>
                                     </AlertProvider>
                                 </AppInitializer>
                             </AuthProvider>

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -5,14 +5,16 @@ import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
-
+import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddDesignRequest from '../../api/endpoints/addDesign';
+import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
 import ImageUpload from '../../components/ImageUpload';
@@ -22,6 +24,8 @@ import TimeInput from '../../components/TimeInput';
 import { computeVariants, VariationGroupBuilder } from '../../components/VariationGroupBuilder';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
+import { useDraftStatus } from '../../context/DraftStatus';
+import { useDraftAutosave } from '../../hooks/useDraftAutosave';
 import { usePriceSettings } from '../../hooks/usePriceSettings';
 import { getTotalMaterialCosts } from '../../utils/getPriceOfMaterials';
 import { getWageCosts } from '../../utils/getWageCost';
@@ -45,7 +49,10 @@ const AddDesign: React.FC = () => {
 
     const { accessToken, login, logout } = useAuth();
     const [isMakingRequest, setIsMakingRequest] = useState(false);
+    const [isLoadingDraft, setIsLoadingDraft] = useState(false);
     const { hourlyWage, profitMargin, updateHourlyWage, updateProfitMargin } = usePriceSettings();
+    const [searchParams] = useSearchParams();
+    const draftIdParam = searchParams.get('draftId');
 
     const { data } = useQuery({
         ...getMaterialsQuery(() => accessToken, login, logout),
@@ -57,6 +64,41 @@ const AddDesign: React.FC = () => {
     const variationGroups = form.watch('variationGroups') ?? [];
 
     const { dispatch } = useAlert();
+    const { setDraftStatus, clearDraftStatus } = useDraftStatus();
+
+    const { draftId, uploadedImageId, clearDraft } = useDraftAutosave({
+        form,
+        type: 'design',
+        initialDraftId: draftIdParam,
+        getAccessToken: () => accessToken,
+        onTokenRefresh: login,
+        onTokenClear: logout,
+        onStatusChange: setDraftStatus,
+    });
+
+    useEffect(() => () => clearDraftStatus(), [clearDraftStatus]);
+
+    // Load draft on mount if draftId param present
+    useEffect(() => {
+        if (!draftIdParam || !accessToken) return;
+
+        setIsLoadingDraft(true);
+
+        fetch(`${DRAFTS_ENDPOINT}/${draftIdParam}`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        })
+            .then((res) => res.json())
+            .then((draft) => {
+                if (draft?.data) {
+                    form.reset(draft.data);
+                }
+                if (draft?.imageId) {
+                    form.setValue('image', draft.imageId);
+                }
+            })
+            .catch(() => {})
+            .finally(() => setIsLoadingDraft(false));
+    }, [draftIdParam, accessToken, form.reset, form.setValue]);
 
     const onSubmit: SubmitHandler<FormDesign> = async (formData) => {
         setIsMakingRequest(true);
@@ -68,7 +110,17 @@ const AddDesign: React.FC = () => {
                 profitMargin,
                 currentTimeRequired
             );
-            await makeAddDesignRequest({ ...formData, variants }, () => accessToken, login, logout);
+
+            // If image is a string it's a draft imageId already on server
+            const imageIdFromDraft =
+                typeof formData.image === 'string' ? formData.image : (uploadedImageId ?? undefined);
+            const submitData = { ...formData, variants, imageId: imageIdFromDraft };
+
+            await makeAddDesignRequest(submitData, () => accessToken, login, logout);
+
+            if (draftId) {
+                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
+            }
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -80,6 +132,7 @@ const AddDesign: React.FC = () => {
                 },
             });
             form.reset();
+            clearDraft();
         } catch (e) {
             console.error('[AddDesign] Error adding design:', e);
             const message = e instanceof Error ? e.message : 'Unknown Error';
@@ -124,7 +177,7 @@ const AddDesign: React.FC = () => {
         }
     }, [selectedMaterials, currentTimeRequired, hourlyWage, profitMargin, data, variationGroups, form.setValue]);
 
-    if (!data) {
+    if (isLoadingDraft || !data) {
         return null;
     }
 
@@ -197,6 +250,7 @@ const AddDesign: React.FC = () => {
                                             <FormControl>
                                                 <ImageUpload
                                                     setImage={form.setValue}
+                                                    onChange={field.onChange}
                                                     hasError={!!fieldState.error}
                                                     value={field.value}
                                                 />

--- a/packages/web/src/pages/AddMaterial/index.tsx
+++ b/packages/web/src/pages/AddMaterial/index.tsx
@@ -2,8 +2,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuth } from '@imapps/web-utils';
 import { type FormMaterial, formMaterialSchema, MaterialType } from '@jewellery-catalogue/types';
 import { Link, Loader2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
@@ -11,11 +12,14 @@ import { Card } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
-
+import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddMaterialRequest from '../../api/endpoints/addMaterial';
+import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import MaterialFormResolver from '../../components/MaterialFormResolver';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
+import { useDraftStatus } from '../../context/DraftStatus';
+import { useDraftAutosave } from '../../hooks/useDraftAutosave';
 import { MATERIAL_TYPE_LABELS } from '../../lib/materialLabels';
 
 const AddMaterial = () => {
@@ -32,15 +36,55 @@ const AddMaterial = () => {
     });
 
     const [isMakingRequest, setIsMakingRequest] = useState(false);
+    const [isLoadingDraft, setIsLoadingDraft] = useState(false);
     const { accessToken, login, logout } = useAuth();
     const { dispatch } = useAlert();
+    const { setDraftStatus, clearDraftStatus } = useDraftStatus();
+    const [searchParams] = useSearchParams();
+    const draftIdParam = searchParams.get('draftId');
 
     const currentMaterialType = form.watch('type');
+
+    const { draftId, clearDraft } = useDraftAutosave({
+        form,
+        type: 'material',
+        initialDraftId: draftIdParam,
+        getAccessToken: () => accessToken,
+        onTokenRefresh: login,
+        onTokenClear: logout,
+        onStatusChange: setDraftStatus,
+    });
+
+    // Clear header status when leaving this page
+    useEffect(() => () => clearDraftStatus(), [clearDraftStatus]);
+
+    // Load draft on mount if draftId param present
+    useEffect(() => {
+        if (!draftIdParam || !accessToken) return;
+
+        setIsLoadingDraft(true);
+
+        fetch(`${DRAFTS_ENDPOINT}/${draftIdParam}`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        })
+            .then((res) => res.json())
+            .then((draft) => {
+                if (draft?.data) {
+                    form.reset(draft.data);
+                }
+            })
+            .catch(() => {})
+            .finally(() => setIsLoadingDraft(false));
+    }, [draftIdParam, accessToken, form.reset]);
 
     const onSubmit = async (data: FormMaterial) => {
         setIsMakingRequest(true);
         try {
             await makeAddMaterialRequest(data, () => accessToken, login, logout);
+
+            if (draftId) {
+                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
+            }
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -52,6 +96,7 @@ const AddMaterial = () => {
                 },
             });
             form.reset();
+            clearDraft();
         } catch (e) {
             const message = e instanceof Error ? e.message : 'Unknown Error';
 
@@ -68,6 +113,14 @@ const AddMaterial = () => {
             setIsMakingRequest(false);
         }
     };
+
+    if (isLoadingDraft) {
+        return (
+            <div className="container mx-auto max-w-5xl px-4 py-8 flex justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
 
     return (
         <div className="container mx-auto max-w-5xl px-4 py-8">

--- a/packages/web/src/pages/Designs/index.tsx
+++ b/packages/web/src/pages/Designs/index.tsx
@@ -1,21 +1,127 @@
 import { useAuth } from '@imapps/web-utils';
-import { useQuery } from '@tanstack/react-query';
+import type { Draft } from '@jewellery-catalogue/types';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Fuse from 'fuse.js';
-import { Sparkles } from 'lucide-react';
-import { useMemo } from 'react';
+import { FileEdit, Sparkles, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Item, ItemContent, ItemFooter, ItemHeader, ItemTitle } from '@/components/ui/item';
 
+import { getDraftsQuery, makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getDesignsQuery } from '../../api/endpoints/getDesigns';
 import { DesignCard } from '../../components/DesignCard';
 import LoadingScreen from '../../components/Loading';
+import { ADD_DESIGN_PAGE } from '../../constants/routes';
 import { useSearch } from '../../context/SearchContext';
+
+const DraftCard: React.FC<{ draft: Draft; onDeleted: () => void }> = ({ draft, onDeleted }) => {
+    const { accessToken, login, logout } = useAuth();
+    const navigate = useNavigate();
+    const [confirmOpen, setConfirmOpen] = useState(false);
+
+    const handleCardClick = () => {
+        navigate(`${ADD_DESIGN_PAGE.route}?draftId=${draft.id}`);
+    };
+
+    const handleDeleteClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setConfirmOpen(true);
+    };
+
+    const confirmDelete = async () => {
+        await makeDeleteDraftRequest(draft.id, () => accessToken, login, logout);
+        setConfirmOpen(false);
+        onDeleted();
+    };
+
+    return (
+        <>
+            <Item
+                variant="outline"
+                className="w-fit max-w-max flex-col items-start bg-card relative cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02]"
+                onClick={handleCardClick}
+            >
+                <div className="absolute top-2 right-2 z-10 flex gap-1">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8 text-destructive hover:bg-destructive hover:text-destructive-foreground"
+                        onClick={handleDeleteClick}
+                        title="Delete Draft"
+                    >
+                        <Trash2 className="h-4 w-4" />
+                    </Button>
+                </div>
+                <ItemHeader className="basis-auto justify-center">
+                    <div className="w-64 h-64 flex items-center justify-center rounded-md bg-primary/10 border border-primary/20">
+                        <FileEdit className="h-16 w-16 text-primary/40" />
+                    </div>
+                </ItemHeader>
+                <ItemContent className="flex-none items-start text-left w-full">
+                    <div className="flex items-center gap-2 mb-1">
+                        <Badge variant="secondary" className="text-xs">
+                            Draft
+                        </Badge>
+                    </div>
+                    <ItemTitle className="text-lg font-semibold">{draft.name}</ItemTitle>
+                    <ItemFooter className="flex items-center gap-1 w-full">
+                        <span className="text-xs text-muted-foreground">
+                            {new Date(draft.updatedAt).toLocaleString()}
+                        </span>
+                    </ItemFooter>
+                </ItemContent>
+            </Item>
+
+            <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Draft</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Delete draft "{draft.name}"? This cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={confirmDelete}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+};
 
 const Designs = () => {
     const { accessToken, login, logout } = useAuth();
     const { searchQuery } = useSearch();
+    const queryClient = useQueryClient();
+
     const { data, isError, refetch } = useQuery({
         ...getDesignsQuery(() => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    const { data: drafts } = useQuery({
+        ...getDraftsQuery('design', () => accessToken, login, logout),
         enabled: !!accessToken,
     });
 
@@ -29,6 +135,10 @@ const Designs = () => {
         });
     }, [data]);
 
+    const handleDraftDeleted = () => {
+        queryClient.invalidateQueries({ queryKey: ['drafts', 'design'] });
+    };
+
     if (isError) {
         return <span>Something went wrong! :(</span>;
     }
@@ -38,14 +148,23 @@ const Designs = () => {
     }
 
     const filteredData = searchQuery && fuse ? fuse.search(searchQuery).map((result) => result.item) : data;
+    const filteredDrafts = searchQuery
+        ? (drafts ?? []).filter((d) => d.name.toLowerCase().includes(searchQuery.toLowerCase()))
+        : (drafts ?? []);
 
     const designs = filteredData.map((design) => {
         return <DesignCard key={design.id} design={design} onDesignUpdated={() => refetch()} />;
     });
 
+    const draftCards = filteredDrafts.map((draft) => (
+        <DraftCard key={draft.id} draft={draft} onDeleted={handleDraftDeleted} />
+    ));
+
+    const isEmpty = filteredData.length === 0 && filteredDrafts.length === 0;
+
     return (
         <div>
-            {filteredData.length === 0 ? (
+            {isEmpty ? (
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia variant="icon">
@@ -60,7 +179,10 @@ const Designs = () => {
                     </EmptyHeader>
                 </Empty>
             ) : (
-                <div className="flex flex-wrap justify-center gap-6">{designs}</div>
+                <div className="flex flex-wrap justify-center gap-6">
+                    {draftCards}
+                    {designs}
+                </div>
             )}
         </div>
     );

--- a/packages/web/src/pages/Materials/index.tsx
+++ b/packages/web/src/pages/Materials/index.tsx
@@ -1,16 +1,142 @@
 import { useAuth } from '@imapps/web-utils';
-import { useQuery } from '@tanstack/react-query';
+import type { Draft } from '@jewellery-catalogue/types';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { FileEdit, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+import { getDraftsQuery, makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import LoadingScreen from '../../components/Loading';
 import MaterialsTable from '../../components/MaterialsTable';
+import { ADD_MATERIAL_PAGE } from '../../constants/routes';
+
+const DraftsTable: React.FC<{ drafts: Array<Draft>; onDeleted: () => void }> = ({ drafts, onDeleted }) => {
+    const { accessToken, login, logout } = useAuth();
+    const navigate = useNavigate();
+    const [draftToDelete, setDraftToDelete] = useState<Draft | null>(null);
+
+    const handleResume = (draft: Draft) => {
+        navigate(`${ADD_MATERIAL_PAGE.route}?draftId=${draft.id}`);
+    };
+
+    const confirmDelete = async () => {
+        if (!draftToDelete) return;
+        await makeDeleteDraftRequest(draftToDelete.id, () => accessToken, login, logout);
+        setDraftToDelete(null);
+        onDeleted();
+    };
+
+    return (
+        <>
+            <div className="rounded-md border bg-card mb-4">
+                <div className="px-4 py-3 border-b flex items-center gap-2">
+                    <FileEdit className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm font-medium">Material Drafts</span>
+                    <Badge variant="secondary">{drafts.length}</Badge>
+                </div>
+                <Table>
+                    <TableHeader>
+                        <TableRow className="hover:bg-transparent">
+                            <TableHead className="font-semibold">Name</TableHead>
+                            <TableHead className="font-semibold">Last Edited</TableHead>
+                            <TableHead className="font-semibold text-right">Actions</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {drafts.map((draft) => (
+                            <TableRow key={draft.id} className="hover:bg-muted/50">
+                                <TableCell className="font-medium">
+                                    <span className="flex items-center gap-2">
+                                        {draft.name}
+                                        <Badge variant="outline" className="text-xs">
+                                            Draft
+                                        </Badge>
+                                    </span>
+                                </TableCell>
+                                <TableCell className="text-muted-foreground text-sm">
+                                    {new Date(draft.updatedAt).toLocaleString()}
+                                </TableCell>
+                                <TableCell>
+                                    <div className="flex items-center justify-end gap-2">
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => handleResume(draft)}
+                                            className="h-8 px-3 text-xs"
+                                        >
+                                            Resume
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => setDraftToDelete(draft)}
+                                            className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                                        >
+                                            <Trash2 className="h-4 w-4" />
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
+
+            <AlertDialog open={!!draftToDelete} onOpenChange={(open) => !open && setDraftToDelete(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Draft</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Delete draft "{draftToDelete?.name}"? This cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={confirmDelete}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+};
 
 const Materials = () => {
     const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
     const { data, isError, error, refetch } = useQuery({
         ...getMaterialsQuery(() => accessToken, login, logout),
         enabled: !!accessToken,
     });
+
+    const { data: drafts } = useQuery({
+        ...getDraftsQuery('material', () => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    const handleDraftDeleted = () => {
+        queryClient.invalidateQueries({ queryKey: ['drafts', 'material'] });
+    };
 
     if (isError) {
         return (
@@ -25,7 +151,12 @@ const Materials = () => {
         return <LoadingScreen />;
     }
 
-    return <MaterialsTable materials={data} onMaterialUpdated={() => refetch()} />;
+    return (
+        <div>
+            {drafts && drafts.length > 0 && <DraftsTable drafts={drafts} onDeleted={handleDraftDeleted} />}
+            <MaterialsTable materials={data} onMaterialUpdated={() => refetch()} />
+        </div>
+    );
 };
 
 export default Materials;


### PR DESCRIPTION
## Summary

- MongoDB `drafts` collection with full CRUD API (`GET/POST/PUT/DELETE /api/drafts`, `POST /api/drafts/:id/image`)
- `useDraftAutosave` hook: debounced 2s autosave, skips empty name, uploads design images to MinIO before persisting draft data
- Draft resume via `?draftId=` URL param — form pre-populates from saved draft
- Drafts shown in Materials list (table rows) and Designs list (cards) with delete confirmation dialog
- Draft save status in app header: "Saving draft…" / "Draft saved" / "Draft save failed — will retry"
- `DraftStatusContext` bridges save state from page components to MainLayout header without prop drilling
- `POST /api/designs` now accepts `imageId` string to promote a draft's already-uploaded image
- `ImageUpload`: unified UX (bottom-anchored change/delete buttons), fixed image clear not resetting to blank state, fixed image selection not triggering autosave (wired `field.onChange` alongside `setValue`)

## Test plan

- [ ] Fill in name on Add Material → wait 2s → verify draft appears in Materials list
- [ ] Navigate away, click Resume draft → form re-populates
- [ ] Submit form → draft deleted from list
- [ ] Fill in name + upload image on Add Design → verify both saved in draft (image preview on resume)
- [ ] Delete draft from list → confirmation dialog appears, draft removed on confirm
- [ ] Header shows "Saving draft…" while saving, "Draft saved" after, "Draft save failed" on network error

🤖 Generated with [Claude Code](https://claude.com/claude-code)