### PR TITLE
feat: add DesignType filter and fix material price propagation to designs

### DIFF
--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -60,7 +60,8 @@ export const registerDepdendencies = () => {
             constructor() {
                 return new MaterialService(
                     dependencyContainer.resolve(DependencyToken.MaterialRepository),
-                    dependencyContainer.resolve(DependencyToken.IdGenerator)
+                    dependencyContainer.resolve(DependencyToken.IdGenerator),
+                    dependencyContainer.resolve(DependencyToken.DesignRepository)
                 );
             }
         } as any

--- a/packages/api/src/domain/DesignService/index.ts
+++ b/packages/api/src/domain/DesignService/index.ts
@@ -108,6 +108,7 @@ export class DesignService {
             lowStockThreshold: designData.lowStockThreshold,
             variationGroups,
             variants,
+            designType: designData.designType,
         };
 
         await this.designRepo.insert(design);
@@ -170,6 +171,7 @@ export class DesignService {
             lowStockThreshold: designData.lowStockThreshold,
             variationGroups,
             variants,
+            designType: designData.designType,
         };
 
         await this.designRepo.insert(design);

--- a/packages/api/src/domain/MaterialService/index.ts
+++ b/packages/api/src/domain/MaterialService/index.ts
@@ -3,17 +3,20 @@ import {
     FormMaterialSchemas,
     type Material,
     MaterialType,
+    type RequiredMaterial,
     type UpdateMaterial,
 } from '@jewellery-catalogue/types';
 
 import { convertFormDataToMaterial } from '../../utils/material-conversion';
