### PR TITLE
fix(low-stock): per-variant stock detection and pre-selection

### DIFF
--- a/packages/web/src/components/DesignUpdateForm/index.tsx
+++ b/packages/web/src/components/DesignUpdateForm/index.tsx
@@ -31,6 +31,7 @@ export interface IDesignUpdateFormProps {
     design: Design;
     onSuccess: () => void;
     onCancel: () => void;
+    initialVariantId?: string;
 }
 
 interface MaterialAvailability {
@@ -42,9 +43,9 @@ interface MaterialAvailability {
     status: 'sufficient' | 'low' | 'insufficient';
 }
 
-const DesignUpdateForm: React.FC<IDesignUpdateFormProps> = ({ design, onSuccess, onCancel }) => {
+const DesignUpdateForm: React.FC<IDesignUpdateFormProps> = ({ design, onSuccess, onCancel, initialVariantId }) => {
     const [isUpdating, setIsUpdating] = useState(false);
-    const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>(undefined);
+    const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>(initialVariantId);
     const { accessToken, login, logout } = useAuth();
     const { dispatch } = useAlert();
 

--- a/packages/web/src/components/LowStockDesignsTable/index.tsx
+++ b/packages/web/src/components/LowStockDesignsTable/index.tsx
@@ -1,4 +1,4 @@
-import type { Design } from '@jewellery-catalogue/types';
+import type { Design, DesignVariant } from '@jewellery-catalogue/types';
 import { AlertCircle, Edit, Eye } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -10,32 +10,30 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { VIEW_DESIGN_PAGE } from '@/constants/routes';
+import type { LowStockDesignRow } from '@/utils/lowStock';
 
 export interface ILowStockDesignsTableProps {
-    designs: Array<Design>;
+    rows: LowStockDesignRow[];
     onDesignUpdated?: () => void;
 }
 
-const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, onDesignUpdated }) => {
+const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ rows, onDesignUpdated }) => {
     const navigate = useNavigate();
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [selectedDesign, setSelectedDesign] = useState<Design | null>(null);
+    const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>(undefined);
 
-    const getSeverityBadge = (design: Design) => {
-        const threshold = design.lowStockThreshold ?? 0;
-
-        if (design.totalQuantity === 0) {
-            return <Badge variant="destructive">Out of Stock</Badge>;
-        } else if (design.totalQuantity === 1) {
-            return <Badge className="bg-red-600">Critical</Badge>;
-        } else if (design.totalQuantity < threshold) {
-            return <Badge variant="secondary">Low</Badge>;
-        }
+    const getSeverityBadge = (quantity: number, threshold: number | undefined) => {
+        const t = threshold ?? 0;
+        if (quantity === 0) return <Badge variant="destructive">Out of Stock</Badge>;
+        if (quantity === 1) return <Badge className="bg-red-600">Critical</Badge>;
+        if (quantity < t) return <Badge variant="secondary">Low</Badge>;
         return <Badge variant="outline">Normal</Badge>;
     };
 
-    const handleEdit = (design: Design) => {
+    const handleEdit = (design: Design, variant?: DesignVariant) => {
         setSelectedDesign(design);
+        setSelectedVariantId(variant?.id);
         setEditDialogOpen(true);
     };
 
@@ -46,14 +44,14 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
     const handleSuccess = () => {
         setEditDialogOpen(false);
         setSelectedDesign(null);
-        if (onDesignUpdated) {
-            onDesignUpdated();
-        }
+        setSelectedVariantId(undefined);
+        if (onDesignUpdated) onDesignUpdated();
     };
 
     const handleCancel = () => {
         setEditDialogOpen(false);
         setSelectedDesign(null);
+        setSelectedVariantId(undefined);
     };
 
     return (
@@ -64,7 +62,7 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
                         <TableRow className="hover:bg-transparent">
                             <TableHead className="font-semibold">Image</TableHead>
                             <TableHead className="font-semibold">Name</TableHead>
-                            <TableHead className="font-semibold">Total Quantity</TableHead>
+                            <TableHead className="font-semibold">Quantity</TableHead>
                             <TableHead className="font-semibold">Stock Status</TableHead>
                             <TableHead className="font-semibold">Severity</TableHead>
                             <TableHead className="font-semibold">Price</TableHead>
@@ -72,31 +70,35 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {designs.length === 0 ? (
+                        {rows.length === 0 ? (
                             <TableRow>
                                 <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
                                     No low-stock designs.
                                 </TableCell>
                             </TableRow>
                         ) : (
-                            designs.map((design, index) => {
-                                const threshold = design.lowStockThreshold ?? '-';
+                            rows.map(({ design, variant }, index) => {
+                                const quantity = variant ? variant.totalQuantity : design.totalQuantity;
+                                const threshold = variant ? variant.lowStockThreshold : design.lowStockThreshold;
+                                const displayName = variant ? `${design.name} — ${variant.name}` : design.name;
+                                const price = variant ? variant.price : design.price;
+                                const rowKey = variant ? `${design.id}-${variant.id}` : design.id || `design-${index}`;
 
                                 return (
-                                    <TableRow key={design.id || `design-${index}`} className="hover:bg-muted/50">
+                                    <TableRow key={rowKey} className="hover:bg-muted/50">
                                         <TableCell>
                                             <div className="h-12 w-12 rounded-md overflow-hidden bg-muted flex items-center justify-center">
                                                 <Image imageId={design.imageIds?.[0] ?? ''} />
                                             </div>
                                         </TableCell>
-                                        <TableCell className="font-medium">{design.name}</TableCell>
-                                        <TableCell>{design.totalQuantity}</TableCell>
+                                        <TableCell className="font-medium">{displayName}</TableCell>
+                                        <TableCell>{quantity}</TableCell>
                                         <TableCell className="font-medium flex items-center gap-2">
                                             <AlertCircle className="h-4 w-4 text-orange-500" />
-                                            {design.totalQuantity} / {threshold} items
+                                            {quantity} / {threshold ?? '-'} items
                                         </TableCell>
-                                        <TableCell>{getSeverityBadge(design)}</TableCell>
-                                        <TableCell>£{Number(design.price).toFixed(2)}</TableCell>
+                                        <TableCell>{getSeverityBadge(quantity, threshold)}</TableCell>
+                                        <TableCell>£{Number(price).toFixed(2)}</TableCell>
                                         <TableCell>
                                             <div className="flex items-center justify-end gap-2">
                                                 <Button
@@ -111,7 +113,7 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
-                                                    onClick={() => handleEdit(design)}
+                                                    onClick={() => handleEdit(design, variant)}
                                                     className="h-8 w-8 p-0"
                                                 >
                                                     <Edit className="h-4 w-4" />
@@ -133,7 +135,12 @@ const LowStockDesignsTable: React.FC<ILowStockDesignsTableProps> = ({ designs, o
                         <DialogTitle>Manage Design Inventory</DialogTitle>
                     </DialogHeader>
                     {selectedDesign && (
-                        <DesignUpdateForm design={selectedDesign} onSuccess={handleSuccess} onCancel={handleCancel} />
+                        <DesignUpdateForm
+                            design={selectedDesign}
+                            onSuccess={handleSuccess}
+                            onCancel={handleCancel}
+                            initialVariantId={selectedVariantId}
+                        />
                     )}
                 </DialogContent>
             </Dialog>

--- a/packages/web/src/pages/Home/index.tsx
+++ b/packages/web/src/pages/Home/index.tsx
@@ -9,7 +9,7 @@ import LowStockDesignsTable from '@/components/LowStockDesignsTable';
 import LowStockMaterialsTable from '@/components/LowStockMaterialsTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
-import { getLowStockDesigns, getLowStockMaterials } from '@/utils/lowStock';
+import { getLowStockDesignRows, getLowStockMaterials } from '@/utils/lowStock';
 
 const Home = () => {
     const { accessToken, login, logout } = useAuth();
@@ -41,9 +41,9 @@ const Home = () => {
     }
 
     const lowStockMaterials = getLowStockMaterials(materials);
-    const lowStockDesigns = getLowStockDesigns(designs);
+    const lowStockDesignRows = getLowStockDesignRows(designs);
 
-    const hasAnyLowStock = lowStockMaterials.length > 0 || lowStockDesigns.length > 0;
+    const hasAnyLowStock = lowStockMaterials.length > 0 || lowStockDesignRows.length > 0;
 
     const handleRefresh = () => {
         refetchMaterials();
@@ -98,19 +98,19 @@ const Home = () => {
             )}
 
             {/* Low Stock Designs Section */}
-            {lowStockDesigns.length > 0 && (
+            {lowStockDesignRows.length > 0 && (
                 <Card className="border-orange-200 bg-orange-50">
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
                             <AlertTriangle className="h-5 w-5 text-orange-500" />
-                            Low Stock Designs ({lowStockDesigns.length})
+                            Low Stock Designs ({lowStockDesignRows.length})
                         </CardTitle>
                         <CardDescription>
-                            {lowStockDesigns.length} design(s) below their low stock threshold
+                            {lowStockDesignRows.length} design(s) below their low stock threshold
                         </CardDescription>
                     </CardHeader>
                     <CardContent>
-                        <LowStockDesignsTable designs={lowStockDesigns} onDesignUpdated={handleRefresh} />
+                        <LowStockDesignsTable rows={lowStockDesignRows} onDesignUpdated={handleRefresh} />
                     </CardContent>
                 </Card>
             )}

--- a/packages/web/src/utils/lowStock.ts
+++ b/packages/web/src/utils/lowStock.ts
@@ -1,8 +1,5 @@
-import { type Design, type Material, MaterialType } from '@jewellery-catalogue/types';
+import { type Design, type DesignVariant, type Material, MaterialType } from '@jewellery-catalogue/types';
 
-/**
- * Calculate the current number of packs for a material
- */
 function getCurrentPacks(material: Material): number {
     switch (material.type) {
         case MaterialType.WIRE:
@@ -16,44 +13,44 @@ function getCurrentPacks(material: Material): number {
     }
 }
 
-/**
- * Check if a material is below its low stock threshold
- */
 export function isLowStockMaterial(material: Material): boolean {
-    if (material.lowStockThreshold === undefined || material.lowStockThreshold === null) {
-        return false;
-    }
-    const currentPacks = getCurrentPacks(material);
-    return currentPacks < material.lowStockThreshold;
+    if (material.lowStockThreshold == null) return false;
+    return getCurrentPacks(material) < material.lowStockThreshold;
 }
 
-/**
- * Check if a design is below its low stock threshold
- */
 export function isLowStockDesign(design: Design): boolean {
-    if (design.lowStockThreshold === undefined || design.lowStockThreshold === null) {
-        return false;
+    if (design.variants?.length) {
+        return design.variants.some((v) => v.lowStockThreshold != null && v.totalQuantity < v.lowStockThreshold);
     }
+    if (design.lowStockThreshold == null) return false;
     return design.totalQuantity < design.lowStockThreshold;
 }
 
-/**
- * Filter materials to get only those below low stock threshold
- */
+export type LowStockDesignRow = {
+    design: Design;
+    variant?: DesignVariant;
+};
+
+export function getLowStockDesignRows(designs: Design[]): LowStockDesignRow[] {
+    const rows: LowStockDesignRow[] = [];
+    for (const design of designs) {
+        if (design.variants?.length) {
+            for (const variant of design.variants) {
+                if (variant.lowStockThreshold != null && variant.totalQuantity < variant.lowStockThreshold) {
+                    rows.push({ design, variant });
+                }
+            }
+        } else if (isLowStockDesign(design)) {
+            rows.push({ design });
+        }
+    }
+    return rows;
+}
+
 export function getLowStockMaterials(materials: Material[]): Material[] {
     return materials.filter(isLowStockMaterial);
 }
 
-/**
- * Filter designs to get only those below low stock threshold
- */
-export function getLowStockDesigns(designs: Design[]): Design[] {
-    return designs.filter(isLowStockDesign);
-}
-
-/**
- * Get current packs for a material (exposed for use in components)
- */
 export function getMaterialCurrentPacks(material: Material): number {
     return getCurrentPacks(material);
 }


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: Low stock table now explodes variant designs into per-variant rows. Each low-stock variant gets its own row showing `Design — Variant` name with its own quantity, threshold, and price. Clicking Edit pre-selects that variant in the produce form — no guessing required.
- **Bug 2 fixed**: `isLowStockDesign` now checks each variant's `totalQuantity` against its own `lowStockThreshold`. A design with variant A=10 and variant B=0 (below threshold) now correctly surfaces as low stock.

## Changes

- `lowStock.ts` — fixed `isLowStockDesign`; added `LowStockDesignRow` type and `getLowStockDesignRows` helper
- `LowStockDesignsTable` — accepts `rows: LowStockDesignRow[]` instead of `designs: Design[]`; renders per-variant rows
- `DesignUpdateForm` — new `initialVariantId` prop pre-selects variant on open
- `Home` — uses `getLowStockDesignRows` instead of `getLowStockDesigns`

## Test plan

- [ ] Design with variants where one variant is below threshold appears in low stock dashboard
- [ ] Design with variants where all variants are above threshold does NOT appear
- [ ] Each low-stock variant shows as its own row with correct name, quantity, and price
- [ ] Clicking Edit on a variant row opens the produce form with that variant pre-selected
- [ ] Non-variant designs still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)