### PR TITLE
feat(editor): add image upload to rich text editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,7 +75,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@tiptap/extension-image": "^3.23.1",
+        "@tiptap/extension-image": "3.6.5",
         "@tiptap/extension-placeholder": "^3.6.5",
         "@tiptap/pm": "^3.6.5",
         "@tiptap/react": "^3.6.5",
@@ -652,7 +652,7 @@
 
     "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@3.20.4", "", { "peerDependencies": { "@tiptap/core": "^3.20.4", "@tiptap/pm": "^3.20.4" } }, "sha512-y6joCi49haAA0bo3EGUY+dWUMHH1GPUc84hxrBY/0pMs+Bn+kQ1+DQJErZDTWGJrlHPWU/yekBZT72SNdp0DNA=="],
 
-    "@tiptap/extension-image": ["@tiptap/extension-image@3.23.1", "", { "peerDependencies": { "@tiptap/core": "3.23.1" } }, "sha512-rAyfh8HS0PfXS8PKl1VQUiDFzXtF5SlrILpOPmz+4Oc4pmI+/vN+ain4z8k6HRxWM03YVpvLvyeQ0OFwi/fq3A=="],
+    "@tiptap/extension-image": ["@tiptap/extension-image@3.6.5", "", { "peerDependencies": { "@tiptap/core": "^3.6.5" } }, "sha512-Tzej5vSjiIPmr+3zeFYIGOdZ7T+tnOMMuFuduiitynTsVY2oG34Y/oBnwBfD+jLq8v3SBFF55J972Ga6+vBvrA=="],
 
     "@tiptap/extension-italic": ["@tiptap/extension-italic@3.20.4", "", { "peerDependencies": { "@tiptap/core": "^3.20.4" } }, "sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@tiptap/extension-image": "^3.23.1",
         "@tiptap/extension-placeholder": "^3.6.5",
         "@tiptap/pm": "^3.6.5",
         "@tiptap/react": "^3.6.5",
@@ -650,6 +651,8 @@
     "@tiptap/extension-heading": ["@tiptap/extension-heading@3.20.4", "", { "peerDependencies": { "@tiptap/core": "^3.20.4" } }, "sha512-xsnkmTGggJc5P2iCwS1lv8KFG31xC/GNPJKoi/3UH67j/lKDhA3AdtshsLeyv2FKtTtYDb8oV0IqzHB1MM6a7w=="],
 
     "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@3.20.4", "", { "peerDependencies": { "@tiptap/core": "^3.20.4", "@tiptap/pm": "^3.20.4" } }, "sha512-y6joCi49haAA0bo3EGUY+dWUMHH1GPUc84hxrBY/0pMs+Bn+kQ1+DQJErZDTWGJrlHPWU/yekBZT72SNdp0DNA=="],
+
+    "@tiptap/extension-image": ["@tiptap/extension-image@3.23.1", "", { "peerDependencies": { "@tiptap/core": "3.23.1" } }, "sha512-rAyfh8HS0PfXS8PKl1VQUiDFzXtF5SlrILpOPmz+4Oc4pmI+/vN+ain4z8k6HRxWM03YVpvLvyeQ0OFwi/fq3A=="],
 
     "@tiptap/extension-italic": ["@tiptap/extension-italic@3.20.4", "", { "peerDependencies": { "@tiptap/core": "^3.20.4" } }, "sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ=="],
 

--- a/packages/api/src/handlers/Image/index.ts
+++ b/packages/api/src/handlers/Image/index.ts
@@ -1,10 +1,39 @@
+import fs from 'node:fs';
+import type { PersistentFile } from '@jewellery-catalogue/types';
 import type { Context } from 'koa';
 
 import { dependencyContainer } from '../../dependencies';
 import { DependencyToken } from '../../dependencies/types';
+import type { IdGenerator } from '../../domain/IdGenerator';
 import type { ImageService } from '../../domain/ImageService';
 
 const getImageService = (): ImageService => dependencyContainer.resolve(DependencyToken.ImageService);
