### PR TITLE
test(api): MongoDB integration tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,9 +33,34 @@ jobs:
       - run: bun run tsc --noEmit
       - run: bun run --filter @jewellery-catalogue/api test
 
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+      packages: read
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27018:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.adminCommand({ping:1})'"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+          --health-start-period 5s
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: RUN_INTEGRATION_TESTS=1 bun run --filter @jewellery-catalogue/api test integration
+
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, integration-test]
     permissions:
       contents: write
       packages: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,3 +36,30 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run tsc --noEmit
       - run: bun --filter @jewellery-catalogue/api test
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+      packages: read
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27018:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.adminCommand({ping:1})'"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+          --health-start-period 5s
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: RUN_INTEGRATION_TESTS=1 bun --filter @jewellery-catalogue/api test integration

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,13 @@
+services:
+  mongo-test:
+    image: mongo:7
+    ports:
+      - "27018:27017"
+    environment:
+      MONGO_INITDB_DATABASE: integration-test
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 5s

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
     "build": "bun build src/index.ts --outfile build/index.js --target bun --minify",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
-    "test:run": "bun test"
+    "test:run": "bun test",
+    "test:integration": "docker compose -f ../../docker-compose.test.yml up -d --wait && RUN_INTEGRATION_TESTS=1 bun test integration; docker compose -f ../../docker-compose.test.yml down"
   },
   "dependencies": {
     "@imapps/api-utils": "0.5.1",

--- a/packages/api/src/domain/MaterialService/index.integration.test.ts
+++ b/packages/api/src/domain/MaterialService/index.integration.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import {
+    type Design,
+    MaterialType,
+    METAL_TYPE,
+    type RequiredWire,
+    WIRE_TYPE,
+    type Wire,
+} from '@jewellery-catalogue/types';
+
+import { MongoDesignRepository } from '../../infrastructure/MongoDesignRepository';
+import { MongoMaterialRepository } from '../../infrastructure/MongoMaterialRepository';
+import { UuidGenerator } from '../../infrastructure/UuidGenerator';
+import { createTestContext, type TestContext } from '../../test-helpers/mongodb';
+import { MaterialService } from './index';
+
+const wireMaterial: Wire = {
+    id: 'mat-wire-1',
+    userId: 'user-1',
+    name: 'Silver Wire',
+    brand: 'Beadalon',
+    purchaseUrl: 'https://example.com',
+    type: MaterialType.WIRE,
+    wireType: WIRE_TYPE.FULL,
+    metalType: METAL_TYPE.SILVER,
+    diameter: 0.5,
+    lengthPerPack: 1000,
+    pricePerPack: 10,
+    totalLength: 1000,
+    pricePerMeter: 0.01, // 10 / 1000
+    dateAdded: '2024-01-01T00:00:00.000Z',
+};
+
+// cost = (200cm / 100) * 0.01/m = 0.02
+const requiredWire: RequiredWire = { ...wireMaterial, requiredLength: 200 };
+
+function makeDesign(id: string, userId: string): Design {
+    return {
+        id,
+        userId,
+        name: `Design ${id}`,
+        description: '',
+        timeRequired: '00:30',
+        price: 5,
+        totalMaterialCosts: 0.02,
+        totalQuantity: 0,
+        imageIds: [],
+        materials: [requiredWire],
+        dateAdded: new Date('2024-01-01'),
+    };
+}
+
+const RUN = !!process.env.RUN_INTEGRATION_TESTS;
+
+describe.if(RUN)('MaterialService (integration)', () => {
+    let ctx: TestContext;
+    let service: MaterialService;
+    let materialRepo: MongoMaterialRepository;
+    let designRepo: MongoDesignRepository;
+
+    beforeAll(async () => {
+        ctx = await createTestContext();
+        materialRepo = new MongoMaterialRepository(ctx.mongoDb);
+        designRepo = new MongoDesignRepository(ctx.mongoDb);
+        service = new MaterialService(materialRepo, new UuidGenerator(), designRepo);
+    });
+
+    beforeEach(async () => {
+        await ctx.clearCollections();
+    });
+
+    afterAll(async () => {
+        await ctx.close();
+    });
+
+    describe('updateMaterial — cascade to designs', () => {
+        it("propagates price change to all user's designs using that material", async () => {
+            await materialRepo.insert(wireMaterial);
+            await designRepo.insert(makeDesign('d1', 'user-1'));
+            await designRepo.insert(makeDesign('d2', 'user-1'));
+
+            // doubling price: newPricePerMeter = 20/1000 = 0.02
+            // new cost = (200/100) * 0.02 = 0.04
+            await service.updateMaterial('mat-wire-1', { type: MaterialType.WIRE, pricePerPack: 20 }, 'user-1');
+
+            const d1 = await designRepo.getByIdAndUserId('d1', 'user-1');
+            const d2 = await designRepo.getByIdAndUserId('d2', 'user-1');
+
+            expect(d1?.totalMaterialCosts).toBe(0.04);
+            expect(d2?.totalMaterialCosts).toBe(0.04);
+        });
+
+        it('does not update designs belonging to a different user', async () => {
+            await materialRepo.insert(wireMaterial);
+            await designRepo.insert(makeDesign('d-other', 'user-2'));
+
+            await service.updateMaterial('mat-wire-1', { type: MaterialType.WIRE, pricePerPack: 20 }, 'user-1');
+
+            const d = await designRepo.getByIdAndUserId('d-other', 'user-2');
+            expect(d?.totalMaterialCosts).toBe(0.02);
+        });
+
+        it('updates pricePerMeter on the material in DB', async () => {
+            await materialRepo.insert(wireMaterial);
+
+            await service.updateMaterial('mat-wire-1', { type: MaterialType.WIRE, pricePerPack: 20 }, 'user-1');
+
+            const updated = await materialRepo.getByIdAndUserId('mat-wire-1', 'user-1');
+            expect((updated as Wire).pricePerMeter).toBe(0.02);
+        });
+
+        it('throws 404 when material does not exist', async () => {
+            await expect(
+                service.updateMaterial('nonexistent', { type: MaterialType.WIRE }, 'user-1')
+            ).rejects.toMatchObject({ status: 404 });
+        });
+    });
+});

--- a/packages/api/src/infrastructure/MongoDesignRepository/index.integration.test.ts
+++ b/packages/api/src/infrastructure/MongoDesignRepository/index.integration.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import {
+    type Design,
+    MaterialType,
+    METAL_TYPE,
+    type RequiredWire,
+    WIRE_TYPE,
+    type Wire,
+} from '@jewellery-catalogue/types';
+
+import { CollectionNames } from '../../dependencies/types';
+import { createTestContext, type TestContext } from '../../test-helpers/mongodb';
+import { MongoDesignRepository } from './index';
+
+const wire: Wire = {
+    id: 'mat-1',
+    userId: 'user-1',
+    name: 'Silver Wire',
+    brand: 'Beadalon',
+    purchaseUrl: 'https://example.com',
+    type: MaterialType.WIRE,
+    wireType: WIRE_TYPE.FULL,
+    metalType: METAL_TYPE.SILVER,
+    diameter: 0.5,
+    lengthPerPack: 1000,
+    pricePerPack: 10,
+    totalLength: 1000,
+    pricePerMeter: 0.01,
+    dateAdded: '2024-01-01T00:00:00.000Z',
+};
+
+const requiredWire: RequiredWire = { ...wire, requiredLength: 200 };
+
+function makeDesign(id: string, userId: string, materials: Design['materials'] = []): Design {
+    return {
+        id,
+        userId,
+        name: `Design ${id}`,
+        description: '',
+        timeRequired: '00:30',
+        price: 5,
+        totalMaterialCosts: 0.02,
+        totalQuantity: 0,
+        imageIds: [],
+        materials,
+        dateAdded: new Date('2024-01-01'),
+    };
+}
+
+const RUN = !!process.env.RUN_INTEGRATION_TESTS;
+
+describe.if(RUN)('MongoDesignRepository (integration)', () => {
+    let ctx: TestContext;
+    let repo: MongoDesignRepository;
+
+    beforeAll(async () => {
+        ctx = await createTestContext();
+        repo = new MongoDesignRepository(ctx.mongoDb);
+    });
+
+    beforeEach(async () => {
+        await ctx.clearCollections();
+    });
+
+    afterAll(async () => {
+        await ctx.close();
+    });
+
+    describe('getByUserId', () => {
+        it('returns only designs belonging to the given user', async () => {
+            await repo.insert(makeDesign('d1', 'user-1'));
+            await repo.insert(makeDesign('d2', 'user-1'));
+            await repo.insert(makeDesign('d3', 'user-2'));
+
+            const results = await repo.getByUserId('user-1');
+
+            expect(results).toHaveLength(2);
+            expect(results.every((d) => d.userId === 'user-1')).toBe(true);
+        });
+
+        it('returns empty array when user has no designs', async () => {
+            await repo.insert(makeDesign('d1', 'user-2'));
+
+            const results = await repo.getByUserId('user-1');
+
+            expect(results).toHaveLength(0);
+        });
+    });
+
+    describe('getByIdAndUserId', () => {
+        it('returns design when id and userId both match', async () => {
+            await repo.insert(makeDesign('d1', 'user-1'));
+
+            const result = await repo.getByIdAndUserId('d1', 'user-1');
+
+            expect(result?.id).toBe('d1');
+        });
+
+        it('returns null when userId does not match', async () => {
+            await repo.insert(makeDesign('d1', 'user-1'));
+
+            const result = await repo.getByIdAndUserId('d1', 'user-2');
+
+            expect(result).toBeNull();
+        });
+
+        it('excludes _id from result', async () => {
+            await repo.insert(makeDesign('d1', 'user-1'));
+
+            const result = await repo.getByIdAndUserId('d1', 'user-1');
+
+            expect((result as any)?._id).toBeUndefined();
+        });
+    });
+
+    describe('findByMaterialId', () => {
+        it('returns designs containing the given material in nested array', async () => {
+            await repo.insert(makeDesign('d1', 'user-1', [requiredWire]));
+            await repo.insert(makeDesign('d2', 'user-1', []));
+
+            const results = await repo.findByMaterialId('mat-1');
+
+            expect(results).toHaveLength(1);
+            expect(results[0].id).toBe('d1');
+        });
+
+        it('returns empty array when no design uses the material', async () => {
+            await repo.insert(makeDesign('d1', 'user-1', []));
+
+            const results = await repo.findByMaterialId('mat-1');
+
+            expect(results).toHaveLength(0);
+        });
+
+        it('returns designs across multiple users', async () => {
+            await repo.insert(makeDesign('d1', 'user-1', [requiredWire]));
+            await repo.insert(makeDesign('d2', 'user-2', [requiredWire]));
+
+            const results = await repo.findByMaterialId('mat-1');
+
+            expect(results).toHaveLength(2);
+        });
+    });
+
+    describe('migrate', () => {
+        it('converts legacy imageId field to imageIds array on read', async () => {
+            await ctx.mongoDb.getCollection(CollectionNames.Designs).insertOne({
+                id: 'legacy',
+                userId: 'user-1',
+                name: 'Legacy Design',
+                description: '',
+                timeRequired: '00:30',
+                price: 0,
+                totalMaterialCosts: 0,
+                totalQuantity: 0,
+                imageId: 'img-1',
+                materials: [],
+                dateAdded: new Date('2024-01-01'),
+            } as any);
+
+            const result = await repo.getByIdAndUserId('legacy', 'user-1');
+
+            expect(result?.imageIds).toEqual(['img-1']);
+            expect((result as any)?.imageId).toBeUndefined();
+        });
+    });
+});

--- a/packages/api/src/infrastructure/MongoMaterialRepository/index.integration.test.ts
+++ b/packages/api/src/infrastructure/MongoMaterialRepository/index.integration.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { MaterialType, METAL_TYPE, WIRE_TYPE, type Wire } from '@jewellery-catalogue/types';
+
+import { createTestContext, type TestContext } from '../../test-helpers/mongodb';
+import { MongoMaterialRepository } from './index';
+
+function makeWire(id: string, userId: string): Wire {
+    return {
+        id,
+        userId,
+        name: `Wire ${id}`,
+        brand: 'Beadalon',
+        purchaseUrl: 'https://example.com',
+        type: MaterialType.WIRE,
+        wireType: WIRE_TYPE.FULL,
+        metalType: METAL_TYPE.SILVER,
+        diameter: 0.5,
+        lengthPerPack: 1000,
+        pricePerPack: 10,
+        totalLength: 1000,
+        pricePerMeter: 0.01,
+        dateAdded: '2024-01-01T00:00:00.000Z',
+    };
+}
+
+const RUN = !!process.env.RUN_INTEGRATION_TESTS;
+
+describe.if(RUN)('MongoMaterialRepository (integration)', () => {
+    let ctx: TestContext;
+    let repo: MongoMaterialRepository;
+
+    beforeAll(async () => {
+        ctx = await createTestContext();
+        repo = new MongoMaterialRepository(ctx.mongoDb);
+    });
+
+    beforeEach(async () => {
+        await ctx.clearCollections();
+    });
+
+    afterAll(async () => {
+        await ctx.close();
+    });
+
+    describe('getByUserId', () => {
+        it('returns only materials belonging to the given user', async () => {
+            await repo.insert(makeWire('m1', 'user-1'));
+            await repo.insert(makeWire('m2', 'user-1'));
+            await repo.insert(makeWire('m3', 'user-2'));
+
+            const results = await repo.getByUserId('user-1');
+
+            expect(results).toHaveLength(2);
+            expect(results.every((m) => m.userId === 'user-1')).toBe(true);
+        });
+
+        it('returns empty array when user has no materials', async () => {
+            await repo.insert(makeWire('m1', 'user-2'));
+
+            const results = await repo.getByUserId('user-1');
+
+            expect(results).toHaveLength(0);
+        });
+
+        it('excludes _id from results', async () => {
+            await repo.insert(makeWire('m1', 'user-1'));
+
+            const results = await repo.getByUserId('user-1');
+
+            expect((results[0] as any)?._id).toBeUndefined();
+        });
+    });
+
+    describe('getByIdAndUserId', () => {
+        it('returns material when id and userId both match', async () => {
+            await repo.insert(makeWire('m1', 'user-1'));
+
+            const result = await repo.getByIdAndUserId('m1', 'user-1');
+
+            expect(result?.id).toBe('m1');
+        });
+
+        it('returns null when userId does not match', async () => {
+            await repo.insert(makeWire('m1', 'user-1'));
+
+            const result = await repo.getByIdAndUserId('m1', 'user-2');
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when id does not exist', async () => {
+            const result = await repo.getByIdAndUserId('nonexistent', 'user-1');
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/packages/api/src/test-helpers/mongodb.ts
+++ b/packages/api/src/test-helpers/mongodb.ts
@@ -1,0 +1,32 @@
+import { MongoDbConnection } from '@imapps/api-utils';
+import { MongoClient } from 'mongodb';
+
+import { CollectionNames, type Collections } from '../dependencies/types';
+
+const URI = 'mongodb://localhost:27018/test';
+const DB = 'integration-test';
+
+export interface TestContext {
+    mongoDb: MongoDbConnection<Collections>;
+    clearCollections(): Promise<void>;
+    close(): Promise<void>;
+}
+
+export async function createTestContext(): Promise<TestContext> {
+    const mongoDb = new MongoDbConnection<Collections>();
+    await mongoDb.connect({ connectionUri: URI, databaseName: DB });
+
+    const client = new MongoClient(URI);
+    await client.connect();
+    const db = client.db(DB);
+
+    return {
+        mongoDb,
+        async clearCollections() {
+            await Promise.all(Object.values(CollectionNames).map((name) => db.collection(name).deleteMany({})));
+        },
+        async close() {
+            await client.close();
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- Adds integration tests hitting a real MongoDB instance to verify logic that mocks cannot validate: nested-array queries (`findByMaterialId`), userId isolation, legacy doc migration (`imageId` → `imageIds`), and material price cascade to designs
- `docker-compose.test.yml` for local dev (port 27018, avoids dev DB on 27017)
- `test-helpers/mongodb.ts` shared connect/clear/close utilities
- `RUN_INTEGRATION_TESTS=1` guard so `bun test` (default) skips integration tests without Docker

## CI

Both `pull-request.yml` and `ci-cd.yml` get an `integration-test` job with a MongoDB 7 service container. Release is gated on integration tests passing.

## Test plan

- [ ] `bun test` passes with 0 failures (integration tests skipped)
- [ ] `bun run test:integration` (with Docker running) — all integration tests pass
- [ ] PR checks: `lint`, `test`, `integration-test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)