### PR TITLE
feat(designs): multi-image upload and carousel

### DIFF
--- a/packages/api/src/domain/DesignService/index.test.ts
+++ b/packages/api/src/domain/DesignService/index.test.ts
@@ -62,7 +62,7 @@ describe('DesignService', () => {
                 timeRequired: '45',
                 totalMaterialCosts: 20.0,
                 price: 35.0,
-                imageId: 'image-123',
+                imageIds: ['image-123'],
                 materials: [],
                 dateAdded: new Date('2025-01-01'),
             };
@@ -87,7 +87,7 @@ describe('DesignService', () => {
                 userId: wrongUserId,
                 totalMaterialCosts: 20.0,
                 price: 35.0,
-                imageId: 'image-123',
+                imageIds: ['image-123'],
                 materials: [],
                 dateAdded: new Date('2025-01-01'),
             };
@@ -138,6 +138,7 @@ describe('DesignService', () => {
 
         const mockImageBuffer = Buffer.from('image data');
         const mockContentType = 'image/jpeg';
+        const mockImageBuffers = [{ buffer: mockImageBuffer, contentType: mockContentType }];
 
         beforeEach(() => {
             mockIdGenerator.generate.mockReturnValueOnce('design-id-123').mockReturnValueOnce('image-id-123');
@@ -147,7 +148,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(mockDesignData, mockImageBuffer, mockContentType, userId);
+            const result = await service.addDesign(mockDesignData, mockImageBuffers, [], userId);
 
             expect(mockImageService.uploadImage).toHaveBeenCalledWith('image-id-123', mockImageBuffer, mockContentType);
             expect(mockDesignRepo.insert).toHaveBeenCalledWith(
@@ -159,7 +160,7 @@ describe('DesignService', () => {
                     timeRequired: '6',
                     totalMaterialCosts: 30.0,
                     price: 50.0,
-                    imageId: 'image-id-123',
+                    imageIds: ['image-id-123'],
                     materials: [],
                     dateAdded: expect.any(Date),
                 })
@@ -182,12 +183,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(
-                designDataWithStringMaterials,
-                mockImageBuffer,
-                mockContentType,
-                userId
-            );
+            const result = await service.addDesign(designDataWithStringMaterials, mockImageBuffers, [], userId);
 
             expect(result.materials).toEqual(materials);
         });
@@ -203,12 +199,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(
-                designDataWithArrayMaterials,
-                mockImageBuffer,
-                mockContentType,
-                userId
-            );
+            const result = await service.addDesign(designDataWithArrayMaterials, mockImageBuffers, [], userId);
 
             expect(result.materials).toEqual(materials);
         });
@@ -220,7 +211,7 @@ describe('DesignService', () => {
             };
 
             await expect(
-                service.addDesign(designDataWithInvalidMaterials, mockImageBuffer, mockContentType, userId)
+                service.addDesign(designDataWithInvalidMaterials, mockImageBuffers, [], userId)
             ).rejects.toMatchObject({
                 message: 'Invalid materials format',
                 status: 400,
@@ -232,7 +223,7 @@ describe('DesignService', () => {
         it('should propagate image service errors', async () => {
             mockImageService.uploadImage.mockRejectedValue(new Error('Upload failed'));
 
-            await expect(service.addDesign(mockDesignData, mockImageBuffer, mockContentType, userId)).rejects.toThrow(
+            await expect(service.addDesign(mockDesignData, mockImageBuffers, [], userId)).rejects.toThrow(
                 'Upload failed'
             );
 
@@ -251,7 +242,7 @@ describe('DesignService', () => {
             timeRequired: '30',
             totalMaterialCosts: 15.0,
             price: 25.0,
-            imageId: 'image-123',
+            imageIds: ['image-123'],
             materials: [],
             dateAdded: new Date('2025-01-01'),
         };
@@ -316,7 +307,7 @@ describe('DesignService', () => {
             timeRequired: '30',
             totalMaterialCosts: 15.0,
             price: 25.0,
-            imageId: 'image-123',
+            imageIds: ['image-123'],
             materials: [],
             dateAdded: new Date('2025-01-01'),
         };
@@ -449,7 +440,7 @@ describe('DesignService', () => {
             timeRequired: '30',
             totalMaterialCosts: 5,
             price: 20,
-            imageId: 'img-1',
+            imageIds: ['img-1'],
             materials: [material],
             dateAdded: new Date('2025-01-01'),
             totalQuantity: 0,

--- a/packages/api/src/domain/DesignService/index.ts
+++ b/packages/api/src/domain/DesignService/index.ts
@@ -47,8 +47,8 @@ export class DesignService {
 
     async addDesign(
         designData: UploadDesign,
-        imageBuffer: Buffer,
-        contentType: string,
+        imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        existingImageIds: string[],
         userId: string
     ): Promise<Design> {
         if (!userId) {
@@ -56,9 +56,16 @@ export class DesignService {
         }
 
         const designId = this.idGenerator.generate();
-        const imageId = this.idGenerator.generate();
 
-        await this.imageService.uploadImage(imageId, imageBuffer, contentType);
+        const newImageIds = await Promise.all(
+            imageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
+        const imageIds = [...existingImageIds, ...newImageIds];
 
         let materials: Array<RequiredMaterial>;
 
@@ -101,70 +108,7 @@ export class DesignService {
             timeRequired: designData.timeRequired,
             totalMaterialCosts: designData.totalMaterialCosts,
             price: designData.price,
-            imageId,
-            materials,
-            dateAdded: new Date(),
-            totalQuantity: 0,
-            lowStockThreshold: designData.lowStockThreshold,
-            variationGroups,
-            variants,
-            designType: designData.designType,
-        };
-
-        await this.designRepo.insert(design);
-
-        return design;
-    }
-
-    async addDesignWithImageId(designData: UploadDesign, imageId: string, userId: string): Promise<Design> {
-        if (!userId) {
-            throw Object.assign(new Error('User ID is required'), { status: 400 });
-        }
-
-        const designId = this.idGenerator.generate();
-
-        let materials: Array<RequiredMaterial>;
-
-        try {
-            materials =
-                typeof designData.materials === 'string' ? JSON.parse(designData.materials) : designData.materials;
-        } catch {
-            throw Object.assign(new Error('Invalid materials format'), { status: 400 });
-        }
-
-        let variationGroups: VariationGroup[] | undefined;
-        let variants: DesignVariant[] | undefined;
-
-        if (designData.variationGroups) {
-            try {
-                variationGroups =
-                    typeof designData.variationGroups === 'string'
-                        ? JSON.parse(designData.variationGroups)
-                        : designData.variationGroups;
-            } catch {
-                throw Object.assign(new Error('Invalid variationGroups format'), { status: 400 });
-            }
-        }
-
-        if (designData.variants) {
-            try {
-                const parsed: DesignVariant[] =
-                    typeof designData.variants === 'string' ? JSON.parse(designData.variants) : designData.variants;
-                variants = parsed.map((v) => ({ ...v, totalQuantity: 0 }));
-            } catch {
-                throw Object.assign(new Error('Invalid variants format'), { status: 400 });
-            }
-        }
-
-        const design: Design = {
-            id: designId,
-            userId,
-            name: designData.name,
-            description: designData.description,
-            timeRequired: designData.timeRequired,
-            totalMaterialCosts: designData.totalMaterialCosts,
-            price: designData.price,
-            imageId,
+            imageIds,
             materials,
             dateAdded: new Date(),
             totalQuantity: 0,
@@ -205,8 +149,8 @@ export class DesignService {
     async editDesignProperties(
         id: string,
         updates: EditDesign,
-        imageBuffer: Buffer | null,
-        contentType: string | null,
+        imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        keepImageIds: string[],
         userId: string
     ): Promise<Design> {
         if (!id) {
@@ -219,13 +163,15 @@ export class DesignService {
             throw Object.assign(new Error('Design not found'), { status: 404 });
         }
 
-        let imageId = existing.imageId;
+        const newImageIds = await Promise.all(
+            imageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
 
-        if (imageBuffer && contentType) {
-            const newImageId = this.idGenerator.generate();
-            await this.imageService.uploadImage(newImageId, imageBuffer, contentType);
-            imageId = newImageId;
-        }
+        const imageIds = [...keepImageIds, ...newImageIds];
 
         let materials = existing.materials;
         if (updates.materials) {
@@ -247,7 +193,7 @@ export class DesignService {
             ...existing,
             ...updates,
             materials,
-            imageId,
+            imageIds,
             variationGroups,
             variants,
         };

--- a/packages/api/src/handlers/Design/index.ts
+++ b/packages/api/src/handlers/Design/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import type { Design, EditDesign, PersistentFile, UploadDesign } from '@jewellery-catalogue/types';
+import type { EditDesign, PersistentFile, UploadDesign } from '@jewellery-catalogue/types';
 import type { Context } from 'koa';
 
 import { dependencyContainer } from '../../dependencies';
@@ -7,6 +7,11 @@ import { DependencyToken } from '../../dependencies/types';
 import type { DesignService } from '../../domain/DesignService';
 
 const getDesignService = (): DesignService => dependencyContainer.resolve(DependencyToken.DesignService);
+
+function normalizeFiles(f: unknown): PersistentFile[] {
+    if (!f) return [];
+    return Array.isArray(f) ? f : [f];
+}
 
 export const getDesigns = async (ctx: Context) => {
     const userId = ctx.state.userId;
@@ -41,7 +46,7 @@ export const getDesign = async (ctx: Context) => {
 
 export const addDesign = async (ctx: Context) => {
     const userId = ctx.state.userId;
-    const file = ctx.request.files?.file as unknown as PersistentFile | undefined;
+    const files = normalizeFiles(ctx.request.files?.files);
 
     const {
         name,
@@ -54,12 +59,14 @@ export const addDesign = async (ctx: Context) => {
         variationGroups,
         variants,
         designType,
-        imageId: existingImageId,
-    } = ctx.request.body as Partial<UploadDesign> & { imageId?: string };
+        existingImageIds: existingImageIdsRaw,
+    } = ctx.request.body as Partial<UploadDesign> & { existingImageIds?: string; designType?: string };
 
-    if (!file && !existingImageId) {
+    const existingImageIds: string[] = existingImageIdsRaw ? JSON.parse(existingImageIdsRaw) : [];
+
+    if (files.length === 0 && existingImageIds.length === 0) {
         ctx.status = 400;
-        ctx.body = { error: 'File or imageId is required' };
+        ctx.body = { error: 'At least one image file or imageId is required' };
 
         return;
     }
@@ -72,23 +79,19 @@ export const addDesign = async (ctx: Context) => {
             materials: materials!,
             totalMaterialCosts: Number(totalMaterialCosts),
             price: Number(price),
-            image: file!,
+            image: files[0]!,
             lowStockThreshold: lowStockThreshold !== undefined ? Number(lowStockThreshold) : undefined,
             variationGroups,
             variants,
             designType,
         };
 
-        let design: Design;
+        const imageBuffers = files.map((file) => ({
+            buffer: fs.readFileSync(file.filepath),
+            contentType: file.mimetype || 'application/octet-stream',
+        }));
 
-        if (file) {
-            const fileBuffer = fs.readFileSync(file.filepath);
-            const contentType = file.mimetype || 'application/octet-stream';
-
-            design = await getDesignService().addDesign(designData, fileBuffer, contentType, userId);
-        } else {
-            design = await getDesignService().addDesignWithImageId(designData, existingImageId!, userId);
-        }
+        const design = await getDesignService().addDesign(designData, imageBuffers, existingImageIds, userId);
 
         ctx.status = 200;
         ctx.body = design;
@@ -120,7 +123,7 @@ export const updateDesign = async (ctx: Context) => {
 export const editDesignProperties = async (ctx: Context) => {
     const userId = ctx.state.userId;
     const { id } = ctx.params;
-    const file = ctx.request.files?.file as unknown as PersistentFile | undefined;
+    const files = normalizeFiles(ctx.request.files?.files);
 
     const {
         name,
@@ -132,16 +135,21 @@ export const editDesignProperties = async (ctx: Context) => {
         variationGroups,
         variants,
         designType,
-    } = ctx.request.body as Partial<EditDesign> & { variationGroups?: string; variants?: string };
+        keepImageIds: keepImageIdsRaw,
+    } = ctx.request.body as Partial<EditDesign> & {
+        variationGroups?: string;
+        variants?: string;
+        keepImageIds?: string;
+        designType?: string;
+    };
+
+    const keepImageIds: string[] = keepImageIdsRaw ? JSON.parse(keepImageIdsRaw) : [];
 
     try {
-        let fileBuffer: Buffer | null = null;
-        let contentType: string | null = null;
-
-        if (file) {
-            fileBuffer = fs.readFileSync(file.filepath);
-            contentType = file.mimetype || 'application/octet-stream';
-        }
+        const imageBuffers = files.map((file) => ({
+            buffer: fs.readFileSync(file.filepath),
+            contentType: file.mimetype || 'application/octet-stream',
+        }));
 
         const updates: EditDesign = {};
 
@@ -160,7 +168,7 @@ export const editDesignProperties = async (ctx: Context) => {
         }
         if (designType !== undefined) updates.designType = designType;
 
-        const design = await getDesignService().editDesignProperties(id, updates, fileBuffer, contentType, userId);
+        const design = await getDesignService().editDesignProperties(id, updates, imageBuffers, keepImageIds, userId);
 
         ctx.status = 200;
         ctx.body = design;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -61,6 +61,7 @@ const bodyOptions = {
     multipart: true,
     formidable: {
         keepExtensions: true,
+        multiples: true,
     },
 };
 

--- a/packages/api/src/infrastructure/MongoDesignRepository/index.test.ts
+++ b/packages/api/src/infrastructure/MongoDesignRepository/index.test.ts
@@ -40,7 +40,7 @@ describe('MongoDesignRepository', () => {
             timeRequired: '45',
             totalMaterialCosts: 20.0,
             price: 35.0,
-            imageId: 'image-123',
+            imageIds: ['image-123'],
             materials: [],
             dateAdded: new Date('2025-01-01'),
         };

--- a/packages/api/src/infrastructure/MongoDesignRepository/index.ts
+++ b/packages/api/src/infrastructure/MongoDesignRepository/index.ts
@@ -11,21 +11,31 @@ export class MongoDesignRepository extends MongoRepository<Design> implements De
     }
 
     protected usesObjectId(): boolean {
-        return false; // Designs use string id, not ObjectId _id
+        return false;
+    }
+
+    private migrate(doc: any): Design {
+        if (!doc.imageIds && doc.imageId) {
+            doc.imageIds = [doc.imageId];
+            delete doc.imageId;
+        }
+        return doc as Design;
     }
 
     async getByUserId(userId: string): Promise<Array<Design>> {
-        return this.collection()
+        const docs = await this.collection()
             .find({ userId }, { projection: { _id: 0 } })
             .toArray();
+        return docs.map((d) => this.migrate(d));
     }
 
     async getByIdAndUserId(id: string, userId: string): Promise<Design | null> {
-        return this.collection().findOne({ id, userId }, { projection: { _id: 0 } });
+        const doc = await this.collection().findOne({ id, userId }, { projection: { _id: 0 } });
+        return doc ? this.migrate(doc) : null;
     }
 
     async findByMaterialId(materialId: string): Promise<Array<Design>> {
-        return this.collection()
+        const docs = await this.collection()
             .find(
                 {
                     'materials.id': materialId,
@@ -33,5 +43,6 @@ export class MongoDesignRepository extends MongoRepository<Design> implements De
                 { projection: { _id: 0 } }
             )
             .toArray();
+        return docs.map((d) => this.migrate(d));
     }
 }

--- a/packages/types/src/design/index.ts
+++ b/packages/types/src/design/index.ts
@@ -13,7 +13,7 @@ export const designSchema = z.object({
     name: z.string(),
     timeRequired: z.string(),
     materials: z.array(requiredMaterialSchema),
-    imageId: z.string(),
+    imageIds: z.array(z.string()),
     price: z.number(),
     description: z.string(),
     totalMaterialCosts: z.number(),

--- a/packages/types/src/editDesign/index.ts
+++ b/packages/types/src/editDesign/index.ts
@@ -8,7 +8,6 @@ export const editDesignSchema = z.object({
     name: z.string().min(1, 'Please enter the design name').optional(),
     timeRequired: z.string().min(1, 'Please enter the time required').optional(),
     materials: z.array(requiredMaterialSchema).optional(),
-    image: z.string().optional(),
     price: z.number().positive('Price must be greater than 0').optional(),
     description: z.string().optional(),
     totalMaterialCosts: z.number().optional(),

--- a/packages/types/src/formDesign/index.ts
+++ b/packages/types/src/formDesign/index.ts
@@ -8,7 +8,10 @@ export const formDesignSchema = z
         name: z.string().min(1, 'Please enter the design name').trim(),
         timeRequired: z.string().min(1, 'Please enter the time required'),
         materials: z.array(requiredMaterialSchema),
-        image: z.union([z.instanceof(File), z.string()], { message: 'Please upload an image' }).optional(),
+        images: z
+            .array(z.union([z.instanceof(File), z.string()]))
+            .optional()
+            .default([]),
         price: z.number({ message: 'Please enter the price' }).nonnegative('Price must be 0 or greater'),
         description: z.string(),
         totalMaterialCosts: z.number(),

--- a/packages/web/src/api/endpoints/addDesign/index.ts
+++ b/packages/web/src/api/endpoints/addDesign/index.ts
@@ -4,21 +4,31 @@ import { DESIGNS_ENDPOINT } from '../../endpoints';
 import { makeRequestWithAutoRefresh } from '../../makeRequest';
 
 const makeAddDesignRequest = async (
-    formDesign: FormDesign & { imageId?: string },
+    formDesign: FormDesign,
     getAccessToken: () => string,
     onTokenRefresh: (newToken: string) => void,
     onTokenClear: () => void
 ) => {
     const formData = new FormData();
 
+    const images = formDesign.images ?? [];
+    const existingImageIds = images.filter((v): v is string => typeof v === 'string');
+    const newFiles = images.filter((v): v is File => v instanceof File);
+
+    for (const file of newFiles) {
+        formData.append('files', file);
+    }
+
+    if (existingImageIds.length > 0) {
+        formData.append('existingImageIds', JSON.stringify(existingImageIds));
+    }
+
     for (const key in formDesign) {
         if (Object.hasOwn(formDesign, key)) {
             const value = formDesign[key as keyof typeof formDesign];
 
-            if (key === 'image' && value instanceof File) {
-                formData.append('file', value);
-            } else if (key === 'image') {
-                // string imageId already handled via imageId field
+            if (key === 'images') {
+                // handled above
             } else if (
                 (key === 'materials' || key === 'variationGroups' || key === 'variants') &&
                 Array.isArray(value)

--- a/packages/web/src/api/endpoints/editDesign/index.ts
+++ b/packages/web/src/api/endpoints/editDesign/index.ts
@@ -12,13 +12,22 @@ const makeEditDesignRequest = async (
 ) => {
     const formData = new FormData();
 
+    const images = formDesign.images ?? [];
+    const keepImageIds = images.filter((v): v is string => typeof v === 'string');
+    const newFiles = images.filter((v): v is File => v instanceof File);
+
+    for (const file of newFiles) {
+        formData.append('files', file);
+    }
+
+    formData.append('keepImageIds', JSON.stringify(keepImageIds));
+
     for (const key in formDesign) {
         if (Object.hasOwn(formDesign, key)) {
             const value = formDesign[key as keyof FormDesign];
 
-            if (key === 'image' && value instanceof File) {
-                formData.append('file', value);
-            } else if (key === 'image' && typeof value === 'string') {
+            if (key === 'images') {
+                // handled above
             } else if (
                 (key === 'materials' || key === 'variationGroups' || key === 'variants') &&
                 Array.isArray(value)
@@ -37,7 +46,7 @@ const makeEditDesignRequest = async (
             headers: {},
             operationString: 'edit design',
             body: formData,
-            accessToken: '', // Will be replaced by getAccessToken()
+            accessToken: '',
         },
         getAccessToken,
         onTokenRefresh,

--- a/packages/web/src/components/DesignCard/index.tsx
+++ b/packages/web/src/components/DesignCard/index.tsx
@@ -27,7 +27,7 @@ export interface DesignCardProps {
 }
 
 export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated }) => {
-    const { name, timeRequired, id, imageId, totalQuantity } = design;
+    const { name, timeRequired, id, imageIds, totalQuantity } = design;
     const [isFavorite, setIsFavorite] = useState(false);
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -104,7 +104,7 @@ export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated 
                 </div>
                 <ItemHeader className="basis-auto justify-start">
                     <div className="w-64 h-64">
-                        <Image imageId={imageId} />
+                        <Image imageId={imageIds?.[0] ?? ''} />
                     </div>
                 </ItemHeader>
                 <ItemContent className="flex-none items-start text-left w-full">

--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -15,7 +15,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/
 import makeEditDesignRequest from '../../api/endpoints/editDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
-import ImageUpload from '../../components/ImageUpload';
+import MultiImageUpload from '../../components/MultiImageUpload';
 import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
 import TimeInput from '../../components/TimeInput';
@@ -44,7 +44,7 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
             description: design.description,
             totalMaterialCosts: design.totalMaterialCosts,
             price: design.price,
-            image: design.imageId,
+            images: design.imageIds,
             lowStockThreshold: design.lowStockThreshold,
             variationGroups: design.variationGroups ?? [],
             variants: design.variants ?? [],
@@ -220,22 +220,22 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
 
                 <hr className="border-t border-border" />
 
-                {/* Upload Image Section */}
+                {/* Upload Images Section */}
                 <div className="grid grid-cols-12 gap-4">
                     <div className="col-span-4">
-                        <h2 className="text-lg font-medium text-center h-[30px] leading-[30px]">Upload Image</h2>
+                        <h2 className="text-lg font-medium text-center h-[30px] leading-[30px]">Upload Images</h2>
                     </div>
                     <div className="col-span-8">
                         <FormField
                             control={form.control}
-                            name="image"
+                            name="images"
                             render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormControl>
-                                        <ImageUpload
-                                            setImage={form.setValue}
+                                        <MultiImageUpload
+                                            value={field.value ?? []}
+                                            onChange={field.onChange}
                                             hasError={!!fieldState.error}
-                                            value={field.value}
                                         />
                                     </FormControl>
                                     <FormMessage />

--- a/packages/web/src/components/LowStockDesignsTable/index.tsx
+++ b/packages/web/src/components/LowStockDesignsTable/index.tsx
@@ -86,7 +86,7 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
                                     <TableRow key={design.id || `design-${index}`} className="hover:bg-muted/50">
                                         <TableCell>
                                             <div className="h-12 w-12 rounded-md overflow-hidden bg-muted flex items-center justify-center">
-                                                <Image imageId={design.imageId} />
+                                                <Image imageId={design.imageIds?.[0] ?? ''} />
                                             </div>
                                         </TableCell>
                                         <TableCell className="font-medium">{design.name}</TableCell>

--- a/packages/web/src/components/MultiImageUpload/index.tsx
+++ b/packages/web/src/components/MultiImageUpload/index.tsx
@@ -1,0 +1,120 @@
+import { ImagePlus, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { Image } from '@/components/Image';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface MultiImageUploadProps {
+    value: Array<File | string>;
+    onChange: (images: Array<File | string>) => void;
+    hasError?: boolean;
+}
+
+function Thumbnail({ item, onRemove }: { item: File | string; onRemove: () => void }) {
+    const [preview, setPreview] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (item instanceof File) {
+            const reader = new FileReader();
+            reader.onload = () => setPreview(reader.result as string);
+            reader.readAsDataURL(item);
+        } else {
+            setPreview(null);
+        }
+    }, [item]);
+
+    return (
+        <div className="relative w-24 h-24 rounded-md overflow-hidden border border-border flex-shrink-0">
+            {item instanceof File && preview ? (
+                <img src={preview} alt="Preview" className="w-full h-full object-cover" />
+            ) : typeof item === 'string' ? (
+                <Image imageId={item} />
+            ) : null}
+            <Button
+                type="button"
+                variant="destructive"
+                size="icon"
+                onClick={onRemove}
+                className="absolute top-1 right-1 w-5 h-5 rounded-full"
+            >
+                <X className="w-3 h-3" />
+            </Button>
+        </div>
+    );
+}
+
+function itemKey(item: File | string, i: number): string {
+    return typeof item === 'string' ? item : `file-${i}-${item.name}-${item.size}`;
+}
+
+const MultiImageUpload: React.FC<MultiImageUploadProps> = ({ value, onChange, hasError = false }) => {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isDragging, setIsDragging] = useState(false);
+
+    const addFiles = (files: FileList | null) => {
+        if (!files) return;
+        const newImages = Array.from(files).filter((f) => f.type.startsWith('image/'));
+        onChange([...value, ...newImages]);
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => addFiles(e.target.files);
+
+    const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+        addFiles(e.dataTransfer.files);
+    };
+
+    const remove = (index: number) => {
+        onChange(value.filter((_, i) => i !== index));
+    };
+
+    return (
+        <div className="flex flex-wrap gap-3 items-start">
+            {value.map((item, i) => (
+                <Thumbnail key={itemKey(item, i)} item={item} onRemove={() => remove(i)} />
+            ))}
+
+            <div
+                role="button"
+                tabIndex={0}
+                onDrop={handleDrop}
+                onDragOver={(e) => {
+                    e.preventDefault();
+                    setIsDragging(true);
+                }}
+                onDragLeave={() => setIsDragging(false)}
+                onClick={() => fileInputRef.current?.click()}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        fileInputRef.current?.click();
+                    }
+                }}
+                className={cn(
+                    'w-24 h-24 rounded-md border-2 border-dashed flex flex-col items-center justify-center cursor-pointer transition-colors flex-shrink-0',
+                    isDragging
+                        ? 'border-primary bg-muted/50'
+                        : hasError
+                          ? 'border-destructive bg-card'
+                          : 'border-border bg-card hover:border-primary/50'
+                )}
+            >
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    className="hidden"
+                    onChange={handleChange}
+                />
+                <ImagePlus className="w-5 h-5 text-muted-foreground mb-1" />
+                <span className="text-xs text-muted-foreground text-center leading-tight px-1">Add</span>
+            </div>
+        </div>
+    );
+};
+
+export default MultiImageUpload;

--- a/packages/web/src/hooks/useDraftAutosave.ts
+++ b/packages/web/src/hooks/useDraftAutosave.ts
@@ -93,16 +93,17 @@ export const useDraftAutosave = ({
             const name = (values.name as string) || '';
             if (!name.trim()) return;
 
-            const imageValue = values.image;
+            const imagesValue = values.images as Array<File | string> | undefined;
+            const firstNewFile = imagesValue?.find((v): v is File => v instanceof File);
 
-            if (imageValue instanceof File && imageValue !== pendingFileRef.current) {
-                pendingFileRef.current = imageValue;
+            if (firstNewFile && firstNewFile !== pendingFileRef.current) {
+                pendingFileRef.current = firstNewFile;
                 uploadedImageIdRef.current = null;
-            } else if (!(imageValue instanceof File) && typeof imageValue !== 'string') {
+            } else if (!firstNewFile) {
                 pendingFileRef.current = null;
             }
 
-            const { image: _image, ...serializableData } = values;
+            const { images: _images, ...serializableData } = values;
 
             isSavingRef.current = true;
             setIsSaving(true);

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -17,7 +17,7 @@ import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddDesignRequest from '../../api/endpoints/addDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
-import ImageUpload from '../../components/ImageUpload';
+import MultiImageUpload from '../../components/MultiImageUpload';
 import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
 import TimeInput from '../../components/TimeInput';
@@ -41,7 +41,7 @@ const AddDesign: React.FC = () => {
             materials: [],
             description: '',
             totalMaterialCosts: 0,
-            image: undefined,
+            images: [],
             lowStockThreshold: undefined,
             variationGroups: [],
             variants: [],
@@ -94,7 +94,7 @@ const AddDesign: React.FC = () => {
                     form.reset(draft.data);
                 }
                 if (draft?.imageId) {
-                    form.setValue('image', draft.imageId);
+                    form.setValue('images', [draft.imageId]);
                 }
             })
             .catch(() => {})
@@ -112,10 +112,16 @@ const AddDesign: React.FC = () => {
                 currentTimeRequired
             );
 
-            // If image is a string it's a draft imageId already on server
-            const imageIdFromDraft =
-                typeof formData.image === 'string' ? formData.image : (uploadedImageId ?? undefined);
-            const submitData = { ...formData, variants, imageId: imageIdFromDraft };
+            // Replace first File with draft-uploaded imageId if available
+            let images = formData.images ?? [];
+            if (uploadedImageId) {
+                const firstFileIdx = images.findIndex((v) => v instanceof File);
+                if (firstFileIdx !== -1) {
+                    images = [...images];
+                    images[firstFileIdx] = uploadedImageId;
+                }
+            }
+            const submitData = { ...formData, variants, images };
 
             await makeAddDesignRequest(submitData, () => accessToken, login, logout);
             await deleteAndClearDraft(() => accessToken, login, logout);
@@ -268,25 +274,24 @@ const AddDesign: React.FC = () => {
 
                         <hr className="border-t border-border" />
 
-                        {/* Upload Image Section */}
+                        {/* Upload Images Section */}
                         <div className="grid grid-cols-12 gap-4">
                             <div className="col-span-4">
                                 <h2 className="text-lg font-medium text-center h-[30px] leading-[30px]">
-                                    Upload Image
+                                    Upload Images
                                 </h2>
                             </div>
                             <div className="col-span-8">
                                 <FormField
                                     control={form.control}
-                                    name="image"
+                                    name="images"
                                     render={({ field, fieldState }) => (
                                         <FormItem>
                                             <FormControl>
-                                                <ImageUpload
-                                                    setImage={form.setValue}
+                                                <MultiImageUpload
+                                                    value={field.value ?? []}
                                                     onChange={field.onChange}
                                                     hasError={!!fieldState.error}
-                                                    value={field.value}
                                                 />
                                             </FormControl>
                                             <FormMessage />

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -21,6 +21,7 @@ import {
     METAL_TYPE_LABELS,
     WIRE_TYPE_LABELS,
 } from '../../lib/materialLabels';
+import { cn } from '../../lib/utils';
 
 const ViewDesign = () => {
     const { id } = useParams<{ id: string }>();
@@ -116,7 +117,20 @@ const ViewDesign = () => {
                     {/* LEFT: sticky image */}
                     <div className="lg:sticky lg:top-8 relative">
                         <div className="rounded-xl overflow-hidden border border-border shadow-lg aspect-[3/4] bg-card">
-                            <Image imageId={imageIds?.[imageIndex] ?? ''} />
+                            {imageIds && imageIds.length > 0 ? (
+                                <div
+                                    className="flex h-full transition-transform duration-500 ease-in-out"
+                                    style={{ transform: `translateX(-${imageIndex * 100}%)` }}
+                                >
+                                    {imageIds.map((id) => (
+                                        <div key={id} className="w-full h-full flex-shrink-0">
+                                            <Image imageId={id} />
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <Image imageId="" />
+                            )}
                         </div>
                         {imageIds && imageIds.length > 1 && (
                             <>
@@ -124,7 +138,7 @@ const ViewDesign = () => {
                                     type="button"
                                     onClick={() => setImageIndex((i) => Math.max(0, i - 1))}
                                     disabled={imageIndex === 0}
-                                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 disabled:opacity-20 text-white rounded-full p-1 transition-colors"
+                                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-0 text-white rounded-full p-1.5 transition-all backdrop-blur-sm"
                                 >
                                     <ChevronLeft className="h-5 w-5" />
                                 </button>
@@ -132,13 +146,25 @@ const ViewDesign = () => {
                                     type="button"
                                     onClick={() => setImageIndex((i) => Math.min(imageIds.length - 1, i + 1))}
                                     disabled={imageIndex === imageIds.length - 1}
-                                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 disabled:opacity-20 text-white rounded-full p-1 transition-colors"
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-0 text-white rounded-full p-1.5 transition-all backdrop-blur-sm"
                                 >
                                     <ChevronRight className="h-5 w-5" />
                                 </button>
-                                <span className="absolute bottom-2 left-1/2 -translate-x-1/2 bg-black/50 text-white text-xs px-2 py-0.5 rounded-full">
-                                    {imageIndex + 1} / {imageIds.length}
-                                </span>
+                                <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
+                                    {imageIds.map((id, i) => (
+                                        <button
+                                            key={id}
+                                            type="button"
+                                            onClick={() => setImageIndex(i)}
+                                            className={cn(
+                                                'h-1.5 rounded-full transition-all duration-300',
+                                                i === imageIndex
+                                                    ? 'w-4 bg-white'
+                                                    : 'w-1.5 bg-white/50 hover:bg-white/80'
+                                            )}
+                                        />
+                                    ))}
+                                </div>
                             </>
                         )}
                     </div>

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -1,6 +1,6 @@
 import { useAuth, useUser } from '@imapps/web-utils';
 import { useQuery } from '@tanstack/react-query';
-import { Edit, PackageOpen } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Edit, PackageOpen } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
@@ -28,6 +28,7 @@ const ViewDesign = () => {
     const { user } = useUser();
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [editPropertiesDialogOpen, setEditPropertiesDialogOpen] = useState(false);
+    const [imageIndex, setImageIndex] = useState(0);
 
     const {
         data: design,
@@ -41,7 +42,7 @@ const ViewDesign = () => {
 
     const {
         timeRequired,
-        imageId,
+        imageIds,
         name,
         materials,
         totalMaterialCosts,
@@ -67,6 +68,7 @@ const ViewDesign = () => {
 
     const handlePropertiesSuccess = () => {
         setEditPropertiesDialogOpen(false);
+        setImageIndex(0);
         refetch();
     };
 
@@ -112,10 +114,33 @@ const ViewDesign = () => {
                 {/* 2-column layout */}
                 <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-12 items-start">
                     {/* LEFT: sticky image */}
-                    <div className="lg:sticky lg:top-8">
+                    <div className="lg:sticky lg:top-8 relative">
                         <div className="rounded-xl overflow-hidden border border-border shadow-lg aspect-[3/4] bg-card">
-                            <Image imageId={imageId} />
+                            <Image imageId={imageIds?.[imageIndex] ?? ''} />
                         </div>
+                        {imageIds && imageIds.length > 1 && (
+                            <>
+                                <button
+                                    type="button"
+                                    onClick={() => setImageIndex((i) => Math.max(0, i - 1))}
+                                    disabled={imageIndex === 0}
+                                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 disabled:opacity-20 text-white rounded-full p-1 transition-colors"
+                                >
+                                    <ChevronLeft className="h-5 w-5" />
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setImageIndex((i) => Math.min(imageIds.length - 1, i + 1))}
+                                    disabled={imageIndex === imageIds.length - 1}
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 disabled:opacity-20 text-white rounded-full p-1 transition-colors"
+                                >
+                                    <ChevronRight className="h-5 w-5" />
+                                </button>
+                                <span className="absolute bottom-2 left-1/2 -translate-x-1/2 bg-black/50 text-white text-xs px-2 py-0.5 rounded-full">
+                                    {imageIndex + 1} / {imageIds.length}
+                                </span>
+                            </>
+                        )}
                     </div>
 
                     {/* RIGHT: detail panel */}


### PR DESCRIPTION
## Summary

- **`imageId` → `imageIds`** across types, API, and frontend; MongoDB repository migrates old single-`imageId` docs on read (no DB migration needed)
- **Multi-file upload**: formidable `multiples: true`; new `MultiImageUpload` component with thumbnail grid, X-to-remove, and drag-and-drop
- **Carousel on ViewDesign**: sliding strip with `transition-transform duration-500`, frosted-glass arrow buttons that hide at edges, animated pill dot indicators
- **Edit form**: existing image IDs preserved as `keepImageIds`; new uploads appended
- **Draft autosave**: watches first `File` in `images` array instead of single `image` field

## Test plan

- [ ] Add design with 2+ images — thumbnails appear, submit succeeds
- [ ] View design — arrows slide between images, dots track position, dots are clickable
- [ ] Edit design — existing images shown as thumbnails, can remove/add, submit preserves kept images
- [ ] Open old design (single `imageId` in DB) — displays correctly via migration shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)