+const getIdGenerator = (): IdGenerator => dependencyContainer.resolve(DependencyToken.IdGenerator);
+
+export const uploadImage = async (ctx: Context) => {
+    const file = ctx.request.files?.file as unknown as PersistentFile | undefined;
+
+    if (!file) {
+        ctx.status = 400;
+        ctx.body = { error: 'File is required' };
+        return;
+    }
+
+    try {
+        const imageId = getIdGenerator().generate();
+        const fileBuffer = fs.readFileSync(file.filepath);
+        const contentType = file.mimetype || 'application/octet-stream';
+
+        await getImageService().uploadImage(imageId, fileBuffer, contentType);
+
+        ctx.status = 201;
+        ctx.body = { imageId };
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
 
 export const getImage = async (ctx: Context) => {
     const { name } = ctx.params;

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -4,7 +4,7 @@ import { dependencyContainer } from '../dependencies';
 import { DependencyToken } from '../dependencies/types';
 import { addDesign, deleteDesign, editDesignProperties, getDesign, getDesigns, updateDesign } from '../handlers/Design';
 import { createDraft, deleteDraft, getDraft, getDrafts, updateDraft, uploadDraftImage } from '../handlers/Draft';
-import { getImage } from '../handlers/Image';
+import { getImage, uploadImage } from '../handlers/Image';
 import { addMaterial, deleteMaterial, getMaterial, getMaterials, updateMaterial } from '../handlers/Material';
 import { getUserSettings, recalculatePrices, updateUserSettings } from '../handlers/UserSettings';
 import { authenticate } from '../middleware/auth';
@@ -49,6 +49,7 @@ router.post('/api/drafts/:id/image', authenticate, uploadDraftImage);
 router.delete('/api/drafts/:id', authenticate, deleteDraft);
 
 // Image routes
+router.post('/api/images', authenticate, uploadImage);
 router.get('/api/image/:name', getImage);
 
 export default router;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@tiptap/extension-image": "^3.23.1",
+    "@tiptap/extension-image": "3.6.5",
     "@tiptap/extension-placeholder": "^3.6.5",
     "@tiptap/pm": "^3.6.5",
     "@tiptap/react": "^3.6.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@tiptap/extension-image": "^3.23.1",
     "@tiptap/extension-placeholder": "^3.6.5",
     "@tiptap/pm": "^3.6.5",
     "@tiptap/react": "^3.6.5",

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -3,3 +3,4 @@ export const DESIGNS_ENDPOINT = '/api/designs';
 export const DRAFTS_ENDPOINT = '/api/drafts';
 export const USER_SETTINGS_ENDPOINT = '/api/user-settings';
 export const RECALCULATE_PRICES_ENDPOINT = '/api/designs/recalculate-prices';
+export const IMAGES_ENDPOINT = '/api/images';

--- a/packages/web/src/api/endpoints/uploadImage/index.ts
+++ b/packages/web/src/api/endpoints/uploadImage/index.ts
@@ -1,0 +1,27 @@
+import type { MethodType } from '@jewellery-catalogue/types';
+
+import { IMAGES_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export const makeUploadImageRequest = async (
+    file: File,
+    getAccessToken: () => string,
+    onTokenRefresh: (token: string) => void,
+    onTokenClear: () => void
+): Promise<{ imageId: string }> => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return makeRequestWithAutoRefresh<{ imageId: string }>(
+        {
+            pathname: IMAGES_ENDPOINT,
+            method: 'POST' as unknown as MethodType,
+            operationString: 'upload image',
+            body: formData,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};

--- a/packages/web/src/components/RichTextEditor/ResizableImage.tsx
+++ b/packages/web/src/components/RichTextEditor/ResizableImage.tsx
@@ -1,0 +1,58 @@
+import Image from '@tiptap/extension-image';
+import type { NodeViewProps } from '@tiptap/react';
+import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
+import { useRef } from 'react';
+
+const ResizableImageView: React.FC<NodeViewProps> = ({ node, updateAttributes }) => {
+    const wrapperRef = useRef<HTMLDivElement>(null);
+    const width = (node.attrs.width as string) || '100%';
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const el = wrapperRef.current;
+        if (!el) return;
+        const startX = e.clientX;
+        const startWidth = el.offsetWidth;
+        const parentWidth = el.parentElement?.offsetWidth ?? startWidth;
+
+        const onPointerMove = (moveEvent: PointerEvent) => {
+            const newWidthPx = startWidth + (moveEvent.clientX - startX);
+            const newWidthPct = Math.round(Math.max(10, Math.min(100, (newWidthPx / parentWidth) * 100)));
+            updateAttributes({ width: `${newWidthPct}%` });
+        };
+
+        const onPointerUp = () => {
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
+        };
+
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
+    };
+
+    return (
+        <NodeViewWrapper as="div">
+            <div ref={wrapperRef} className="tiptap-image-wrapper" style={{ width }}>
+                <img src={node.attrs.src as string} alt={(node.attrs.alt as string) || ''} draggable={false} />
+                <div className="tiptap-image-resize-handle" onPointerDown={handlePointerDown} />
+            </div>
+        </NodeViewWrapper>
+    );
+};
+
+export const ResizableImage = Image.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            width: {
+                default: '100%',
+                parseHTML: (el) => (el as HTMLImageElement).style.width || '100%',
+                renderHTML: (attrs) => ({ style: `width: ${attrs.width}` }),
+            },
+        };
+    },
+    addNodeView() {
+        return ReactNodeViewRenderer(ResizableImageView);
+    },
+});

--- a/packages/web/src/components/RichTextEditor/index.tsx
+++ b/packages/web/src/components/RichTextEditor/index.tsx
@@ -1,11 +1,27 @@
 import './styles.css';
 
