### PR TITLE
fix: delete materials, draft cleanup, per-unit price on update

### DIFF
--- a/packages/api/src/domain/MaterialService/index.ts
+++ b/packages/api/src/domain/MaterialService/index.ts
@@ -176,40 +176,57 @@ export class MaterialService {
     private recalculatePerUnitPrice(material: Material): Material {
         switch (material.type) {
             case MaterialType.WIRE: {
-                const wire = material as Material & { totalLength: number; pricePerMeter: number };
-                const totalCost = (wire as any)._totalCost || wire.totalLength * wire.pricePerMeter;
-                const newPricePerMeter = wire.totalLength > 0 ? totalCost / wire.totalLength : wire.pricePerMeter;
+                const wire = material as Material & {
+                    totalLength: number;
+                    pricePerMeter: number;
+                    pricePerPack: number;
+                    lengthPerPack: number;
+                };
+                const newPricePerMeter = (wire as any)._totalCost
+                    ? (wire as any)._totalCost / wire.totalLength
+                    : wire.pricePerPack / wire.lengthPerPack;
 
                 const { _totalCost, ...cleanWire } = wire as any;
                 return { ...cleanWire, pricePerMeter: newPricePerMeter };
             }
             case MaterialType.BEAD: {
-                const bead = material as Material & { totalQuantity: number; pricePerBead: number };
-                const totalCost = (bead as any)._totalCost || bead.totalQuantity * bead.pricePerBead;
-                const newPricePerBead = bead.totalQuantity > 0 ? totalCost / bead.totalQuantity : bead.pricePerBead;
+                const bead = material as Material & {
+                    totalQuantity: number;
+                    pricePerBead: number;
+                    pricePerPack: number;
+                    quantityPerPack: number;
+                };
+                const newPricePerBead = (bead as any)._totalCost
+                    ? (bead as any)._totalCost / bead.totalQuantity
+                    : bead.pricePerPack / bead.quantityPerPack;
 
                 const { _totalCost, ...cleanBead } = bead as any;
                 return { ...cleanBead, pricePerBead: newPricePerBead };
             }
             case MaterialType.CHAIN: {
-                const chain = material as Material & { totalLength: number; pricePerMeter?: number };
-                const totalCost =
-                    (chain as any)._totalCost || (chain.pricePerMeter ? chain.totalLength * chain.pricePerMeter : 0);
-                const newPricePerMeter =
-                    chain.totalLength > 0 && totalCost > 0 ? totalCost / chain.totalLength : chain.pricePerMeter;
+                const chain = material as Material & {
+                    totalLength: number;
+                    pricePerMeter?: number;
+                    pricePerPack: number;
+                    lengthPerPack: number;
+                };
+                const newPricePerMeter = (chain as any)._totalCost
+                    ? (chain as any)._totalCost / chain.totalLength
+                    : chain.pricePerPack / chain.lengthPerPack;
 
                 const { _totalCost, ...cleanChain } = chain as any;
                 return { ...cleanChain, pricePerMeter: newPricePerMeter };
             }
             case MaterialType.EAR_HOOK: {
-                const earHook = material as Material & { totalQuantity: number; pricePerPiece?: number };
-                const totalCost =
-                    (earHook as any)._totalCost ||
-                    (earHook.pricePerPiece ? earHook.totalQuantity * earHook.pricePerPiece : 0);
-                const newPricePerPiece =
-                    earHook.totalQuantity > 0 && totalCost > 0
-                        ? totalCost / earHook.totalQuantity
-                        : earHook.pricePerPiece;
+                const earHook = material as Material & {
+                    totalQuantity: number;
+                    pricePerPiece?: number;
+                    pricePerPack: number;
+                    quantityPerPack: number;
+                };
+                const newPricePerPiece = (earHook as any)._totalCost
+                    ? (earHook as any)._totalCost / earHook.totalQuantity
+                    : earHook.pricePerPack / earHook.quantityPerPack;
 
                 const { _totalCost, ...cleanEarHook } = earHook as any;
                 return { ...cleanEarHook, pricePerPiece: newPricePerPiece };

--- a/packages/web/src/api/endpoints/deleteMaterial/index.ts
+++ b/packages/web/src/api/endpoints/deleteMaterial/index.ts
@@ -1,0 +1,25 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { MATERIALS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+const makeDeleteMaterialRequest = async (
+    materialId: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) => {
+    return await makeRequestWithAutoRefresh<{ message: string }>(
+        {
+            pathname: `${MATERIALS_ENDPOINT}/${materialId}`,
+            method: MethodType.DELETE,
+            operationString: 'delete material',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export default makeDeleteMaterialRequest;

--- a/packages/web/src/components/MaterialsTable/AllMaterialsTable.tsx
+++ b/packages/web/src/components/MaterialsTable/AllMaterialsTable.tsx
@@ -1,8 +1,20 @@
+import { useAuth } from '@imapps/web-utils';
 import type { Material } from '@jewellery-catalogue/types';
-import { Edit, ShoppingBasket } from 'lucide-react';
+import { Edit, ShoppingBasket, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
+import makeDeleteMaterialRequest from '@/api/endpoints/deleteMaterial';
 import MaterialUpdateForm from '@/components/MaterialUpdateForm';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
@@ -16,6 +28,9 @@ export interface IAllMaterialsTableProps {
 const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMaterialUpdated }) => {
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null);
+    const [materialToDelete, setMaterialToDelete] = useState<Material | null>(null);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const { accessToken, login, logout } = useAuth();
 
     const formatPrice = (value: number | null | undefined) => {
         if (value == null) return '';
@@ -44,6 +59,20 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
     const handleOpenPurchaseUrl = (url: string | null | undefined) => {
         if (url) {
             window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    };
+
+    const handleDeleteConfirm = async () => {
+        if (!materialToDelete) return;
+        setIsDeleting(true);
+        try {
+            await makeDeleteMaterialRequest(materialToDelete.id, () => accessToken, login, logout);
+            setMaterialToDelete(null);
+            if (onMaterialUpdated) {
+                onMaterialUpdated();
+            }
+        } finally {
+            setIsDeleting(false);
         }
     };
 
@@ -142,6 +171,15 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
                                                     <Edit className="h-4 w-4" />
                                                     <span className="sr-only">Edit material</span>
                                                 </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => setMaterialToDelete(material)}
+                                                    className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                    <span className="sr-only">Delete material</span>
+                                                </Button>
                                             </div>
                                         </TableCell>
                                     </TableRow>
@@ -163,6 +201,27 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
                     )}
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!materialToDelete} onOpenChange={(open) => !open && setMaterialToDelete(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Material</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Delete "{materialToDelete?.name}"? This cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={handleDeleteConfirm}
+                            disabled={isDeleting}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </>
     );
 };

--- a/packages/web/src/hooks/useDraftAutosave.ts
+++ b/packages/web/src/hooks/useDraftAutosave.ts
@@ -1,8 +1,14 @@
 import type { DraftType } from '@jewellery-catalogue/types';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
-import { makeCreateDraftRequest, makeUpdateDraftRequest, makeUploadDraftImageRequest } from '../api/endpoints/drafts';
+import {
+    makeCreateDraftRequest,
+    makeDeleteDraftRequest,
+    makeUpdateDraftRequest,
+    makeUploadDraftImageRequest,
+} from '../api/endpoints/drafts';
 
 const DEBOUNCE_MS = 2000;
 
@@ -23,6 +29,11 @@ interface UseDraftAutosaveResult {
     saveError: boolean;
     uploadedImageId: string | null;
     clearDraft: () => void;
+    deleteAndClearDraft: (
+        getAccessToken: () => string,
+        onTokenRefresh: (token: string) => void,
+        onTokenClear: () => void
+    ) => Promise<void>;
 }
 
 export const useDraftAutosave = ({
@@ -35,6 +46,7 @@ export const useDraftAutosave = ({
     onTokenClear,
     onStatusChange,
 }: UseDraftAutosaveOptions): UseDraftAutosaveResult => {
+    const queryClient = useQueryClient();
     const [draftId, setDraftId] = useState<string | null>(initialDraftId);
     const [isSaving, setIsSaving] = useState(false);
     const [saveError, setSaveError] = useState(false);
@@ -61,6 +73,18 @@ export const useDraftAutosave = ({
         pendingFileRef.current = null;
         onStatusChangeRef.current?.({ isSaving: false, saveError: false, hasDraft: false });
     }, []);
+
+    const deleteAndClearDraft = useCallback(
+        async (getAt: () => string, onRefresh: (token: string) => void, onClear: () => void) => {
+            const id = draftIdRef.current;
+            if (id) {
+                await makeDeleteDraftRequest(id, getAt, onRefresh, onClear).catch(() => {});
+            }
+            queryClient.invalidateQueries({ queryKey: ['drafts', type] });
+            clearDraft();
+        },
+        [clearDraft, queryClient, type]
+    );
 
     const save = useCallback(
         async (values: Record<string, unknown>) => {
@@ -149,5 +173,6 @@ export const useDraftAutosave = ({
         saveError,
         uploadedImageId: uploadedImageIdRef.current,
         clearDraft,
+        deleteAndClearDraft,
     };
 };

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddDesignRequest from '../../api/endpoints/addDesign';
-import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
 import ImageUpload from '../../components/ImageUpload';
@@ -66,7 +65,7 @@ const AddDesign: React.FC = () => {
     const { dispatch } = useAlert();
     const { setDraftStatus, clearDraftStatus } = useDraftStatus();
 
-    const { draftId, uploadedImageId, clearDraft } = useDraftAutosave({
+    const { draftId, uploadedImageId, clearDraft, deleteAndClearDraft } = useDraftAutosave({
         form,
         type: 'design',
         initialDraftId: draftIdParam,
@@ -117,10 +116,7 @@ const AddDesign: React.FC = () => {
             const submitData = { ...formData, variants, imageId: imageIdFromDraft };
 
             await makeAddDesignRequest(submitData, () => accessToken, login, logout);
-
-            if (draftId) {
-                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
-            }
+            await deleteAndClearDraft(() => accessToken, login, logout);
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -132,7 +128,6 @@ const AddDesign: React.FC = () => {
                 },
             });
             form.reset();
-            clearDraft();
         } catch (e) {
             console.error('[AddDesign] Error adding design:', e);
             const message = e instanceof Error ? e.message : 'Unknown Error';

--- a/packages/web/src/pages/AddMaterial/index.tsx
+++ b/packages/web/src/pages/AddMaterial/index.tsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddMaterialRequest from '../../api/endpoints/addMaterial';
-import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import MaterialFormResolver from '../../components/MaterialFormResolver';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
@@ -45,7 +44,7 @@ const AddMaterial = () => {
 
     const currentMaterialType = form.watch('type');
 
-    const { draftId, clearDraft } = useDraftAutosave({
+    const { deleteAndClearDraft } = useDraftAutosave({
         form,
         type: 'material',
         initialDraftId: draftIdParam,
@@ -81,10 +80,7 @@ const AddMaterial = () => {
         setIsMakingRequest(true);
         try {
             await makeAddMaterialRequest(data, () => accessToken, login, logout);
-
-            if (draftId) {
-                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
-            }
+            await deleteAndClearDraft(() => accessToken, login, logout);
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -96,7 +92,6 @@ const AddMaterial = () => {
                 },
             });
             form.reset();
-            clearDraft();
         } catch (e) {
             const message = e instanceof Error ? e.message : 'Unknown Error';
 


### PR DESCRIPTION
## Summary

- **Delete materials**: Add trash icon + confirmation dialog to AllMaterialsTable; wire up existing DELETE /api/materials/:id via new deleteMaterial helper
- **Draft not deleted after design/material added**: useDraftAutosave now exposes deleteAndClearDraft() which reads draftIdRef.current (avoids stale-closure race condition) and invalidates the drafts query cache; AddDesign and AddMaterial use it
- **Per-unit price not updating on price-per-pack change**: recalculatePerUnitPrice fell back to totalLength x oldPricePerUnit when no _totalCost present; now uses pricePerPack / packSize

## Test plan
- [ ] Materials page trash icon -> confirm -> row removed
- [ ] Add material/design -> submit -> no draft shown on list page
- [ ] Edit material price-per-pack only -> per-unit price updates
- [ ] Edit material + add packs -> weighted average unchanged

Generated with Claude Code