### PR TITLE
fix(designs): clear draft race condition and navigate after creation

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,6 +7,7 @@
     "start": "bun run start:dev",
     "start:with-mock": "concurrently \"bun run start:mock-auth\" \"bun run start:dev\"",
     "build": "vite build --emptyOutDir",
+    "test": "vitest run",
     "pw:install": "PLAYWRIGHT_BROWSERS_PATH=~/.cache/ms-playwright playwright install --with-deps",
     "pw:run": "playwright test --config=playwright.config.ts",
     "pw:e2e": "playwright test --config=playwright.config.ts",

--- a/packages/web/src/components/MaterialsTable/index.tsx
+++ b/packages/web/src/components/MaterialsTable/index.tsx
@@ -218,10 +218,10 @@ const MaterialsTable: React.FC<IMaterialTableProps> = ({ materials, onMaterialUp
             >
                 <TabsList>
                     <TabsTrigger value="all">All Materials</TabsTrigger>
-                    <TabsTrigger value="wire">Wire ({wireMaterials.length})</TabsTrigger>
-                    <TabsTrigger value="bead">Bead ({beadMaterials.length})</TabsTrigger>
-                    <TabsTrigger value="chain">Chain ({chainMaterials.length})</TabsTrigger>
-                    <TabsTrigger value="ear-hook">Ear Hook ({earHookMaterials.length})</TabsTrigger>
+                    <TabsTrigger value="wire">Wires ({wireMaterials.length})</TabsTrigger>
+                    <TabsTrigger value="bead">Beads ({beadMaterials.length})</TabsTrigger>
+                    <TabsTrigger value="chain">Chains ({chainMaterials.length})</TabsTrigger>
+                    <TabsTrigger value="ear-hook">Ear Hooks ({earHookMaterials.length})</TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="all">

--- a/packages/web/src/hooks/useDraftAutosave.test.ts
+++ b/packages/web/src/hooks/useDraftAutosave.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeCreateDraftRequest, makeDeleteDraftRequest, makeUpdateDraftRequest } from '../api/endpoints/drafts';
+import { useDraftAutosave } from './useDraftAutosave';
+
+vi.mock('../api/endpoints/drafts', () => ({
+    makeCreateDraftRequest: vi.fn(),
+    makeDeleteDraftRequest: vi.fn(),
+    makeUpdateDraftRequest: vi.fn(),
+    makeUploadDraftImageRequest: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+const mockCreate = vi.mocked(makeCreateDraftRequest);
+const mockDelete = vi.mocked(makeDeleteDraftRequest);
+const mockUpdate = vi.mocked(makeUpdateDraftRequest);
+
+describe('useDraftAutosave', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCreate.mockResolvedValue({ id: 'draft-1' });
+        mockDelete.mockResolvedValue(undefined);
+        mockUpdate.mockResolvedValue({ id: 'draft-1' });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('does not create a new draft after clearDraft cancels the pending save', async () => {
+        const { result: formResult } = renderHook(() => useForm({ defaultValues: { name: '', images: [] } }));
+
+        const { result } = renderHook(() =>
+            useDraftAutosave({
+                form: formResult.current,
+                type: 'design',
+                getAccessToken: () => 'token',
+                onTokenRefresh: vi.fn(),
+                onTokenClear: vi.fn(),
+            })
+        );
+
+        // Simulate user typing — triggers watch and queues debounce timer
+        act(() => {
+            formResult.current.setValue('name', 'Ring');
+        });
+
+        // clearDraft is called before 2s debounce fires (simulating submit clearing draft)
+        act(() => {
+            result.current.clearDraft();
+        });
+
+        // Advance time past debounce — if timer wasn't cancelled, save() would run
+        await act(async () => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+});

--- a/packages/web/src/hooks/useDraftAutosave.test.ts
+++ b/packages/web/src/hooks/useDraftAutosave.test.ts
@@ -23,9 +23,9 @@ const mockUpdate = vi.mocked(makeUpdateDraftRequest);
 describe('useDraftAutosave', () => {
     beforeEach(() => {
         vi.useFakeTimers();
-        mockCreate.mockResolvedValue({ id: 'draft-1' });
+        mockCreate.mockResolvedValue({ id: 'draft-1' } as any);
         mockDelete.mockResolvedValue(undefined);
-        mockUpdate.mockResolvedValue({ id: 'draft-1' });
+        mockUpdate.mockResolvedValue({ id: 'draft-1' } as any);
     });
 
     afterEach(() => {

--- a/packages/web/src/hooks/useDraftAutosave.test.ts
+++ b/packages/web/src/hooks/useDraftAutosave.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { makeCreateDraftRequest, makeDeleteDraftRequest, makeUpdateDraftRequest } from '../api/endpoints/drafts';
+import { makeCreateDraftRequest } from '../api/endpoints/drafts';
 import { useDraftAutosave } from './useDraftAutosave';
 
 vi.mock('../api/endpoints/drafts', () => ({
@@ -17,15 +17,10 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 const mockCreate = vi.mocked(makeCreateDraftRequest);
-const mockDelete = vi.mocked(makeDeleteDraftRequest);
-const mockUpdate = vi.mocked(makeUpdateDraftRequest);
 
 describe('useDraftAutosave', () => {
     beforeEach(() => {
         vi.useFakeTimers();
-        mockCreate.mockResolvedValue({ id: 'draft-1' } as any);
-        mockDelete.mockResolvedValue(undefined);
-        mockUpdate.mockResolvedValue({ id: 'draft-1' } as any);
     });
 
     afterEach(() => {

--- a/packages/web/src/hooks/useDraftAutosave.ts
+++ b/packages/web/src/hooks/useDraftAutosave.ts
@@ -67,6 +67,10 @@ export const useDraftAutosave = ({
     onStatusChangeRef.current = onStatusChange;
 
     const clearDraft = useCallback(() => {
+        if (debounceTimerRef.current) {
+            clearTimeout(debounceTimerRef.current);
+            debounceTimerRef.current = null;
+        }
         setDraftId(null);
         draftIdRef.current = null;
         uploadedImageIdRef.current = null;

--- a/packages/web/src/lib/materialLabels.ts
+++ b/packages/web/src/lib/materialLabels.ts
@@ -17,10 +17,10 @@ export const WIRE_TYPE_LABELS: Record<WIRE_TYPE, string> = {
 
 export const DESIGN_TYPE_LABELS: Record<DesignType, string> = {
     [DesignType.EARRINGS]: 'Earrings',
-    [DesignType.EARCUFF]: 'Ear Cuff',
-    [DesignType.RING]: 'Ring',
-    [DesignType.NECKLACE]: 'Necklace',
-    [DesignType.BRACELET]: 'Bracelet',
+    [DesignType.EARCUFF]: 'Ear Cuffs',
+    [DesignType.RING]: 'Rings',
+    [DesignType.NECKLACE]: 'Necklaces',
+    [DesignType.BRACELET]: 'Bracelets',
 };
 
 // User-friendly labels for Metal Types

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
@@ -22,6 +22,7 @@ import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
 import TimeInput from '../../components/TimeInput';
 import { computeVariants, VariationGroupBuilder } from '../../components/VariationGroupBuilder';
+import { DESIGNS_PAGE } from '../../constants/routes';
 import { useAlert } from '../../context/Alert';
 import { AlertStoreActions } from '../../context/Alert/types';
 import { useDraftStatus } from '../../context/DraftStatus';
@@ -65,6 +66,7 @@ const AddDesign: React.FC = () => {
     const variationGroups = form.watch('variationGroups') ?? [];
 
     const { dispatch } = useAlert();
+    const navigate = useNavigate();
     const { setDraftStatus, clearDraftStatus } = useDraftStatus();
 
     const { draftId, uploadedImageId, clearDraft, deleteAndClearDraft } = useDraftAutosave({
@@ -135,7 +137,7 @@ const AddDesign: React.FC = () => {
                     variant: 'standard',
                 },
             });
-            form.reset();
+            navigate(DESIGNS_PAGE.route);
         } catch (e) {
             console.error('[AddDesign] Error adding design:', e);
             const message = e instanceof Error ? e.message : 'Unknown Error';

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -69,7 +69,7 @@ const AddDesign: React.FC = () => {
     const navigate = useNavigate();
     const { setDraftStatus, clearDraftStatus } = useDraftStatus();
 
-    const { draftId, uploadedImageId, clearDraft, deleteAndClearDraft } = useDraftAutosave({
+    const { uploadedImageId, deleteAndClearDraft } = useDraftAutosave({
         form,
         type: 'design',
         initialDraftId: draftIdParam,

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        globals: false,
+    },
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,8 +1,15 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            '@jewellery-catalogue/types': path.resolve(__dirname, '../types/src'),
+        },
+    },
     test: {
         environment: 'jsdom',
         globals: false,
+        setupFiles: ['@testing-library/jest-dom/vitest'],
     },
 });

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
         environment: 'jsdom',
         globals: false,
         setupFiles: ['@testing-library/jest-dom/vitest'],
+        exclude: ['**/node_modules/**', '**/tests/e2e/**'],
     },
 });


### PR DESCRIPTION
## Summary

- Fix race condition in `useDraftAutosave` where a pending debounce timer could fire after `clearDraft` was called (on submit), creating an orphaned draft — fixed by cancelling `debounceTimerRef` inside `clearDraft`
- Navigate to `/designs` after successful design creation instead of resetting the form in place
- Add vitest unit test (TDD red→green) covering the race condition fix

## Test Plan

- [ ] Run `bun test` in `packages/web` — 1 unit test passes
- [ ] Create a design and verify redirect to `/designs` page
- [ ] Verify no stale drafts remain after creating a design