### PR TITLE
feat(materials): prompt to update design prices after material price change

### DIFF
--- a/packages/api/src/domain/MaterialService/index.ts
+++ b/packages/api/src/domain/MaterialService/index.ts
@@ -58,7 +58,11 @@ export class MaterialService {
         return material;
     }
 
-    async updateMaterial(id: string, updates: UpdateMaterial, userId: string): Promise<Material> {
+    async updateMaterial(
+        id: string,
+        updates: UpdateMaterial,
+        userId: string
+    ): Promise<{ material: Material; affectedDesignsCount: number; priceChanged: boolean }> {
         if (!id) {
             throw Object.assign(new Error('Material ID is required'), { status: 400 });
         }
@@ -73,22 +77,39 @@ export class MaterialService {
             throw Object.assign(new Error('Material not found'), { status: 404 });
         }
 
-        // Process the updates based on material type
+        const oldPerUnitPrice = this.getPerUnitPrice(existing);
         const processed = this.processUpdateMaterial(existing, updates);
+        const newPerUnitPrice = this.getPerUnitPrice(processed);
+        const priceChanged = oldPerUnitPrice !== newPerUnitPrice;
 
         await this.materialRepo.update(id, processed);
 
-        await this.propagateMaterialUpdateToDesigns(id, processed, userId);
+        const affectedDesignsCount = await this.propagateMaterialUpdateToDesigns(id, processed, userId);
 
-        return processed;
+        return { material: processed, affectedDesignsCount, priceChanged };
+    }
+
+    private getPerUnitPrice(material: Material): number {
+        switch (material.type) {
+            case MaterialType.WIRE:
+            case MaterialType.CHAIN:
+                return (material as any).pricePerMeter ?? 0;
+            case MaterialType.BEAD:
+                return (material as any).pricePerBead ?? 0;
+            case MaterialType.EAR_HOOK:
+                return (material as any).pricePerPiece ?? 0;
+            default:
+                return 0;
+        }
     }
 
     private async propagateMaterialUpdateToDesigns(
         materialId: string,
         updatedMaterial: Material,
         userId: string
-    ): Promise<void> {
+    ): Promise<number> {
         const designs = await this.designRepo.findByMaterialId(materialId);
+        let count = 0;
 
         for (const design of designs) {
             if (design.userId !== userId) continue;
@@ -107,7 +128,10 @@ export class MaterialService {
                 materials: updatedMaterials,
                 totalMaterialCosts: parseFloat(totalMaterialCosts.toFixed(2)),
             });
+            count++;
         }
+
+        return count;
     }
 
     private calculateRequiredMaterialCost(rm: RequiredMaterial): number {

--- a/packages/api/src/domain/UserSettingsService/index.ts
+++ b/packages/api/src/domain/UserSettingsService/index.ts
@@ -37,6 +37,36 @@ export class UserSettingsService {
         return settings;
     }
 
+    async recalculatePricesForMaterial(
+        materialId: string,
+        userId: string
+    ): Promise<{ updated: number; total: number }> {
+        const settings = await this.get(userId);
+        const designs = await this.designRepo.findByMaterialId(materialId);
+        const userDesigns = designs.filter((d) => d.userId === userId);
+        const total = userDesigns.length;
+        let updated = 0;
+
+        for (const design of userDesigns) {
+            const price = calcPrice(
+                design.totalMaterialCosts,
+                design.timeRequired,
+                settings.hourlyWage,
+                settings.profitMargin
+            );
+
+            const variants = design.variants?.map((v) => ({
+                ...v,
+                price: calcPrice(v.totalMaterialCosts, design.timeRequired, settings.hourlyWage, settings.profitMargin),
+            }));
+
+            await this.designRepo.update(design.id, { ...design, price, variants });
+            updated++;
+        }
+
+        return { updated, total };
+    }
+
     async recalculatePrices(userId: string): Promise<{ updated: number; total: number }> {
         const settings = await this.get(userId);
         const designs = await this.designRepo.getByUserId(userId);

--- a/packages/api/src/handlers/Material/index.test.ts
+++ b/packages/api/src/handlers/Material/index.test.ts
@@ -26,4 +26,9 @@ describe('Material Handlers', () => {
         expect(materialHandlers.deleteMaterial).toBeDefined();
         expect(typeof materialHandlers.deleteMaterial).toBe('function');
     });
+
+    it('should export recalculateMaterialPrices', () => {
+        expect(materialHandlers.recalculateMaterialPrices).toBeDefined();
+        expect(typeof materialHandlers.recalculateMaterialPrices).toBe('function');
+    });
 });

