### PR TITLE
feat(ci): add fallow static analysis

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,11 @@
+{
+  "ignorePatterns": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "packages/web/src/components/ui/**",
+    "**/dist/**",
+    "**/coverage/**"
+  ],
+  "ignoreUnresolvedImports": ["bun:test"]
+}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -116,7 +116,7 @@ jobs:
             -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
             -w "\nHTTP Status: %{http_code}\n" \
             "${{ secrets.DEPLOY_WEB_URL }}" \
-            -d '{"event":"deployment","timestamp":"'$(date -u +'%Y-%m-%dT%H:%M:%SZ')'","ref":"${{ github.ref }}"}'
+            -d '{"event":"deployment","timestamp":"'$(date -u +'%Y-%m-%dT%H:%M:%SZ')'","ref":"'"$GITHUB_REF"'"}'
       - name: Trigger API deployment
         run: |
           curl -X POST --fail-with-body \
@@ -125,4 +125,4 @@ jobs:
             -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
             -w "\nHTTP Status: %{http_code}\n" \
             "${{ secrets.DEPLOY_API_URL }}" \
-            -d '{"event":"deployment","timestamp":"'$(date -u +'%Y-%m-%dT%H:%M:%SZ')'","ref":"${{ github.ref }}"}'
+            -d '{"event":"deployment","timestamp":"'$(date -u +'%Y-%m-%dT%H:%M:%SZ')'","ref":"'"$GITHUB_REF"'"}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,3 +94,20 @@ jobs:
           name: playwright-report
           path: packages/web/playwright-report/
           retention-days: 7
+
+  fallow:
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: fallow-rs/fallow@v2
+        with:
+          command: audit
+          comment: true
+          review-comments: true
+          gate: new-only


### PR DESCRIPTION
## Summary

- Add `fallow` job to PR pipeline — runs after `lint`, posts inline review comments, fails on new issues (`gate: new-only`)
- Add `.fallowrc.json` excluding test files, shadcn/ui vendored components, and `bun:test` virtual import
- Fix shell injection in deploy steps: `${{ github.ref }}` → `$GITHUB_REF`

## Test plan

- [ ] Verify fallow job appears in PR checks
- [ ] Verify fallow posts PR comments/annotations on changed code
- [ ] Verify deploy steps use `$GITHUB_REF` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)