+import { useAuth } from '@imapps/web-utils';
+import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { Bold, Heading1, Heading2, Heading3, Italic, List, ListOrdered, Redo, Strikethrough, Undo } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import {
+    Bold,
+    Heading1,
+    Heading2,
+    Heading3,
+    ImageIcon,
+    Italic,
+    List,
+    ListOrdered,
+    Loader2,
+    Redo,
+    Strikethrough,
+    Undo,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
+import { makeUploadImageRequest } from '@/api/endpoints/uploadImage';
 import { Button } from '@/components/ui/button';
 
 export interface RichTextEditorProps {
@@ -16,6 +32,9 @@ export interface RichTextEditorProps {
 
 const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeholder = 'Start typing...' }) => {
     const [, forceUpdate] = useState({});
+    const { accessToken, login, logout } = useAuth();
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     const editor = useEditor({
         extensions: [
@@ -29,6 +48,10 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeh
             }),
             Placeholder.configure({
                 placeholder,
+            }),
+            Image.configure({
+                inline: false,
+                allowBase64: false,
             }),
         ],
         content: value,
@@ -55,6 +78,25 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeh
             editor.commands.setContent(value);
         }
     }, [value, editor]);
+
+    const handleImageFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file || !editor) return;
+        e.target.value = '';
+        setIsUploading(true);
+        try {
+            const { imageId } = await makeUploadImageRequest(file, () => accessToken, login, logout);
+            editor
+                .chain()
+                .focus()
+                .setImage({ src: `/api/image/${imageId}` })
+                .run();
+        } catch (err) {
+            console.error('[RichTextEditor] Image upload failed:', err);
+        } finally {
+            setIsUploading(false);
+        }
+    };
 
     if (!editor) {
         return null;
@@ -129,6 +171,24 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeh
                 >
                     <ListOrdered className="h-4 w-4" />
                 </Button>
+                <div className="w-px bg-border mx-1" />
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isUploading}
+                    title="Insert image"
+                >
+                    {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageIcon className="h-4 w-4" />}
+                </Button>
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleImageFileChange}
+                />
                 <div className="w-px bg-border mx-1" />
                 <Button
                     type="button"

--- a/packages/web/src/components/RichTextEditor/index.tsx
+++ b/packages/web/src/components/RichTextEditor/index.tsx
@@ -1,7 +1,6 @@
 import './styles.css';
 
 import { useAuth } from '@imapps/web-utils';
-import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -23,6 +22,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { makeUploadImageRequest } from '@/api/endpoints/uploadImage';
 import { Button } from '@/components/ui/button';
+import { ResizableImage } from './ResizableImage';
 
 export interface RichTextEditorProps {
     value: string;
@@ -49,7 +49,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeh
             Placeholder.configure({
                 placeholder,
             }),
-            Image.configure({
+            ResizableImage.configure({
                 inline: false,
                 allowBase64: false,
             }),

--- a/packages/web/src/components/RichTextEditor/styles.css
+++ b/packages/web/src/components/RichTextEditor/styles.css
@@ -91,6 +91,22 @@
     outline: none;
 }
 
+/* Resizable image node */
+.tiptap-image-wrapper {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    margin: 0.5em 0;
+}
+
+.tiptap-image-wrapper img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 0.375rem;
+}
+
+/* Read-only view (DesignDescription) */
 .tiptap-editor img {
     max-width: 100%;
     height: auto;
@@ -99,7 +115,21 @@
     display: block;
 }
 
-.tiptap-editor img.ProseMirror-selectednode {
-    outline: 2px solid hsl(var(--primary));
-    outline-offset: 2px;
+.tiptap-image-resize-handle {
+    position: absolute;
+    right: -6px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 12px;
+    height: 48px;
+    background: var(--primary);
+    border-radius: 6px;
+    cursor: col-resize;
+    opacity: 0.25;
+    transition: opacity 0.15s;
+    touch-action: none;
+}
+
+.tiptap-image-wrapper:hover .tiptap-image-resize-handle {
+    opacity: 1;
 }

--- a/packages/web/src/components/RichTextEditor/styles.css
+++ b/packages/web/src/components/RichTextEditor/styles.css
@@ -90,3 +90,16 @@
 .tiptap-editor:focus-within {
     outline: none;
 }
+
+.tiptap-editor img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.375rem;
+    margin: 0.5em 0;
+    display: block;
+}
+
+.tiptap-editor img.ProseMirror-selectednode {
+    outline: 2px solid hsl(var(--primary));
+    outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- New `POST /api/images` endpoint — uploads image to object store, returns `imageId`
- `@tiptap/extension-image` added; image toolbar button in `RichTextEditor`
- Clicking the button opens a file picker → uploads → inserts `<img src="/api/image/{id}">` inline
- Images render in the read-only `DesignDescription` view automatically (shares same CSS)

## Test plan
- [ ] Open AddDesign or edit an existing design
- [ ] Click image icon in editor toolbar, select an image
- [ ] Confirm image appears inline in the editor
- [ ] Save, navigate to design view — confirm image renders in description
- [ ] Network tab: `POST /api/images` returns `{ imageId }`, `GET /api/image/{id}` serves image

🤖 Generated with [Claude Code](https://claude.com/claude-code)