--- a/packages/api/src/handlers/Material/index.ts
+++ b/packages/api/src/handlers/Material/index.ts
@@ -4,8 +4,11 @@ import type { Context } from 'koa';
 import { dependencyContainer } from '../../dependencies';
 import { DependencyToken } from '../../dependencies/types';
 import type { MaterialService } from '../../domain/MaterialService';
+import type { UserSettingsService } from '../../domain/UserSettingsService';
 
 const getMaterialService = (): MaterialService => dependencyContainer.resolve(DependencyToken.MaterialService);
+const getUserSettingsService = (): UserSettingsService =>
+    dependencyContainer.resolve(DependencyToken.UserSettingsService);
 
 export const getMaterials = async (ctx: Context) => {
     const userId = ctx.state.userId;
@@ -61,9 +64,25 @@ export const updateMaterial = async (ctx: Context) => {
     const updates = ctx.request.body;
 
     try {
-        const material = await getMaterialService().updateMaterial(id, updates, userId);
+        const result = await getMaterialService().updateMaterial(id, updates, userId);
 
-        ctx.body = material;
+        ctx.body = result;
+    } catch (error: unknown) {
+        const err = error as { status?: number; message?: string } | null;
+
+        ctx.status = err?.status ?? 500;
+        ctx.body = { error: err?.message ?? 'Internal Server Error' };
+    }
+};
+
+export const recalculateMaterialPrices = async (ctx: Context) => {
+    const userId = ctx.state.userId;
+    const { id } = ctx.params;
+
+    try {
+        const result = await getUserSettingsService().recalculatePricesForMaterial(id, userId);
+
+        ctx.body = result;
     } catch (error: unknown) {
         const err = error as { status?: number; message?: string } | null;
 

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -5,7 +5,14 @@ import { DependencyToken } from '../dependencies/types';
 import { addDesign, deleteDesign, editDesignProperties, getDesign, getDesigns, updateDesign } from '../handlers/Design';
 import { createDraft, deleteDraft, getDraft, getDrafts, updateDraft, uploadDraftImage } from '../handlers/Draft';
 import { getImage, uploadImage } from '../handlers/Image';
-import { addMaterial, deleteMaterial, getMaterial, getMaterials, updateMaterial } from '../handlers/Material';
+import {
+    addMaterial,
+    deleteMaterial,
+    getMaterial,
+    getMaterials,
+    recalculateMaterialPrices,
+    updateMaterial,
+} from '../handlers/Material';
 import { getUserSettings, recalculatePrices, updateUserSettings } from '../handlers/UserSettings';
 import { authenticate } from '../middleware/auth';
 
@@ -38,6 +45,7 @@ router.get('/api/materials', authenticate, getMaterials);
 router.post('/api/materials', authenticate, addMaterial);
 router.get('/api/materials/:id', authenticate, getMaterial);
 router.put('/api/materials/:id', authenticate, updateMaterial);
+router.post('/api/materials/:id/recalculate-prices', authenticate, recalculateMaterialPrices);
 router.delete('/api/materials/:id', authenticate, deleteMaterial);
 
 // Draft routes

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -4,3 +4,6 @@ export const DRAFTS_ENDPOINT = '/api/drafts';
 export const USER_SETTINGS_ENDPOINT = '/api/user-settings';
 export const RECALCULATE_PRICES_ENDPOINT = '/api/designs/recalculate-prices';
 export const IMAGES_ENDPOINT = '/api/images';
+
+export const getMaterialRecalculatePricesEndpoint = (materialId: string) =>
+    `${MATERIALS_ENDPOINT}/${materialId}/recalculate-prices`;

--- a/packages/web/src/api/endpoints/recalculateMaterialPrices/index.ts
+++ b/packages/web/src/api/endpoints/recalculateMaterialPrices/index.ts
@@ -1,0 +1,28 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { getMaterialRecalculatePricesEndpoint } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+const makeRecalculateMaterialPricesRequest = async (
+    materialId: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) => {
+    return await makeRequestWithAutoRefresh<{ updated: number; total: number }>(
+        {
+            pathname: getMaterialRecalculatePricesEndpoint(materialId),
+            method: MethodType.POST,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            operationString: 'recalculate material prices',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+};
+
+export default makeRecalculateMaterialPricesRequest;

--- a/packages/web/src/api/endpoints/updateMaterial/index.ts
+++ b/packages/web/src/api/endpoints/updateMaterial/index.ts
@@ -3,6 +3,12 @@ import { type Material, MethodType, type UpdateMaterial } from '@jewellery-catal
 import { MATERIALS_ENDPOINT } from '../../endpoints';
 import { makeRequestWithAutoRefresh } from '../../makeRequest';
 
+export type UpdateMaterialResponse = {
+    material: Material;
+    affectedDesignsCount: number;
+    priceChanged: boolean;
+};
+
 const makeUpdateMaterialRequest = async (
     materialId: string,
     updates: UpdateMaterial,
@@ -10,7 +16,7 @@ const makeUpdateMaterialRequest = async (
     onTokenRefresh: (newToken: string) => void,
     onTokenClear: () => void
 ) => {
-    return await makeRequestWithAutoRefresh<Material>(
+    return await makeRequestWithAutoRefresh<UpdateMaterialResponse>(
         {
             pathname: `${MATERIALS_ENDPOINT}/${materialId}`,
             method: MethodType.PUT,

--- a/packages/web/src/components/MaterialUpdateForm/index.tsx
+++ b/packages/web/src/components/MaterialUpdateForm/index.tsx
@@ -5,7 +5,18 @@ import { Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import makeRecalculateMaterialPricesRequest from '@/api/endpoints/recalculateMaterialPrices';
 import makeUpdateMaterialRequest from '@/api/endpoints/updateMaterial';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
@@ -24,6 +35,8 @@ export interface IMaterialUpdateFormProps {
 
 const MaterialUpdateForm: React.FC<IMaterialUpdateFormProps> = ({ material, onSuccess, onCancel }) => {
     const [isUpdating, setIsUpdating] = useState(false);
+    const [isRecalculating, setIsRecalculating] = useState(false);
+    const [pendingRecalculate, setPendingRecalculate] = useState<{ count: number } | null>(null);
     const { accessToken, login, logout } = useAuth();
     const { dispatch } = useAlert();
 
@@ -115,10 +128,41 @@ const MaterialUpdateForm: React.FC<IMaterialUpdateFormProps> = ({ material, onSu
         }
     }, [addPacks, material, lengthPerPack, quantityPerPack, totalLength, totalQuantity]);
 
+    const handleRecalculateConfirm = async () => {
+        setIsRecalculating(true);
+        try {
+            const result = await makeRecalculateMaterialPricesRequest(material.id, () => accessToken, login, logout);
+            dispatch({
+                type: AlertStoreActions.SHOW_ALERT,
+                payload: {
+                    title: 'Prices updated!',
+                    message: `Updated ${result.updated} of ${result.total} design prices.`,
+                    severity: 'success',
+                    variant: 'standard',
+                },
+            });
+        } catch (e) {
+            const message = e instanceof Error ? e.message : 'Unknown Error';
+            dispatch({
+                type: AlertStoreActions.SHOW_ALERT,
+                payload: {
+                    title: 'Error updating prices',
+                    message: `Details: ${message}`,
+                    severity: 'error',
+                    variant: 'standard',
+                },
+            });
+        } finally {
+            setIsRecalculating(false);
+            setPendingRecalculate(null);
+            onSuccess();
+        }
+    };
+
     const onSubmit = async (data: UpdateMaterial) => {
         setIsUpdating(true);
         try {
-            await makeUpdateMaterialRequest(material.id, data, () => accessToken, login, logout);
+            const result = await makeUpdateMaterialRequest(material.id, data, () => accessToken, login, logout);
 
             dispatch({
                 type: AlertStoreActions.SHOW_ALERT,
@@ -130,7 +174,11 @@ const MaterialUpdateForm: React.FC<IMaterialUpdateFormProps> = ({ material, onSu
                 },
             });
 
-            onSuccess();
+            if (result.priceChanged && result.affectedDesignsCount > 0) {
+                setPendingRecalculate({ count: result.affectedDesignsCount });
+            } else {
+                onSuccess();
+            }
         } catch (e) {
             const message = e instanceof Error ? e.message : 'Unknown Error';
 
@@ -149,218 +197,248 @@ const MaterialUpdateForm: React.FC<IMaterialUpdateFormProps> = ({ material, onSu
     };
 
     return (
-        <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                {/* Current Stock Info */}
-                <div className="space-y-2">
-                    <h3 className="text-sm font-semibold">Current Inventory</h3>
-                    <div className="grid grid-cols-2 gap-4 text-sm">
-                        <div>
-                            <p className="text-muted-foreground">Stock Level</p>
-                            <p className="font-medium">{currentStock}</p>
-                        </div>
-                        <div>
-                            <p className="text-muted-foreground">Pack Size</p>
-                            <p className="font-medium">{packSize}</p>
+        <>
+            <AlertDialog
+                open={!!pendingRecalculate}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setPendingRecalculate(null);
+                        onSuccess();
+                    }
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Update Design Prices?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This material is used in {pendingRecalculate?.count}{' '}
+                            {pendingRecalculate?.count === 1 ? 'design' : 'designs'}. Would you like to recalculate
+                            their selling prices based on the new material cost?
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isRecalculating}>Skip</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleRecalculateConfirm} disabled={isRecalculating}>
+                            {isRecalculating ? 'Updating…' : 'Update Prices'}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                    {/* Current Stock Info */}
+                    <div className="space-y-2">
+                        <h3 className="text-sm font-semibold">Current Inventory</h3>
+                        <div className="grid grid-cols-2 gap-4 text-sm">
+                            <div>
+                                <p className="text-muted-foreground">Stock Level</p>
+                                <p className="font-medium">{currentStock}</p>
+                            </div>
+                            <div>
+                                <p className="text-muted-foreground">Pack Size</p>
+                                <p className="font-medium">{packSize}</p>
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                <Separator />
+                    <Separator />
 
-                {/* Material Details and Type-specific fields side by side */}
-                <div className="grid grid-cols-2 gap-6">
-                    {/* Basic Details */}
-                    <div className="space-y-4">
-                        <h3 className="text-sm font-semibold">Material Details</h3>
+                    {/* Material Details and Type-specific fields side by side */}
+                    <div className="grid grid-cols-2 gap-6">
+                        {/* Basic Details */}
+                        <div className="space-y-4">
+                            <h3 className="text-sm font-semibold">Material Details</h3>
 
-                        <FormField
-                            control={form.control}
-                            name="name"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Name</FormLabel>
-                                    <FormControl>
-                                        <Input {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                            <FormField
+                                control={form.control}
+                                name="name"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Name</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
 
-                        <FormField
-                            control={form.control}
-                            name="brand"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Brand</FormLabel>
-                                    <FormControl>
-                                        <Input {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                            <FormField
+                                control={form.control}
+                                name="brand"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Brand</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
 
-                        <FormField
-                            control={form.control}
-                            name="materialCode"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Material Code (Optional)</FormLabel>
-                                    <FormControl>
-                                        <Input {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                            <FormField
+                                control={form.control}
+                                name="materialCode"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Material Code (Optional)</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
 
-                        <FormField
-                            control={form.control}
-                            name="purchaseUrl"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Purchase URL</FormLabel>
-                                    <FormControl>
-                                        <Input {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                            <FormField
+                                control={form.control}
+                                name="purchaseUrl"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Purchase URL</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
 
-                        <FormField
-                            control={form.control}
-                            name="lowStockThreshold"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Low Stock Threshold (Optional)</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            className="max-w-[150px]"
-                                            type="number"
-                                            step="any"
-                                            min="0"
-                                            placeholder="e.g., 1.5"
-                                            {...field}
-                                            value={field.value ?? ''}
-                                            onChange={(e) => {
-                                                const value = e.target.value;
-                                                field.onChange(value === '' ? undefined : Number(value));
-                                            }}
-                                        />
-                                    </FormControl>
-                                    <FormDescription>Alert when stock drops below this many packs</FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                    </div>
-
-                    {/* Type-specific fields */}
-                    <UpdateFormResolver
-                        control={form.control}
-                        materialType={currentMaterialType}
-                        form={form}
-                        material={material}
-                    />
-                </div>
-
-                <Separator />
-
-                {/* Pack Pricing and Add Stock side by side */}
-                <div className="grid grid-cols-2 gap-6">
-                    {/* Pack Pricing */}
-                    <div className="space-y-4">
-                        <h3 className="text-sm font-semibold">Pack Pricing</h3>
-
-                        <FormField
-                            control={form.control}
-                            name="pricePerPack"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Price per Pack</FormLabel>
-                                    <FormControl>
-                                        <InputGroup className="max-w-[150px]">
-                                            <InputGroupAddon align="inline-start">
-                                                <InputGroupText>£</InputGroupText>
-                                            </InputGroupAddon>
-                                            <InputGroupInput
+                            <FormField
+                                control={form.control}
+                                name="lowStockThreshold"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Low Stock Threshold (Optional)</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                className="max-w-[150px]"
                                                 type="number"
-                                                step="0.01"
+                                                step="any"
+                                                min="0"
+                                                placeholder="e.g., 1.5"
                                                 {...field}
-                                                value={field.value ?? (material as any).pricePerPack ?? ''}
+                                                value={field.value ?? ''}
                                                 onChange={(e) => {
                                                     const value = e.target.value;
                                                     field.onChange(value === '' ? undefined : Number(value));
                                                 }}
                                             />
-                                        </InputGroup>
-                                    </FormControl>
-                                    <FormDescription>Current price for buying a new pack</FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
+                                        </FormControl>
+                                        <FormDescription>Alert when stock drops below this many packs</FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+
+                        {/* Type-specific fields */}
+                        <UpdateFormResolver
+                            control={form.control}
+                            materialType={currentMaterialType}
+                            form={form}
+                            material={material}
                         />
                     </div>
 
-                    {/* Add Stock Section */}
-                    <div className="space-y-4">
-                        <h3 className="text-sm font-semibold">Add Stock</h3>
+                    <Separator />
 
-                        <FormField
-                            control={form.control}
-                            name="addPacks"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Add Packs</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            className="max-w-[150px]"
-                                            type="number"
-                                            step="1"
-                                            placeholder="0"
-                                            {...field}
-                                            value={field.value ?? ''}
-                                            onChange={(e) => {
-                                                const value = e.target.value;
-                                                field.onChange(value === '' ? undefined : Number(value));
-                                            }}
-                                        />
-                                    </FormControl>
-                                    <FormDescription>How many new packs did you buy?</FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                    {/* Pack Pricing and Add Stock side by side */}
+                    <div className="grid grid-cols-2 gap-6">
+                        {/* Pack Pricing */}
+                        <div className="space-y-4">
+                            <h3 className="text-sm font-semibold">Pack Pricing</h3>
 
-                        {/* Reserved space for estimated new stock */}
-                        <div className={`rounded-md p-3 text-sm min-h-[60px] ${estimatedNewStock ? 'bg-muted' : ''}`}>
-                            {estimatedNewStock ? (
-                                <>
-                                    <p className="text-muted-foreground">New stock level will be:</p>
-                                    <p className="font-semibold">{estimatedNewStock}</p>
-                                </>
-                            ) : (
-                                <p className="text-muted-foreground opacity-0">Placeholder</p>
-                            )}
+                            <FormField
+                                control={form.control}
+                                name="pricePerPack"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Price per Pack</FormLabel>
+                                        <FormControl>
+                                            <InputGroup className="max-w-[150px]">
+                                                <InputGroupAddon align="inline-start">
+                                                    <InputGroupText>£</InputGroupText>
+                                                </InputGroupAddon>
+                                                <InputGroupInput
+                                                    type="number"
+                                                    step="0.01"
+                                                    {...field}
+                                                    value={field.value ?? (material as any).pricePerPack ?? ''}
+                                                    onChange={(e) => {
+                                                        const value = e.target.value;
+                                                        field.onChange(value === '' ? undefined : Number(value));
+                                                    }}
+                                                />
+                                            </InputGroup>
+                                        </FormControl>
+                                        <FormDescription>Current price for buying a new pack</FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+
+                        {/* Add Stock Section */}
+                        <div className="space-y-4">
+                            <h3 className="text-sm font-semibold">Add Stock</h3>
+
+                            <FormField
+                                control={form.control}
+                                name="addPacks"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Add Packs</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                className="max-w-[150px]"
+                                                type="number"
+                                                step="1"
+                                                placeholder="0"
+                                                {...field}
+                                                value={field.value ?? ''}
+                                                onChange={(e) => {
+                                                    const value = e.target.value;
+                                                    field.onChange(value === '' ? undefined : Number(value));
+                                                }}
+                                            />
+                                        </FormControl>
+                                        <FormDescription>How many new packs did you buy?</FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            {/* Reserved space for estimated new stock */}
+                            <div
+                                className={`rounded-md p-3 text-sm min-h-[60px] ${estimatedNewStock ? 'bg-muted' : ''}`}
+                            >
+                                {estimatedNewStock ? (
+                                    <>
+                                        <p className="text-muted-foreground">New stock level will be:</p>
+                                        <p className="font-semibold">{estimatedNewStock}</p>
+                                    </>
+                                ) : (
+                                    <p className="text-muted-foreground opacity-0">Placeholder</p>
+                                )}
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                {/* Action Buttons */}
-                <div className="flex justify-end gap-2 pt-4">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isUpdating}>
-                        Cancel
-                    </Button>
-                    <Button type="submit" disabled={isUpdating}>
-                        {isUpdating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        Update Material
-                    </Button>
-                </div>
-            </form>
-        </Form>
+                    {/* Action Buttons */}
+                    <div className="flex justify-end gap-2 pt-4">
+                        <Button type="button" variant="outline" onClick={onCancel} disabled={isUpdating}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={isUpdating}>
+                            {isUpdating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Update Material
+                        </Button>
+                    </div>
+                </form>
+            </Form>
+        </>
     );
 };
 


### PR DESCRIPTION
## Summary

- When a material's per-unit price changes, `MaterialService.updateMaterial` now returns `{ material, affectedDesignsCount, priceChanged }` alongside the existing propagation of `totalMaterialCosts` to designs
- New `POST /api/materials/:id/recalculate-prices` endpoint recalculates selling `price` on only the affected designs using current user wage/margin settings (reuses existing `calcPrice` logic from `UserSettingsService`)
- `MaterialUpdateForm` shows an `AlertDialog` after a price-changing update if any designs are affected — user can confirm to update prices or skip

## Test plan

- [ ] Edit a material, change `pricePerPack` → submit → dialog appears with correct design count
- [ ] Confirm → prices updated alert shows `Updated X of Y designs`
- [ ] Skip → no price changes, material still updated
- [ ] Edit a material without changing price → no dialog appears
- [ ] Material used in 0 designs → no dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)