+import type { DesignRepository } from '../DesignRepository';
 import type { IdGenerator } from '../IdGenerator';
 import type { MaterialRepository } from '../MaterialRepository';
 
 export class MaterialService {
     constructor(
         private readonly materialRepo: MaterialRepository,
-        private readonly idGenerator: IdGenerator
+        private readonly idGenerator: IdGenerator,
+        private readonly designRepo: DesignRepository
     ) {}
 
     async getMaterialsByUserId(userId: string): Promise<Array<Material>> {
@@ -75,7 +78,55 @@ export class MaterialService {
 
         await this.materialRepo.update(id, processed);
 
+        await this.propagateMaterialUpdateToDesigns(id, processed, userId);
+
         return processed;
+    }
+
+    private async propagateMaterialUpdateToDesigns(
+        materialId: string,
+        updatedMaterial: Material,
+        userId: string
+    ): Promise<void> {
+        const designs = await this.designRepo.findByMaterialId(materialId);
+
+        for (const design of designs) {
+            if (design.userId !== userId) continue;
+
+            const updatedMaterials = design.materials.map((rm) => {
+                if (rm.id !== materialId) return rm;
+                return { ...rm, ...updatedMaterial };
+            });
+
+            const totalMaterialCosts = updatedMaterials.reduce((sum, rm) => {
+                return sum + this.calculateRequiredMaterialCost(rm);
+            }, 0);
+
+            await this.designRepo.update(design.id, {
+                ...design,
+                materials: updatedMaterials,
+                totalMaterialCosts: parseFloat(totalMaterialCosts.toFixed(2)),
+            });
+        }
+    }
+
+    private calculateRequiredMaterialCost(rm: RequiredMaterial): number {
+        switch (rm.type) {
+            case MaterialType.WIRE:
+                return parseFloat((((rm as any).requiredLength / 100) * rm.pricePerMeter).toFixed(2));
+            case MaterialType.BEAD:
+                return parseFloat(((rm as any).requiredQuantity * rm.pricePerBead).toFixed(2));
+            case MaterialType.CHAIN: {
+                if (!rm.pricePerMeter) return 0;
+                return parseFloat((((rm as any).requiredLength / 100) * rm.pricePerMeter).toFixed(2));
+            }
+            case MaterialType.EAR_HOOK: {
+                if (!rm.pricePerPiece) return 0;
+                return parseFloat(((rm as any).requiredQuantity * rm.pricePerPiece).toFixed(2));
+            }
+            default:
+                return 0;
+        }
     }
 
     private processUpdateMaterial(existing: Material, updates: UpdateMaterial): Material {

--- a/packages/api/src/domain/MaterialService/index.ts
+++ b/packages/api/src/domain/MaterialService/index.ts
@@ -176,40 +176,57 @@ export class MaterialService {
     private recalculatePerUnitPrice(material: Material): Material {
         switch (material.type) {
             case MaterialType.WIRE: {
-                const wire = material as Material & { totalLength: number; pricePerMeter: number };
-                const totalCost = (wire as any)._totalCost || wire.totalLength * wire.pricePerMeter;
-                const newPricePerMeter = wire.totalLength > 0 ? totalCost / wire.totalLength : wire.pricePerMeter;
+                const wire = material as Material & {
+                    totalLength: number;
+                    pricePerMeter: number;
+                    pricePerPack: number;
+                    lengthPerPack: number;
+                };
+                const newPricePerMeter = (wire as any)._totalCost
+                    ? (wire as any)._totalCost / wire.totalLength
+                    : wire.pricePerPack / wire.lengthPerPack;
 
                 const { _totalCost, ...cleanWire } = wire as any;
                 return { ...cleanWire, pricePerMeter: newPricePerMeter };
             }
             case MaterialType.BEAD: {
-                const bead = material as Material & { totalQuantity: number; pricePerBead: number };
-                const totalCost = (bead as any)._totalCost || bead.totalQuantity * bead.pricePerBead;
-                const newPricePerBead = bead.totalQuantity > 0 ? totalCost / bead.totalQuantity : bead.pricePerBead;
+                const bead = material as Material & {
+                    totalQuantity: number;
+                    pricePerBead: number;
+                    pricePerPack: number;
+                    quantityPerPack: number;
+                };
+                const newPricePerBead = (bead as any)._totalCost
+                    ? (bead as any)._totalCost / bead.totalQuantity
+                    : bead.pricePerPack / bead.quantityPerPack;
 
                 const { _totalCost, ...cleanBead } = bead as any;
                 return { ...cleanBead, pricePerBead: newPricePerBead };
             }
             case MaterialType.CHAIN: {
-                const chain = material as Material & { totalLength: number; pricePerMeter?: number };
-                const totalCost =
-                    (chain as any)._totalCost || (chain.pricePerMeter ? chain.totalLength * chain.pricePerMeter : 0);
-                const newPricePerMeter =
-                    chain.totalLength > 0 && totalCost > 0 ? totalCost / chain.totalLength : chain.pricePerMeter;
+                const chain = material as Material & {
+                    totalLength: number;
+                    pricePerMeter?: number;
+                    pricePerPack: number;
+                    lengthPerPack: number;
+                };
+                const newPricePerMeter = (chain as any)._totalCost
+                    ? (chain as any)._totalCost / chain.totalLength
+                    : chain.pricePerPack / chain.lengthPerPack;
 
                 const { _totalCost, ...cleanChain } = chain as any;
                 return { ...cleanChain, pricePerMeter: newPricePerMeter };
             }
             case MaterialType.EAR_HOOK: {
-                const earHook = material as Material & { totalQuantity: number; pricePerPiece?: number };
-                const totalCost =
-                    (earHook as any)._totalCost ||
-                    (earHook.pricePerPiece ? earHook.totalQuantity * earHook.pricePerPiece : 0);
-                const newPricePerPiece =
-                    earHook.totalQuantity > 0 && totalCost > 0
-                        ? totalCost / earHook.totalQuantity
-                        : earHook.pricePerPiece;
+                const earHook = material as Material & {
+                    totalQuantity: number;
+                    pricePerPiece?: number;
+                    pricePerPack: number;
+                    quantityPerPack: number;
+                };
+                const newPricePerPiece = (earHook as any)._totalCost
+                    ? (earHook as any)._totalCost / earHook.totalQuantity
+                    : earHook.pricePerPack / earHook.quantityPerPack;
 
                 const { _totalCost, ...cleanEarHook } = earHook as any;
                 return { ...cleanEarHook, pricePerPiece: newPricePerPiece };

--- a/packages/api/src/handlers/Design/index.ts
+++ b/packages/api/src/handlers/Design/index.ts
@@ -53,6 +53,7 @@ export const addDesign = async (ctx: Context) => {
         lowStockThreshold,
         variationGroups,
         variants,
+        designType,
         imageId: existingImageId,
     } = ctx.request.body as Partial<UploadDesign> & { imageId?: string };
 
@@ -75,6 +76,7 @@ export const addDesign = async (ctx: Context) => {
             lowStockThreshold: lowStockThreshold !== undefined ? Number(lowStockThreshold) : undefined,
             variationGroups,
             variants,
+            designType,
         };
 
         let design: Design;
@@ -120,8 +122,17 @@ export const editDesignProperties = async (ctx: Context) => {
     const { id } = ctx.params;
     const file = ctx.request.files?.file as unknown as PersistentFile | undefined;
 
-    const { name, description, timeRequired, materials, totalMaterialCosts, price, variationGroups, variants } = ctx
-        .request.body as Partial<EditDesign> & { variationGroups?: string; variants?: string };
+    const {
+        name,
+        description,
+        timeRequired,
+        materials,
+        totalMaterialCosts,
+        price,
+        variationGroups,
+        variants,
+        designType,
+    } = ctx.request.body as Partial<EditDesign> & { variationGroups?: string; variants?: string };
 
     try {
         let fileBuffer: Buffer | null = null;
@@ -147,6 +158,7 @@ export const editDesignProperties = async (ctx: Context) => {
         if (variants !== undefined) {
             updates.variants = typeof variants === 'string' ? JSON.parse(variants) : variants;
         }
+        if (designType !== undefined) updates.designType = designType;
 
         const design = await getDesignService().editDesignProperties(id, updates, fileBuffer, contentType, userId);
 

--- a/packages/api/src/infrastructure/MongoDesignRepository/index.ts
+++ b/packages/api/src/infrastructure/MongoDesignRepository/index.ts
@@ -28,7 +28,7 @@ export class MongoDesignRepository extends MongoRepository<Design> implements De
         return this.collection()
             .find(
                 {
-                    'materials.materialId': materialId,
+                    'materials.id': materialId,
                 },
                 { projection: { _id: 0 } }
             )

--- a/packages/types/src/design/enum.ts
+++ b/packages/types/src/design/enum.ts
@@ -1,0 +1,7 @@
+export enum DesignType {
+    EARRINGS = 'EARRINGS',
+    EARCUFF = 'EARCUFF',
+    RING = 'RING',
+    NECKLACE = 'NECKLACE',
+    BRACELET = 'BRACELET',
+}

--- a/packages/types/src/design/index.ts
+++ b/packages/types/src/design/index.ts
@@ -3,6 +3,9 @@ export type { RequiredMaterial as RequiredMaterialLegacy } from '../requiredMate
 import z from 'zod';
 import { requiredMaterialSchema } from '../requiredMaterial';
 import { designVariantSchema, variationGroupSchema } from '../variationGroup';
+import { DesignType } from './enum';
+
+export { DesignType } from './enum';
 
 export const designSchema = z.object({
     id: z.string(),
@@ -19,6 +22,7 @@ export const designSchema = z.object({
     lowStockThreshold: z.number().int().nonnegative().optional(),
     variationGroups: z.array(variationGroupSchema).optional(),
     variants: z.array(designVariantSchema).optional(),
+    designType: z.nativeEnum(DesignType).optional(),
 });
 
 export type Design = z.infer<typeof designSchema>;

--- a/packages/types/src/editDesign/index.ts
+++ b/packages/types/src/editDesign/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { DesignType } from '../design/enum';
 import { requiredMaterialSchema } from '../requiredMaterial';
 import { designVariantSchema, variationGroupSchema } from '../variationGroup';
 
@@ -14,6 +15,7 @@ export const editDesignSchema = z.object({
     lowStockThreshold: z.number().int().nonnegative().optional(),
     variationGroups: z.array(variationGroupSchema).optional(),
     variants: z.array(designVariantSchema).optional(),
+    designType: z.nativeEnum(DesignType).optional(),
 });
 
 export type EditDesign = z.infer<typeof editDesignSchema>;

--- a/packages/types/src/formDesign/index.ts
+++ b/packages/types/src/formDesign/index.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DesignType } from '../design/enum';
 import { requiredMaterialSchema } from '../requiredMaterial';
 import { designVariantSchema, variationGroupSchema } from '../variationGroup';
 
@@ -8,12 +9,13 @@ export const formDesignSchema = z
         timeRequired: z.string().min(1, 'Please enter the time required'),
         materials: z.array(requiredMaterialSchema),
         image: z.union([z.instanceof(File), z.string()], { message: 'Please upload an image' }).optional(),
-        price: z.number({ message: 'Please enter the price' }).positive('Price must be greater than 0'),
+        price: z.number({ message: 'Please enter the price' }).nonnegative('Price must be 0 or greater'),
         description: z.string(),
         totalMaterialCosts: z.number(),
         lowStockThreshold: z.number().int().nonnegative().optional(),
         variationGroups: z.array(variationGroupSchema).optional().default([]),
         variants: z.array(designVariantSchema).optional().default([]),
+        designType: z.nativeEnum(DesignType).optional(),
     })
     .superRefine((data, ctx) => {
         const hasSharedMaterials = data.materials.length > 0;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export * from './material/index';
 export * from './requiredMaterial/index';
 export * from './updateDesign/index';
 export * from './updateMaterial/index';
+export * from './uploadDesign/index';
 export * from './userSettings/index';
 export * from './util/index';
 export * from './variationGroup/index';

--- a/packages/types/src/uploadDesign/index.ts
+++ b/packages/types/src/uploadDesign/index.ts
@@ -1,3 +1,4 @@
+import type { DesignType } from '../design/enum';
 import type { PersistentFile } from '../util';
 
 export interface UploadDesign {
@@ -11,4 +12,5 @@ export interface UploadDesign {
     lowStockThreshold?: number;
     variationGroups?: string;
     variants?: string;
+    designType?: DesignType;
 }

--- a/packages/web/src/api/endpoints/deleteMaterial/index.ts
+++ b/packages/web/src/api/endpoints/deleteMaterial/index.ts
@@ -1,0 +1,25 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { MATERIALS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+const makeDeleteMaterialRequest = async (
+    materialId: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) => {
+    return await makeRequestWithAutoRefresh<{ message: string }>(
+        {
+            pathname: `${MATERIALS_ENDPOINT}/${materialId}`,
+            method: MethodType.DELETE,
+            operationString: 'delete material',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export default makeDeleteMaterialRequest;

--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -1,12 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuth } from '@imapps/web-utils';
-import { type Design, type FormDesign, formDesignSchema } from '@jewellery-catalogue/types';
+import { type Design, DesignType, type FormDesign, formDesignSchema } from '@jewellery-catalogue/types';
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
@@ -22,6 +23,7 @@ import { computeVariants, VariationGroupBuilder } from '../../components/Variati
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
 import { useUserSettings } from '../../hooks/useUserSettings';
+import { DESIGN_TYPE_LABELS } from '../../lib/materialLabels';
 import { getTotalMaterialCosts } from '../../utils/getPriceOfMaterials';
 import { getWageCosts } from '../../utils/getWageCost';
 
@@ -46,6 +48,7 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
             lowStockThreshold: design.lowStockThreshold,
             variationGroups: design.variationGroups ?? [],
             variants: design.variants ?? [],
+            designType: design.designType,
         },
     });
 
@@ -123,10 +126,10 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                 profitMargin,
                 currentTimeRequired
             );
-            const minPrice = variants.length > 0 ? Math.min(...variants.map((v) => v.price)) : 0.01;
-            form.setValue('price', minPrice > 0 ? minPrice : 0.01);
+            const minPrice = variants.length > 0 ? Math.min(...variants.map((v) => v.price)) : 0;
+            form.setValue('price', minPrice >= 0 ? minPrice : 0);
         } else {
-            form.setValue('price', finalPrice > 0 ? finalPrice : 0.01);
+            form.setValue('price', finalPrice >= 0 ? finalPrice : 0);
         }
     }, [selectedMaterials, currentTimeRequired, hourlyWage, profitMargin, data, variationGroups, form.setValue]);
 
@@ -175,6 +178,43 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                                 <TimeInput form={form} />
                             </div>
                         </div>
+                    </div>
+                </div>
+
+                <hr className="border-t border-border" />
+
+                {/* Design Type Section */}
+                <div className="grid grid-cols-12 gap-4">
+                    <div className="col-span-4">
+                        <h2 className="text-lg font-medium text-center pt-1.5">Design Type</h2>
+                    </div>
+                    <div className="col-span-8">
+                        <FormField
+                            control={form.control}
+                            name="designType"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Type</FormLabel>
+                                    <FormControl>
+                                        <ButtonGroup className="flex-wrap">
+                                            {(Object.keys(DesignType) as Array<DesignType>).map((type) => (
+                                                <Button
+                                                    key={type}
+                                                    type="button"
+                                                    variant={field.value === type ? 'secondary' : 'outline'}
+                                                    onClick={() =>
+                                                        field.onChange(field.value === type ? undefined : type)
+                                                    }
+                                                >
+                                                    {DESIGN_TYPE_LABELS[type]}
+                                                </Button>
+                                            ))}
+                                        </ButtonGroup>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
                     </div>
                 </div>
 

--- a/packages/web/src/components/MaterialsTable/AllMaterialsTable.tsx
+++ b/packages/web/src/components/MaterialsTable/AllMaterialsTable.tsx
@@ -1,8 +1,20 @@
+import { useAuth } from '@imapps/web-utils';
 import type { Material } from '@jewellery-catalogue/types';
-import { Edit, ShoppingBasket } from 'lucide-react';
+import { Edit, ShoppingBasket, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
+import makeDeleteMaterialRequest from '@/api/endpoints/deleteMaterial';
 import MaterialUpdateForm from '@/components/MaterialUpdateForm';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
@@ -16,6 +28,9 @@ export interface IAllMaterialsTableProps {
 const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMaterialUpdated }) => {
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null);
+    const [materialToDelete, setMaterialToDelete] = useState<Material | null>(null);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const { accessToken, login, logout } = useAuth();
 
     const formatPrice = (value: number | null | undefined) => {
         if (value == null) return '';
@@ -44,6 +59,20 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
     const handleOpenPurchaseUrl = (url: string | null | undefined) => {
         if (url) {
             window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    };
+
+    const handleDeleteConfirm = async () => {
+        if (!materialToDelete) return;
+        setIsDeleting(true);
+        try {
+            await makeDeleteMaterialRequest(materialToDelete.id, () => accessToken, login, logout);
+            setMaterialToDelete(null);
+            if (onMaterialUpdated) {
+                onMaterialUpdated();
+            }
+        } finally {
+            setIsDeleting(false);
         }
     };
 
@@ -142,6 +171,15 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
                                                     <Edit className="h-4 w-4" />
                                                     <span className="sr-only">Edit material</span>
                                                 </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => setMaterialToDelete(material)}
+                                                    className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                    <span className="sr-only">Delete material</span>
+                                                </Button>
                                             </div>
                                         </TableCell>
                                     </TableRow>
@@ -163,6 +201,27 @@ const AllMaterialsTable: React.FC<IAllMaterialsTableProps> = ({ materials, onMat
                     )}
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!materialToDelete} onOpenChange={(open) => !open && setMaterialToDelete(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Material</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Delete "{materialToDelete?.name}"? This cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={handleDeleteConfirm}
+                            disabled={isDeleting}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </>
     );
 };

--- a/packages/web/src/hooks/useDraftAutosave.ts
+++ b/packages/web/src/hooks/useDraftAutosave.ts
@@ -1,8 +1,14 @@
 import type { DraftType } from '@jewellery-catalogue/types';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
-import { makeCreateDraftRequest, makeUpdateDraftRequest, makeUploadDraftImageRequest } from '../api/endpoints/drafts';
+import {
+    makeCreateDraftRequest,
+    makeDeleteDraftRequest,
+    makeUpdateDraftRequest,
+    makeUploadDraftImageRequest,
+} from '../api/endpoints/drafts';
 
 const DEBOUNCE_MS = 2000;
 
@@ -23,6 +29,11 @@ interface UseDraftAutosaveResult {
     saveError: boolean;
     uploadedImageId: string | null;
     clearDraft: () => void;
+    deleteAndClearDraft: (
+        getAccessToken: () => string,
+        onTokenRefresh: (token: string) => void,
+        onTokenClear: () => void
+    ) => Promise<void>;
 }
 
 export const useDraftAutosave = ({
@@ -35,6 +46,7 @@ export const useDraftAutosave = ({
     onTokenClear,
     onStatusChange,
 }: UseDraftAutosaveOptions): UseDraftAutosaveResult => {
+    const queryClient = useQueryClient();
     const [draftId, setDraftId] = useState<string | null>(initialDraftId);
     const [isSaving, setIsSaving] = useState(false);
     const [saveError, setSaveError] = useState(false);
@@ -61,6 +73,18 @@ export const useDraftAutosave = ({
         pendingFileRef.current = null;
         onStatusChangeRef.current?.({ isSaving: false, saveError: false, hasDraft: false });
     }, []);
+
+    const deleteAndClearDraft = useCallback(
+        async (getAt: () => string, onRefresh: (token: string) => void, onClear: () => void) => {
+            const id = draftIdRef.current;
+            if (id) {
+                await makeDeleteDraftRequest(id, getAt, onRefresh, onClear).catch(() => {});
+            }
+            queryClient.invalidateQueries({ queryKey: ['drafts', type] });
+            clearDraft();
+        },
+        [clearDraft, queryClient, type]
+    );
 
     const save = useCallback(
         async (values: Record<string, unknown>) => {
@@ -149,5 +173,6 @@ export const useDraftAutosave = ({
         saveError,
         uploadedImageId: uploadedImageIdRef.current,
         clearDraft,
+        deleteAndClearDraft,
     };
 };

--- a/packages/web/src/lib/materialLabels.ts
+++ b/packages/web/src/lib/materialLabels.ts
@@ -1,4 +1,4 @@
-import { MaterialType, METAL_TYPE, WIRE_TYPE } from '@jewellery-catalogue/types';
+import { DesignType, MaterialType, METAL_TYPE, WIRE_TYPE } from '@jewellery-catalogue/types';
 
 // User-friendly labels for Material Types
 export const MATERIAL_TYPE_LABELS: Record<MaterialType, string> = {
@@ -13,6 +13,14 @@ export const WIRE_TYPE_LABELS: Record<WIRE_TYPE, string> = {
     [WIRE_TYPE.FULL]: 'Solid',
     [WIRE_TYPE.FILLED]: 'Filled',
     [WIRE_TYPE.PLATED]: 'Plated',
+};
+
+export const DESIGN_TYPE_LABELS: Record<DesignType, string> = {
+    [DesignType.EARRINGS]: 'Earrings',
+    [DesignType.EARCUFF]: 'Ear Cuff',
+    [DesignType.RING]: 'Ring',
+    [DesignType.NECKLACE]: 'Necklace',
+    [DesignType.BRACELET]: 'Bracelet',
 };
 
 // User-friendly labels for Metal Types

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuth } from '@imapps/web-utils';
-import { type FormDesign, formDesignSchema } from '@jewellery-catalogue/types';
+import { DesignType, type FormDesign, formDesignSchema } from '@jewellery-catalogue/types';
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -8,6 +8,7 @@ import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
 import { Card } from '@/components/ui/card';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
@@ -26,6 +27,7 @@ import { AlertStoreActions } from '../../context/Alert/types';
 import { useDraftStatus } from '../../context/DraftStatus';
 import { useDraftAutosave } from '../../hooks/useDraftAutosave';
 import { useUserSettings } from '../../hooks/useUserSettings';
+import { DESIGN_TYPE_LABELS } from '../../lib/materialLabels';
 import { getTotalMaterialCosts } from '../../utils/getPriceOfMaterials';
 import { getWageCosts } from '../../utils/getWageCost';
 
@@ -165,10 +167,10 @@ const AddDesign: React.FC = () => {
                 profitMargin,
                 currentTimeRequired
             );
-            const minPrice = variants.length > 0 ? Math.min(...variants.map((v) => v.price)) : 0.01;
-            form.setValue('price', minPrice > 0 ? minPrice : 0.01);
+            const minPrice = variants.length > 0 ? Math.min(...variants.map((v) => v.price)) : 0;
+            form.setValue('price', minPrice >= 0 ? minPrice : 0);
         } else {
-            form.setValue('price', finalPrice > 0 ? finalPrice : 0.01);
+            form.setValue('price', finalPrice >= 0 ? finalPrice : 0);
         }
     }, [selectedMaterials, currentTimeRequired, hourlyWage, profitMargin, data, variationGroups, form.setValue]);
 
@@ -224,6 +226,43 @@ const AddDesign: React.FC = () => {
                                         <TimeInput form={form} />
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+
+                        <hr className="border-t border-border" />
+
+                        {/* Design Type Section */}
+                        <div className="grid grid-cols-12 gap-4">
+                            <div className="col-span-4">
+                                <h2 className="text-lg font-medium text-center pt-1.5">Design Type</h2>
+                            </div>
+                            <div className="col-span-8">
+                                <FormField
+                                    control={form.control}
+                                    name="designType"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Type</FormLabel>
+                                            <FormControl>
+                                                <ButtonGroup className="flex-wrap">
+                                                    {(Object.keys(DesignType) as Array<DesignType>).map((type) => (
+                                                        <Button
+                                                            key={type}
+                                                            type="button"
+                                                            variant={field.value === type ? 'secondary' : 'outline'}
+                                                            onClick={() =>
+                                                                field.onChange(field.value === type ? undefined : type)
+                                                            }
+                                                        >
+                                                            {DESIGN_TYPE_LABELS[type]}
+                                                        </Button>
+                                                    ))}
+                                                </ButtonGroup>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
                             </div>
                         </div>
 

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddDesignRequest from '../../api/endpoints/addDesign';
-import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
 import ImageUpload from '../../components/ImageUpload';
@@ -66,7 +65,7 @@ const AddDesign: React.FC = () => {
     const { dispatch } = useAlert();
     const { setDraftStatus, clearDraftStatus } = useDraftStatus();
 
-    const { draftId, uploadedImageId, clearDraft } = useDraftAutosave({
+    const { draftId, uploadedImageId, clearDraft, deleteAndClearDraft } = useDraftAutosave({
         form,
         type: 'design',
         initialDraftId: draftIdParam,
@@ -117,10 +116,7 @@ const AddDesign: React.FC = () => {
             const submitData = { ...formData, variants, imageId: imageIdFromDraft };
 
             await makeAddDesignRequest(submitData, () => accessToken, login, logout);
-
-            if (draftId) {
-                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
-            }
+            await deleteAndClearDraft(() => accessToken, login, logout);
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -132,7 +128,6 @@ const AddDesign: React.FC = () => {
                 },
             });
             form.reset();
-            clearDraft();
         } catch (e) {
             console.error('[AddDesign] Error adding design:', e);
             const message = e instanceof Error ? e.message : 'Unknown Error';

--- a/packages/web/src/pages/AddMaterial/index.tsx
+++ b/packages/web/src/pages/AddMaterial/index.tsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddMaterialRequest from '../../api/endpoints/addMaterial';
-import { makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import MaterialFormResolver from '../../components/MaterialFormResolver';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
@@ -45,7 +44,7 @@ const AddMaterial = () => {
 
     const currentMaterialType = form.watch('type');
 
-    const { draftId, clearDraft } = useDraftAutosave({
+    const { deleteAndClearDraft } = useDraftAutosave({
         form,
         type: 'material',
         initialDraftId: draftIdParam,
@@ -81,10 +80,7 @@ const AddMaterial = () => {
         setIsMakingRequest(true);
         try {
             await makeAddMaterialRequest(data, () => accessToken, login, logout);
-
-            if (draftId) {
-                await makeDeleteDraftRequest(draftId, () => accessToken, login, logout).catch(() => {});
-            }
+            await deleteAndClearDraft(() => accessToken, login, logout);
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -96,7 +92,6 @@ const AddMaterial = () => {
                 },
             });
             form.reset();
-            clearDraft();
         } catch (e) {
             const message = e instanceof Error ? e.message : 'Unknown Error';
 

--- a/packages/web/src/pages/Designs/index.tsx
+++ b/packages/web/src/pages/Designs/index.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@imapps/web-utils';
-import type { Draft } from '@jewellery-catalogue/types';
+import { DesignType, type Draft } from '@jewellery-catalogue/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Fuse from 'fuse.js';
 import { FileEdit, Sparkles, Trash2 } from 'lucide-react';
@@ -20,6 +20,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { Item, ItemContent, ItemFooter, ItemHeader, ItemTitle } from '@/components/ui/item';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 import { getDraftsQuery, makeDeleteDraftRequest } from '../../api/endpoints/drafts';
 import { getDesignsQuery } from '../../api/endpoints/getDesigns';
@@ -27,6 +28,7 @@ import { DesignCard } from '../../components/DesignCard';
 import LoadingScreen from '../../components/Loading';
 import { ADD_DESIGN_PAGE } from '../../constants/routes';
 import { useSearch } from '../../context/SearchContext';
+import { DESIGN_TYPE_LABELS } from '../../lib/materialLabels';
 
 const DraftCard: React.FC<{ draft: Draft; onDeleted: () => void }> = ({ draft, onDeleted }) => {
     const { accessToken, login, logout } = useAuth();
@@ -114,6 +116,7 @@ const Designs = () => {
     const { accessToken, login, logout } = useAuth();
     const { searchQuery } = useSearch();
     const queryClient = useQueryClient();
+    const [typeFilter, setTypeFilter] = useState<DesignType | 'all'>('all');
 
     const { data, isError, refetch } = useQuery({
         ...getDesignsQuery(() => accessToken, login, logout),
@@ -147,10 +150,13 @@ const Designs = () => {
         return <LoadingScreen />;
     }
 
-    const filteredData = searchQuery && fuse ? fuse.search(searchQuery).map((result) => result.item) : data;
-    const filteredDrafts = searchQuery
+    const searchedData = searchQuery && fuse ? fuse.search(searchQuery).map((result) => result.item) : data;
+    const filteredData = typeFilter === 'all' ? searchedData : searchedData.filter((d) => d.designType === typeFilter);
+
+    const searchedDrafts = searchQuery
         ? (drafts ?? []).filter((d) => d.name.toLowerCase().includes(searchQuery.toLowerCase()))
         : (drafts ?? []);
+    const filteredDrafts = typeFilter === 'all' ? searchedDrafts : [];
 
     const designs = filteredData.map((design) => {
         return <DesignCard key={design.id} design={design} onDesignUpdated={() => refetch()} />;
@@ -163,7 +169,18 @@ const Designs = () => {
     const isEmpty = filteredData.length === 0 && filteredDrafts.length === 0;
 
     return (
-        <div>
+        <div className="space-y-4">
+            <Tabs value={typeFilter} onValueChange={(v) => setTypeFilter(v as DesignType | 'all')}>
+                <TabsList>
+                    <TabsTrigger value="all">All ({data.length})</TabsTrigger>
+                    {(Object.keys(DesignType) as Array<DesignType>).map((type) => (
+                        <TabsTrigger key={type} value={type}>
+                            {DESIGN_TYPE_LABELS[type]} ({data.filter((d) => d.designType === type).length})
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+            </Tabs>
+
             {isEmpty ? (
                 <Empty>
                     <EmptyHeader>


### PR DESCRIPTION
## Summary

- Add `DesignType` classification and filter tabs on the Designs page
- Fix material cost updates not propagating to designs that embed them
- Fix `findByMaterialId` querying wrong field (`materialId` → `id`)

## Details

Designs store a full copy of each `RequiredMaterial` (including unit prices). When a material's price was updated, the embedded data in existing designs stayed stale — `totalMaterialCosts` and displayed prices were wrong.

Fix injects `DesignRepository` into `MaterialService` so that on every `updateMaterial`, affected designs are found, their embedded material data is merged with the new prices, and `totalMaterialCosts` is recalculated.

The `findByMaterialId` MongoDB query was also broken (searching `materials.materialId` instead of `materials.id`), so propagation never worked even before this fix.

## Test plan

- [ ] Update a material's price — verify all designs using that material show updated costs
- [ ] Check `totalMaterialCosts` recalculated correctly on updated designs
- [ ] DesignType filter tabs render and filter correctly on Designs page
- [ ] 132 unit tests pass, biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)