### PR TITLE
feat: design authoring upgrades — maker docs + price suggestion

### DIFF
--- a/packages/api/src/domain/DesignService/index.test.ts
+++ b/packages/api/src/domain/DesignService/index.test.ts
@@ -148,7 +148,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(mockDesignData, mockImageBuffers, [], userId);
+            const result = await service.addDesign(mockDesignData, mockImageBuffers, [], [], [], userId);
 
             expect(mockImageService.uploadImage).toHaveBeenCalledWith('image-id-123', mockImageBuffer, mockContentType);
             expect(mockDesignRepo.insert).toHaveBeenCalledWith(
@@ -183,7 +183,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(designDataWithStringMaterials, mockImageBuffers, [], userId);
+            const result = await service.addDesign(designDataWithStringMaterials, mockImageBuffers, [], [], [], userId);
 
             expect(result.materials).toEqual(materials);
         });
@@ -199,7 +199,7 @@ describe('DesignService', () => {
             mockImageService.uploadImage.mockResolvedValue(undefined);
             mockDesignRepo.insert.mockResolvedValue(undefined);
 
-            const result = await service.addDesign(designDataWithArrayMaterials, mockImageBuffers, [], userId);
+            const result = await service.addDesign(designDataWithArrayMaterials, mockImageBuffers, [], [], [], userId);
 
             expect(result.materials).toEqual(materials);
         });
@@ -211,7 +211,7 @@ describe('DesignService', () => {
             };
 
             await expect(
-                service.addDesign(designDataWithInvalidMaterials, mockImageBuffers, [], userId)
+                service.addDesign(designDataWithInvalidMaterials, mockImageBuffers, [], [], [], userId)
             ).rejects.toMatchObject({
                 message: 'Invalid materials format',
                 status: 400,
@@ -223,11 +223,65 @@ describe('DesignService', () => {
         it('should propagate image service errors', async () => {
             mockImageService.uploadImage.mockRejectedValue(new Error('Upload failed'));
 
-            await expect(service.addDesign(mockDesignData, mockImageBuffers, [], userId)).rejects.toThrow(
+            await expect(service.addDesign(mockDesignData, mockImageBuffers, [], [], [], userId)).rejects.toThrow(
                 'Upload failed'
             );
 
             expect(mockDesignRepo.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('addDesign — maker docs', () => {
+        it('uploads diagram images separately from product images and stores both id lists plus makingNotes', async () => {
+            mockIdGenerator.generate
+                .mockReturnValueOnce('design-1')
+                .mockReturnValueOnce('product-img-1')
+                .mockReturnValueOnce('diagram-img-1');
+            mockImageService.uploadImage.mockResolvedValue(undefined);
+
+            const designData = {
+                name: 'Test',
+                description: 'desc',
+                timeRequired: '01:00',
+                materials: JSON.stringify([]),
+                totalMaterialCosts: 10,
+                price: 20,
+                image: undefined,
+                makingNotes: 'Solder the clasp before adding the chain.',
+            } as any;
+
+            const result = await service.addDesign(
+                designData,
+                [{ buffer: Buffer.from('product'), contentType: 'image/png' }],
+                [],
+                [{ buffer: Buffer.from('diagram'), contentType: 'image/png' }],
+                [],
+                'user-1'
+            );
+
+            expect(result.imageIds).toEqual(['product-img-1']);
+            expect(result.diagramImageIds).toEqual(['diagram-img-1']);
+            expect(result.makingNotes).toBe('Solder the clasp before adding the chain.');
+            expect(mockImageService.uploadImage).toHaveBeenCalledTimes(2);
+        });
+
+        it('defaults makingNotes to empty string and diagramImageIds to empty array when omitted', async () => {
+            mockIdGenerator.generate.mockReturnValueOnce('design-2');
+
+            const designData = {
+                name: 'Test',
+                description: 'desc',
+                timeRequired: '01:00',
+                materials: JSON.stringify([]),
+                totalMaterialCosts: 10,
+                price: 20,
+                image: undefined,
+            } as any;
+
+            const result = await service.addDesign(designData, [], [], [], [], 'user-1');
+
+            expect(result.diagramImageIds).toEqual([]);
+            expect(result.makingNotes).toBe('');
         });
     });
 

--- a/packages/api/src/domain/DesignService/index.test.ts
+++ b/packages/api/src/domain/DesignService/index.test.ts
@@ -350,6 +350,75 @@ describe('DesignService', () => {
         });
     });
 
+    describe('editDesignProperties — maker docs', () => {
+        it('merges kept + newly uploaded diagram image ids and updates makingNotes', async () => {
+            const existing: Design = {
+                id: 'design-1',
+                userId: 'user-1',
+                name: 'Existing',
+                description: 'desc',
+                timeRequired: '01:00',
+                materials: [],
+                imageIds: ['product-1'],
+                diagramImageIds: ['old-diagram-1', 'old-diagram-2'],
+                makingNotes: 'Old notes',
+                price: 20,
+                totalMaterialCosts: 10,
+                dateAdded: new Date(),
+                totalQuantity: 0,
+            };
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(existing);
+            mockIdGenerator.generate.mockReturnValueOnce('new-diagram-1');
+            mockImageService.uploadImage.mockResolvedValue(undefined);
+
+            const result = await service.editDesignProperties(
+                'design-1',
+                { makingNotes: 'Updated notes' },
+                [],
+                ['product-1'],
+                [{ buffer: Buffer.from('diagram'), contentType: 'image/png' }],
+                ['old-diagram-1'],
+                'user-1'
+            );
+
+            expect(result.diagramImageIds).toEqual(['old-diagram-1', 'new-diagram-1']);
+            expect(result.makingNotes).toBe('Updated notes');
+            expect(result.imageIds).toEqual(['product-1']);
+        });
+
+        it('leaves diagramImageIds and makingNotes unchanged when not part of the update', async () => {
+            const existing: Design = {
+                id: 'design-1',
+                userId: 'user-1',
+                name: 'Existing',
+                description: 'desc',
+                timeRequired: '01:00',
+                materials: [],
+                imageIds: ['product-1'],
+                diagramImageIds: ['old-diagram-1'],
+                makingNotes: 'Keep me',
+                price: 20,
+                totalMaterialCosts: 10,
+                dateAdded: new Date(),
+                totalQuantity: 0,
+            };
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(existing);
+
+            const result = await service.editDesignProperties(
+                'design-1',
+                { name: 'Renamed' },
+                [],
+                ['product-1'],
+                [],
+                ['old-diagram-1'],
+                'user-1'
+            );
+
+            expect(result.diagramImageIds).toEqual(['old-diagram-1']);
+            expect(result.makingNotes).toBe('Keep me');
+        });
+    });
+
     describe('deleteDesign', () => {
         const designId = 'design-123';
         const userId = 'user-123';

--- a/packages/api/src/domain/DesignService/index.ts
+++ b/packages/api/src/domain/DesignService/index.ts
@@ -49,6 +49,8 @@ export class DesignService {
         designData: UploadDesign,
         imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
         existingImageIds: string[],
+        diagramImageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        existingDiagramImageIds: string[],
         userId: string
     ): Promise<Design> {
         if (!userId) {
@@ -65,7 +67,16 @@ export class DesignService {
             })
         );
 
+        const newDiagramImageIds = await Promise.all(
+            diagramImageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
         const imageIds = [...existingImageIds, ...newImageIds];
+        const diagramImageIds = [...existingDiagramImageIds, ...newDiagramImageIds];
 
         let materials: Array<RequiredMaterial>;
 
@@ -109,6 +120,8 @@ export class DesignService {
             totalMaterialCosts: designData.totalMaterialCosts,
             price: designData.price,
             imageIds,
+            diagramImageIds,
+            makingNotes: designData.makingNotes ?? '',
             materials,
             dateAdded: new Date(),
             totalQuantity: 0,

--- a/packages/api/src/domain/DesignService/index.ts
+++ b/packages/api/src/domain/DesignService/index.ts
@@ -164,6 +164,8 @@ export class DesignService {
         updates: EditDesign,
         imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
         keepImageIds: string[],
+        diagramImageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        keepDiagramImageIds: string[],
         userId: string
     ): Promise<Design> {
         if (!id) {
@@ -184,7 +186,16 @@ export class DesignService {
             })
         );
 
+        const newDiagramImageIds = await Promise.all(
+            diagramImageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
         const imageIds = [...keepImageIds, ...newImageIds];
+        const diagramImageIds = [...keepDiagramImageIds, ...newDiagramImageIds];
 
         let materials = existing.materials;
         if (updates.materials) {
@@ -207,6 +218,8 @@ export class DesignService {
             ...updates,
             materials,
             imageIds,
+            diagramImageIds,
+            makingNotes: updates.makingNotes ?? existing.makingNotes,
             variationGroups,
             variants,
         };

--- a/packages/api/src/domain/UserSettingsService/index.test.ts
+++ b/packages/api/src/domain/UserSettingsService/index.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, jest, mock } from 'bun:test';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { UserSettingsRepository } from '../UserSettingsRepository';
+import { UserSettingsService } from './index';
+
+const mockSettingsRepo = {
+    getByUserId: mock(),
+    upsert: mock(),
+};
+
+const mockDesignRepo = {
+    getById: mock(),
+    getByIdAndUserId: mock(),
+    getByUserId: mock(),
+    findByMaterialId: mock(),
+    insert: mock(),
+    update: mock(),
+    delete: mock(),
+    getAll: mock(),
+};
+
+describe('UserSettingsService', () => {
+    let service: UserSettingsService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        service = new UserSettingsService(
+            mockSettingsRepo as unknown as UserSettingsRepository,
+            mockDesignRepo as unknown as DesignRepository
+        );
+    });
+
+    describe('get', () => {
+        it('returns default hourlyWage and profitMargin when no settings stored', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue(null);
+
+            const result = await service.get('user-1');
+
+            expect(result.hourlyWage).toBe(10);
+            expect(result.profitMargin).toBe(15);
+        });
+
+        it('returns markupMultiplier 2.5 and hourlyRate 0 defaults when no settings stored', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue(null);
+
+            const result = await service.get('user-1');
+
+            expect(result.markupMultiplier).toBe(2.5);
+            expect(result.hourlyRate).toBe(0);
+        });
+
+        it('returns stored markupMultiplier and hourlyRate when present', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue({
+                userId: 'user-1',
+                hourlyWage: 10,
+                profitMargin: 15,
+                markupMultiplier: 3,
+                hourlyRate: 5,
+            });
+
+            const result = await service.get('user-1');
+
+            expect(result.markupMultiplier).toBe(3);
+            expect(result.hourlyRate).toBe(5);
+        });
+    });
+
+    describe('upsert — price suggestion fields', () => {
+        it('persists markupMultiplier and hourlyRate alongside the existing fields', async () => {
+            const result = await service.upsert('user-1', {
+                hourlyWage: 12,
+                profitMargin: 20,
+                markupMultiplier: 2,
+                hourlyRate: 8,
+            });
+
+            expect(result).toEqual({
+                userId: 'user-1',
+                hourlyWage: 12,
+                profitMargin: 20,
+                markupMultiplier: 2,
+                hourlyRate: 8,
+            });
+            expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
+        });
+    });
+});

--- a/packages/api/src/domain/UserSettingsService/index.ts
+++ b/packages/api/src/domain/UserSettingsService/index.ts
@@ -5,6 +5,8 @@ import type { UserSettingsRepository } from '../UserSettingsRepository';
 
 const DEFAULT_HOURLY_WAGE = 10;
 const DEFAULT_PROFIT_MARGIN = 15;
+const DEFAULT_MARKUP_MULTIPLIER = 2.5;
+const DEFAULT_HOURLY_RATE = 0;
 
 function parseTimeToHours(timeRequired: string): number {
     const [hoursStr, minutesStr] = timeRequired.split(':');
@@ -28,10 +30,21 @@ export class UserSettingsService {
 
     async get(userId: string): Promise<UserSettings> {
         const stored = await this.settingsRepo.getByUserId(userId);
-        return stored ?? { userId, hourlyWage: DEFAULT_HOURLY_WAGE, profitMargin: DEFAULT_PROFIT_MARGIN };
+        return (
+            stored ?? {
+                userId,
+                hourlyWage: DEFAULT_HOURLY_WAGE,
+                profitMargin: DEFAULT_PROFIT_MARGIN,
+                markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
+                hourlyRate: DEFAULT_HOURLY_RATE,
+            }
+        );
     }
 
-    async upsert(userId: string, updates: { hourlyWage: number; profitMargin: number }): Promise<UserSettings> {
+    async upsert(
+        userId: string,
+        updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number }
+    ): Promise<UserSettings> {
         const settings: UserSettings = { userId, ...updates };
         await this.settingsRepo.upsert(settings);
         return settings;

--- a/packages/api/src/handlers/Design/index.ts
+++ b/packages/api/src/handlers/Design/index.ts
@@ -107,6 +107,7 @@ export const editDesignProperties = async (c: Ctx) => {
     const userId = c.get('userId');
     const body = await c.req.parseBody({ all: true });
     const files = collectFiles(body.files);
+    const diagramFiles = collectFiles(body.diagramFiles);
 
     const {
         name,
@@ -119,19 +120,25 @@ export const editDesignProperties = async (c: Ctx) => {
         variationGroups,
         variants,
         designType,
+        makingNotes,
         keepImageIds: keepImageIdsRaw,
+        keepDiagramImageIds: keepDiagramImageIdsRaw,
     } = body as unknown as Partial<EditDesign> & {
         lowStockThreshold?: string;
         variationGroups?: string;
         variants?: string;
         keepImageIds?: string;
+        keepDiagramImageIds?: string;
         designType?: string;
     };
 
     const keepImageIds: string[] =
         typeof keepImageIdsRaw === 'string' && keepImageIdsRaw ? JSON.parse(keepImageIdsRaw) : [];
+    const keepDiagramImageIds: string[] =
+        typeof keepDiagramImageIdsRaw === 'string' && keepDiagramImageIdsRaw ? JSON.parse(keepDiagramImageIdsRaw) : [];
 
     const imageBuffers = await Promise.all(files.map(toImageBuffer));
+    const diagramImageBuffers = await Promise.all(diagramFiles.map(toImageBuffer));
     const updates: EditDesign = {};
 
     if (name) updates.name = name as EditDesign['name'];
@@ -148,12 +155,15 @@ export const editDesignProperties = async (c: Ctx) => {
     }
     if (designType !== undefined) updates.designType = designType as EditDesign['designType'];
     if (lowStockThreshold !== undefined) updates.lowStockThreshold = Number(lowStockThreshold);
+    if (makingNotes !== undefined) updates.makingNotes = makingNotes as EditDesign['makingNotes'];
 
     const design = await getDesignService().editDesignProperties(
         c.req.param('id'),
         updates,
         imageBuffers,
         keepImageIds,
+        diagramImageBuffers,
+        keepDiagramImageIds,
         userId
     );
     return c.json(design, 200);

--- a/packages/api/src/handlers/Design/index.ts
+++ b/packages/api/src/handlers/Design/index.ts
@@ -36,6 +36,7 @@ export const addDesign = async (c: Ctx) => {
     const isJson = (c.req.header('content-type') ?? '').includes('application/json');
     const body = isJson ? await c.req.json() : await c.req.parseBody({ all: true });
     const files = isJson ? [] : collectFiles(body.files);
+    const diagramFiles = isJson ? [] : collectFiles(body.diagramFiles);
 
     const {
         name,
@@ -48,11 +49,21 @@ export const addDesign = async (c: Ctx) => {
         variationGroups,
         variants,
         designType,
+        makingNotes,
         existingImageIds: existingImageIdsRaw,
-    } = body as unknown as Partial<UploadDesign> & { existingImageIds?: string; designType?: string };
+        existingDiagramImageIds: existingDiagramImageIdsRaw,
+    } = body as unknown as Partial<UploadDesign> & {
+        existingImageIds?: string;
+        existingDiagramImageIds?: string;
+        designType?: string;
+    };
 
     const existingImageIds: string[] =
         typeof existingImageIdsRaw === 'string' && existingImageIdsRaw ? JSON.parse(existingImageIdsRaw) : [];
+    const existingDiagramImageIds: string[] =
+        typeof existingDiagramImageIdsRaw === 'string' && existingDiagramImageIdsRaw
+            ? JSON.parse(existingDiagramImageIdsRaw)
+            : [];
 
     if (files.length === 0 && existingImageIds.length === 0) {
         throw new APIError('At least one image file or imageId is required', 400);
@@ -70,10 +81,19 @@ export const addDesign = async (c: Ctx) => {
         variationGroups,
         variants,
         designType,
+        makingNotes,
     };
 
     const imageBuffers = await Promise.all(files.map(toImageBuffer));
-    const design = await getDesignService().addDesign(designData, imageBuffers, existingImageIds, userId);
+    const diagramImageBuffers = await Promise.all(diagramFiles.map(toImageBuffer));
+    const design = await getDesignService().addDesign(
+        designData,
+        imageBuffers,
+        existingImageIds,
+        diagramImageBuffers,
+        existingDiagramImageIds,
+        userId
+    );
     return c.json(design, 200);
 };
 

--- a/packages/api/src/handlers/UserSettings/index.ts
+++ b/packages/api/src/handlers/UserSettings/index.ts
@@ -12,19 +12,28 @@ const getService = (): UserSettingsService => dependencyContainer.resolve(Depend
 export const getUserSettings = async (c: Ctx) => c.json(await getService().get(c.get('userId')));
 
 export const updateUserSettings = async (c: Ctx) => {
-    const { hourlyWage, profitMargin } = (await c.req.json()) as {
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = (await c.req.json()) as {
         hourlyWage?: number;
         profitMargin?: number;
+        markupMultiplier?: number;
+        hourlyRate?: number;
     };
 
-    if (hourlyWage === undefined || profitMargin === undefined) {
-        throw new APIError('hourlyWage and profitMargin are required', 400);
+    if (
+        hourlyWage === undefined ||
+        profitMargin === undefined ||
+        markupMultiplier === undefined ||
+        hourlyRate === undefined
+    ) {
+        throw new APIError('hourlyWage, profitMargin, markupMultiplier and hourlyRate are required', 400);
     }
 
     return c.json(
         await getService().upsert(c.get('userId'), {
             hourlyWage: Number(hourlyWage),
             profitMargin: Number(profitMargin),
+            markupMultiplier: Number(markupMultiplier),
+            hourlyRate: Number(hourlyRate),
         })
     );
 };

--- a/packages/types/src/design/index.ts
+++ b/packages/types/src/design/index.ts
@@ -14,6 +14,8 @@ export const designSchema = z.object({
     timeRequired: z.string(),
     materials: z.array(requiredMaterialSchema),
     imageIds: z.array(z.string()),
+    diagramImageIds: z.array(z.string()).default([]),
+    makingNotes: z.string().default(''),
     price: z.number(),
     description: z.string(),
     totalMaterialCosts: z.number(),

--- a/packages/types/src/editDesign/index.ts
+++ b/packages/types/src/editDesign/index.ts
@@ -15,6 +15,8 @@ export const editDesignSchema = z.object({
     variationGroups: z.array(variationGroupSchema).optional(),
     variants: z.array(designVariantSchema).optional(),
     designType: z.nativeEnum(DesignType).optional(),
+    diagramImageIds: z.array(z.string()).optional(),
+    makingNotes: z.string().optional(),
 });
 
 export type EditDesign = z.infer<typeof editDesignSchema>;

--- a/packages/types/src/formDesign/index.ts
+++ b/packages/types/src/formDesign/index.ts
@@ -12,6 +12,11 @@ export const formDesignSchema = z
             .array(z.union([z.instanceof(File), z.string()]))
             .optional()
             .default([]),
+        diagramImages: z
+            .array(z.union([z.instanceof(File), z.string()]))
+            .optional()
+            .default([]),
+        makingNotes: z.string().optional().default(''),
         price: z.number({ message: 'Please enter the price' }).nonnegative('Price must be 0 or greater'),
         description: z.string(),
         totalMaterialCosts: z.number(),

--- a/packages/types/src/uploadDesign/index.ts
+++ b/packages/types/src/uploadDesign/index.ts
@@ -13,4 +13,5 @@ export interface UploadDesign {
     variationGroups?: string;
     variants?: string;
     designType?: DesignType;
+    makingNotes?: string;
 }

--- a/packages/types/src/userSettings/index.ts
+++ b/packages/types/src/userSettings/index.ts
@@ -4,6 +4,8 @@ export const userSettingsSchema = z.object({
     userId: z.string(),
     hourlyWage: z.number().nonnegative(),
     profitMargin: z.number().nonnegative(),
+    markupMultiplier: z.number().nonnegative(),
+    hourlyRate: z.number().nonnegative(),
 });
 
 export type UserSettings = z.infer<typeof userSettingsSchema>;

--- a/packages/web/src/api/endpoints/addDesign/index.ts
+++ b/packages/web/src/api/endpoints/addDesign/index.ts
@@ -23,11 +23,23 @@ const makeAddDesignRequest = async (
         formData.append('existingImageIds', JSON.stringify(existingImageIds));
     }
 
+    const diagramImages = formDesign.diagramImages ?? [];
+    const existingDiagramImageIds = diagramImages.filter((v): v is string => typeof v === 'string');
+    const newDiagramFiles = diagramImages.filter((v): v is File => v instanceof File);
+
+    for (const file of newDiagramFiles) {
+        formData.append('diagramFiles', file);
+    }
+
+    if (existingDiagramImageIds.length > 0) {
+        formData.append('existingDiagramImageIds', JSON.stringify(existingDiagramImageIds));
+    }
+
     for (const key in formDesign) {
         if (Object.hasOwn(formDesign, key)) {
             const value = formDesign[key as keyof typeof formDesign];
 
-            if (key === 'images') {
+            if (key === 'images' || key === 'diagramImages') {
                 // handled above
             } else if (
                 (key === 'materials' || key === 'variationGroups' || key === 'variants') &&

--- a/packages/web/src/api/endpoints/editDesign/index.ts
+++ b/packages/web/src/api/endpoints/editDesign/index.ts
@@ -22,11 +22,21 @@ const makeEditDesignRequest = async (
 
     formData.append('keepImageIds', JSON.stringify(keepImageIds));
 
+    const diagramImages = formDesign.diagramImages ?? [];
+    const keepDiagramImageIds = diagramImages.filter((v): v is string => typeof v === 'string');
+    const newDiagramFiles = diagramImages.filter((v): v is File => v instanceof File);
+
+    for (const file of newDiagramFiles) {
+        formData.append('diagramFiles', file);
+    }
+
+    formData.append('keepDiagramImageIds', JSON.stringify(keepDiagramImageIds));
+
     for (const key in formDesign) {
         if (Object.hasOwn(formDesign, key)) {
             const value = formDesign[key as keyof FormDesign];
 
-            if (key === 'images') {
+            if (key === 'images' || key === 'diagramImages') {
                 // handled above
             } else if (
                 (key === 'materials' || key === 'variationGroups' || key === 'variants') &&

--- a/packages/web/src/api/endpoints/userSettings/index.ts
+++ b/packages/web/src/api/endpoints/userSettings/index.ts
@@ -21,7 +21,7 @@ export const makeGetUserSettingsRequest = (
     );
 
 export const makeUpdateUserSettingsRequest = (
-    updates: { hourlyWage: number; profitMargin: number },
+    updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number },
     getAccessToken: () => string,
     onTokenRefresh: (newToken: string) => void,
     onTokenClear: () => void

--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -15,9 +15,11 @@ import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/
 import makeEditDesignRequest from '../../api/endpoints/editDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
+import MakerDocsSection from '../../components/MakerDocsSection';
 import MultiImageUpload from '../../components/MultiImageUpload';
 import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
+import SuggestedPrice from '../../components/SuggestedPrice';
 import TimeInput from '../../components/TimeInput';
 import { computeVariants, VariationGroupBuilder } from '../../components/VariationGroupBuilder';
 import { useAlert } from '../../context/Alert';
@@ -45,6 +47,8 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
             totalMaterialCosts: design.totalMaterialCosts,
             price: design.price,
             images: design.imageIds,
+            diagramImages: design.diagramImageIds ?? [],
+            makingNotes: design.makingNotes ?? '',
             lowStockThreshold: design.lowStockThreshold,
             variationGroups: design.variationGroups ?? [],
             variants: design.variants ?? [],
@@ -54,7 +58,7 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
 
     const { accessToken, login, logout } = useAuth();
     const [isMakingRequest, setIsMakingRequest] = useState(false);
-    const { hourlyWage, profitMargin } = useUserSettings();
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = useUserSettings();
 
     const { data } = useQuery({
         ...getMaterialsQuery(() => accessToken, login, logout),
@@ -247,6 +251,21 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
 
                 <hr className="border-t border-border" />
 
+                {/* Maker Docs Section */}
+                <div className="grid grid-cols-12 gap-4">
+                    <div className="col-span-4">
+                        <h2 className="text-lg font-medium text-center">Maker Docs</h2>
+                        <p className="text-xs text-muted-foreground text-center mt-1">
+                            Private — diagrams and notes never sent to Etsy
+                        </p>
+                    </div>
+                    <div className="col-span-8">
+                        <MakerDocsSection control={form.control} />
+                    </div>
+                </div>
+
+                <hr className="border-t border-border" />
+
                 {/* Add Materials Section */}
                 <div className="grid grid-cols-12 gap-4">
                     <div className="col-span-4">
@@ -379,6 +398,13 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                                                         />
                                                     </InputGroup>
                                                 </FormControl>
+                                                <SuggestedPrice
+                                                    materialsCost={form.watch('totalMaterialCosts') ?? 0}
+                                                    timeRequired={currentTimeRequired}
+                                                    markupMultiplier={markupMultiplier}
+                                                    hourlyRate={hourlyRate}
+                                                    onUse={(price) => field.onChange(price)}
+                                                />
                                                 <FormDescription>
                                                     Auto-calculated above. Edit to override.
                                                 </FormDescription>

--- a/packages/web/src/components/DesignEditForm/index.tsx
+++ b/packages/web/src/components/DesignEditForm/index.tsx
@@ -327,6 +327,8 @@ const DesignEditForm: React.FC<DesignEditFormProps> = ({ design, onSuccess, onCa
                                             hourlyWage={hourlyWage}
                                             profitMargin={profitMargin}
                                             timeRequired={currentTimeRequired}
+                                            markupMultiplier={markupMultiplier}
+                                            hourlyRate={hourlyRate}
                                         />
                                     </FormControl>
                                     <FormMessage />

--- a/packages/web/src/components/MakerDocsSection/index.tsx
+++ b/packages/web/src/components/MakerDocsSection/index.tsx
@@ -1,0 +1,52 @@
+import type { Control } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+
+import MultiImageUpload from '../MultiImageUpload';
+
+interface MakerDocsSectionProps {
+    control: Control<any>;
+}
+
+const MakerDocsSection: React.FC<MakerDocsSectionProps> = ({ control }) => (
+    <div className="space-y-4">
+        <FormField
+            control={control}
+            name="diagramImages"
+            render={({ field, fieldState }) => (
+                <FormItem>
+                    <FormLabel>Diagrams (private — never shown on Etsy)</FormLabel>
+                    <FormControl>
+                        <MultiImageUpload
+                            value={field.value ?? []}
+                            onChange={field.onChange}
+                            hasError={!!fieldState.error}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+        <FormField
+            control={control}
+            name="makingNotes"
+            render={({ field }) => (
+                <FormItem>
+                    <FormLabel>Making notes (private — never shown on Etsy)</FormLabel>
+                    <FormControl>
+                        <Textarea
+                            placeholder="Steps, measurements, gotchas for making this design again..."
+                            value={field.value ?? ''}
+                            onChange={field.onChange}
+                            rows={4}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    </div>
+);
+
+export default MakerDocsSection;

--- a/packages/web/src/components/SuggestedPrice/index.tsx
+++ b/packages/web/src/components/SuggestedPrice/index.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+
+import { getSuggestedPrice } from '../../utils/getSuggestedPrice';
+
+interface SuggestedPriceProps {
+    materialsCost: number;
+    timeRequired: string;
+    markupMultiplier: number;
+    hourlyRate: number;
+    onUse: (price: number) => void;
+}
+
+const SuggestedPrice: React.FC<SuggestedPriceProps> = ({
+    materialsCost,
+    timeRequired,
+    markupMultiplier,
+    hourlyRate,
+    onUse,
+}) => {
+    const suggested = getSuggestedPrice({ materialsCost, timeRequired, markupMultiplier, hourlyRate });
+
+    return (
+        <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">
+                Suggested: <span className="font-mono text-foreground">£{suggested.toFixed(2)}</span>
+            </span>
+            <Button type="button" variant="ghost" size="sm" onClick={() => onUse(suggested)}>
+                Use this price
+            </Button>
+        </div>
+    );
+};
+
+export default SuggestedPrice;

--- a/packages/web/src/components/VariationGroupBuilder/index.tsx
+++ b/packages/web/src/components/VariationGroupBuilder/index.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { MATERIAL_TYPE_LABELS } from '@/lib/materialLabels';
 import { getTotalMaterialCosts } from '@/utils/getPriceOfMaterials';
+import { getSuggestedPrice } from '@/utils/getSuggestedPrice';
 import { getWageCosts } from '@/utils/getWageCost';
 
 export interface VariationGroupBuilderProps {
@@ -24,6 +25,8 @@ export interface VariationGroupBuilderProps {
     hourlyWage: number;
     profitMargin: number;
     timeRequired: string;
+    markupMultiplier: number;
+    hourlyRate: number;
 }
 
 function cartesian<T>(arrays: T[][]): T[][] {
@@ -264,7 +267,9 @@ const VariantPreview: React.FC<{
     hourlyWage: number;
     profitMargin: number;
     timeRequired: string;
-}> = ({ groups, sharedMaterials, hourlyWage, profitMargin, timeRequired }) => {
+    markupMultiplier: number;
+    hourlyRate: number;
+}> = ({ groups, sharedMaterials, hourlyWage, profitMargin, timeRequired, markupMultiplier, hourlyRate }) => {
     const variants = computeVariants(groups, sharedMaterials, hourlyWage, profitMargin, timeRequired);
 
     if (variants.length === 0) {
@@ -284,6 +289,7 @@ const VariantPreview: React.FC<{
                         <TableHead>Variant</TableHead>
                         <TableHead>Material Costs</TableHead>
                         <TableHead>Price</TableHead>
+                        <TableHead>Suggested</TableHead>
                     </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -292,6 +298,15 @@ const VariantPreview: React.FC<{
                             <TableCell className="font-medium">{v.name}</TableCell>
                             <TableCell>£{v.totalMaterialCosts.toFixed(2)}</TableCell>
                             <TableCell>£{v.price.toFixed(2)}</TableCell>
+                            <TableCell>
+                                £
+                                {getSuggestedPrice({
+                                    materialsCost: v.totalMaterialCosts,
+                                    timeRequired,
+                                    markupMultiplier,
+                                    hourlyRate,
+                                }).toFixed(2)}
+                            </TableCell>
                         </TableRow>
                     ))}
                 </TableBody>
@@ -308,6 +323,8 @@ export const VariationGroupBuilder: React.FC<VariationGroupBuilderProps> = ({
     hourlyWage,
     profitMargin,
     timeRequired,
+    markupMultiplier,
+    hourlyRate,
 }) => {
     const addGroup = () => {
         const newGroup: VariationGroup = {
@@ -355,6 +372,8 @@ export const VariationGroupBuilder: React.FC<VariationGroupBuilderProps> = ({
                         hourlyWage={hourlyWage}
                         profitMargin={profitMargin}
                         timeRequired={timeRequired}
+                        markupMultiplier={markupMultiplier}
+                        hourlyRate={hourlyRate}
                     />
                 </div>
             )}

--- a/packages/web/src/hooks/useUserSettings.ts
+++ b/packages/web/src/hooks/useUserSettings.ts
@@ -20,8 +20,12 @@ export const useUserSettings = () => {
     });
 
     const updateMutation = useMutation({
-        mutationFn: (updates: { hourlyWage: number; profitMargin: number }) =>
-            makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
+        mutationFn: (updates: {
+            hourlyWage: number;
+            profitMargin: number;
+            markupMultiplier: number;
+            hourlyRate: number;
+        }) => makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
         onSuccess: (updated) => {
             queryClient.setQueryData(QUERY_KEY, updated);
         },
@@ -37,6 +41,8 @@ export const useUserSettings = () => {
     return {
         hourlyWage: data?.hourlyWage ?? 10,
         profitMargin: data?.profitMargin ?? 15,
+        markupMultiplier: data?.markupMultiplier ?? 2.5,
+        hourlyRate: data?.hourlyRate ?? 0,
         isLoading,
         updateSettings: updateMutation.mutateAsync,
         recalculate: recalculateMutation.mutateAsync,

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -17,9 +17,11 @@ import { DRAFTS_ENDPOINT } from '../../api/endpoints';
 import makeAddDesignRequest from '../../api/endpoints/addDesign';
 import { getMaterialsQuery } from '../../api/endpoints/getMaterials';
 import { AddMaterialsTable } from '../../components/AddMaterialsTable';
+import MakerDocsSection from '../../components/MakerDocsSection';
 import MultiImageUpload from '../../components/MultiImageUpload';
 import PriceBreakdown from '../../components/PriceBreakdown';
 import RichTextEditor from '../../components/RichTextEditor';
+import SuggestedPrice from '../../components/SuggestedPrice';
 import TimeInput from '../../components/TimeInput';
 import { computeVariants, VariationGroupBuilder } from '../../components/VariationGroupBuilder';
 import { DESIGNS_PAGE } from '../../constants/routes';
@@ -43,6 +45,8 @@ const AddDesign: React.FC = () => {
             description: '',
             totalMaterialCosts: 0,
             images: [],
+            diagramImages: [],
+            makingNotes: '',
             lowStockThreshold: undefined,
             variationGroups: [],
             variants: [],
@@ -52,7 +56,7 @@ const AddDesign: React.FC = () => {
     const { accessToken, login, logout } = useAuth();
     const [isMakingRequest, setIsMakingRequest] = useState(false);
     const [isLoadingDraft, setIsLoadingDraft] = useState(false);
-    const { hourlyWage, profitMargin } = useUserSettings();
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = useUserSettings();
     const [searchParams] = useSearchParams();
     const draftIdParam = searchParams.get('draftId');
 
@@ -305,6 +309,21 @@ const AddDesign: React.FC = () => {
 
                         <hr className="border-t border-border" />
 
+                        {/* Maker Docs Section */}
+                        <div className="grid grid-cols-12 gap-4">
+                            <div className="col-span-4">
+                                <h2 className="text-lg font-medium text-center">Maker Docs</h2>
+                                <p className="text-xs text-muted-foreground text-center mt-1">
+                                    Private — diagrams and notes never sent to Etsy
+                                </p>
+                            </div>
+                            <div className="col-span-8">
+                                <MakerDocsSection control={form.control} />
+                            </div>
+                        </div>
+
+                        <hr className="border-t border-border" />
+
                         {/* Add Materials Section */}
                         <div className="grid grid-cols-12 gap-4">
                             <div className="col-span-4">
@@ -440,6 +459,13 @@ const AddDesign: React.FC = () => {
                                                                 />
                                                             </InputGroup>
                                                         </FormControl>
+                                                        <SuggestedPrice
+                                                            materialsCost={form.watch('totalMaterialCosts') ?? 0}
+                                                            timeRequired={currentTimeRequired}
+                                                            markupMultiplier={markupMultiplier}
+                                                            hourlyRate={hourlyRate}
+                                                            onUse={(price) => field.onChange(price)}
+                                                        />
                                                         <FormDescription>
                                                             Auto-calculated above. Edit to override.
                                                         </FormDescription>

--- a/packages/web/src/pages/AddDesign/index.tsx
+++ b/packages/web/src/pages/AddDesign/index.tsx
@@ -388,6 +388,8 @@ const AddDesign: React.FC = () => {
                                                     hourlyWage={hourlyWage}
                                                     profitMargin={profitMargin}
                                                     timeRequired={currentTimeRequired}
+                                                    markupMultiplier={markupMultiplier}
+                                                    hourlyRate={hourlyRate}
                                                 />
                                             </FormControl>
                                             <FormMessage />

--- a/packages/web/src/pages/Settings/index.tsx
+++ b/packages/web/src/pages/Settings/index.tsx
@@ -26,10 +26,20 @@ const Settings = () => {
         disconnect,
         isDisconnecting,
     } = useEtsyConnection();
-    const { hourlyWage, profitMargin, updateSettings, recalculate, isLoading: pricingLoading } = useUserSettings();
+    const {
+        hourlyWage,
+        profitMargin,
+        markupMultiplier,
+        hourlyRate,
+        updateSettings,
+        recalculate,
+        isLoading: pricingLoading,
+    } = useUserSettings();
 
     const [localWage, setLocalWage] = useState<number | ''>(hourlyWage);
     const [localMargin, setLocalMargin] = useState<number | ''>(profitMargin);
+    const [localMarkupMultiplier, setLocalMarkupMultiplier] = useState<number | ''>(markupMultiplier);
+    const [localHourlyRate, setLocalHourlyRate] = useState<number | ''>(hourlyRate);
     const [pricingStatus, setPricingStatus] = useState<'idle' | 'saving' | 'recalculating' | 'success' | 'error'>(
         'idle'
     );
@@ -41,7 +51,9 @@ const Settings = () => {
     useEffect(() => {
         setLocalWage(hourlyWage);
         setLocalMargin(profitMargin);
-    }, [hourlyWage, profitMargin]);
+        setLocalMarkupMultiplier(markupMultiplier);
+        setLocalHourlyRate(hourlyRate);
+    }, [hourlyWage, profitMargin, markupMultiplier, hourlyRate]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount to strip the ?etsy param from the URL
     useEffect(() => {
@@ -65,7 +77,12 @@ const Settings = () => {
         setPricingAction(thenRecalculate ? 'recalculate' : 'save');
         setPricingStatus('saving');
         try {
-            await updateSettings({ hourlyWage: wage, profitMargin: margin });
+            await updateSettings({
+                hourlyWage: wage,
+                profitMargin: margin,
+                markupMultiplier: Number(localMarkupMultiplier),
+                hourlyRate: Number(localHourlyRate),
+            });
             if (thenRecalculate) {
                 setPricingStatus('recalculating');
                 const result = await recalculate();
@@ -175,6 +192,45 @@ const Settings = () => {
                             />
                             <InputGroupAddon align="inline-end">
                                 <InputGroupText>%</InputGroupText>
+                            </InputGroupAddon>
+                        </InputGroup>
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label>Etsy Price Suggestion — Markup Multiplier</Label>
+                        <InputGroup className="max-w-[140px]">
+                            <InputGroupInput
+                                type="number"
+                                min="0"
+                                step="0.1"
+                                disabled={pricingBusy}
+                                value={localMarkupMultiplier}
+                                onChange={(e) =>
+                                    setLocalMarkupMultiplier(e.target.value === '' ? '' : parseFloat(e.target.value))
+                                }
+                            />
+                            <InputGroupAddon align="inline-end">
+                                <InputGroupText>×</InputGroupText>
+                            </InputGroupAddon>
+                        </InputGroup>
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label>Etsy Price Suggestion — Hourly Rate</Label>
+                        <InputGroup className="max-w-[160px]">
+                            <InputGroupAddon align="inline-start">
+                                <InputGroupText>£</InputGroupText>
+                            </InputGroupAddon>
+                            <InputGroupInput
+                                type="number"
+                                min="0"
+                                step="0.50"
+                                disabled={pricingBusy}
+                                value={localHourlyRate}
+                                onChange={(e) =>
+                                    setLocalHourlyRate(e.target.value === '' ? '' : parseFloat(e.target.value))
+                                }
+                            />
+                            <InputGroupAddon align="inline-end">
+                                <InputGroupText>/hr</InputGroupText>
                             </InputGroupAddon>
                         </InputGroup>
                     </div>

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -54,6 +54,8 @@ const ViewDesign = () => {
         description,
         lowStockThreshold,
         designType,
+        diagramImageIds,
+        makingNotes,
     } = design ?? {};
 
     const hasDescription = description && description !== '<p></p>';
@@ -240,6 +242,29 @@ const ViewDesign = () => {
                                 <DesignDescription html={description} />
                             </div>
                         )}
+
+                        {/* Maker Docs */}
+                        {(diagramImageIds && diagramImageIds.length > 0) || makingNotes ? (
+                            <div className="mt-8 rounded-lg border border-border bg-muted/30 p-6">
+                                <h2 className="text-lg font-medium mb-1">Maker Docs</h2>
+                                <p className="text-xs text-muted-foreground mb-4">Private — never shown on Etsy</p>
+
+                                {diagramImageIds && diagramImageIds.length > 0 && (
+                                    <div className="flex flex-wrap gap-3 mb-4">
+                                        {diagramImageIds.map((id) => (
+                                            <div
+                                                key={id}
+                                                className="w-24 h-24 rounded-md overflow-hidden border border-border"
+                                            >
+                                                <Image imageId={id} />
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+
+                                {makingNotes && <p className="text-sm whitespace-pre-wrap">{makingNotes}</p>}
+                            </div>
+                        ) : null}
 
                         {/* Variants */}
                         {variants && variants.length > 0 && (

--- a/packages/web/src/utils/getSuggestedPrice/index.test.ts
+++ b/packages/web/src/utils/getSuggestedPrice/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getSuggestedPrice } from './index';
+
+describe('getSuggestedPrice', () => {
+    it('applies materialsCost × markupMultiplier + hours × hourlyRate', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 10,
+            timeRequired: '02:00',
+            markupMultiplier: 2.5,
+            hourlyRate: 5,
+        });
+
+        // 10 * 2.5 = 25, + 2 hours * 5 = 10 -> 35
+        expect(result).toBe(35);
+    });
+
+    it('handles minutes correctly (partial hours)', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 0,
+            timeRequired: '00:30',
+            markupMultiplier: 1,
+            hourlyRate: 10,
+        });
+
+        // 0.5 hours * 10 = 5
+        expect(result).toBe(5);
+    });
+
+    it('rounds to 2 decimal places', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 10,
+            timeRequired: '00:10',
+            markupMultiplier: 1.111,
+            hourlyRate: 3,
+        });
+
+        // 10 * 1.111 = 11.11, + (10/60)*3 = 0.5 -> 11.61
+        expect(result).toBeCloseTo(11.61, 2);
+    });
+
+    it('returns 0 for an unparseable timeRequired without throwing', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 5,
+            timeRequired: '',
+            markupMultiplier: 2,
+            hourlyRate: 10,
+        });
+
+        // materialsCost * markupMultiplier = 10, + 0 hours (unparseable -> NaN -> treated as 0)
+        expect(result).toBe(10);
+    });
+});

--- a/packages/web/src/utils/getSuggestedPrice/index.ts
+++ b/packages/web/src/utils/getSuggestedPrice/index.ts
@@ -1,0 +1,20 @@
+import { getWageCosts } from '../getWageCost';
+
+interface GetSuggestedPriceArgs {
+    materialsCost: number;
+    timeRequired: string;
+    markupMultiplier: number;
+    hourlyRate: number;
+}
+
+export const getSuggestedPrice = ({
+    materialsCost,
+    timeRequired,
+    markupMultiplier,
+    hourlyRate,
+}: GetSuggestedPriceArgs): number => {
+    const hours = timeRequired ? getWageCosts(timeRequired) : 0;
+    const safeHours = Number.isFinite(hours) ? hours : 0;
+    const suggested = materialsCost * markupMultiplier + safeHours * hourlyRate;
+    return parseFloat(suggested.toFixed(2));
+};


### PR DESCRIPTION
## Summary
- Adds private "maker docs" to Designs — diagram photos (`diagramImageIds`) and free-text notes (`makingNotes`) that reuse the existing image upload pipeline but are kept structurally separate from Etsy-facing product photos (no Etsy code touched; this is sub-project 2 of the Etsy integration spec and doesn't depend on OAuth).
- Adds a read-only price-suggestion formula (`materialsCost × markupMultiplier + hours × hourlyRate`, defaults `2.5`/`0`) shown beside the price field on Add/Edit Design and per-variant in the variation builder, with an explicit "Use this price" button as the only write path — never auto-applied.
- New `markupMultiplier`/`hourlyRate` settings on `/settings`.

## Test plan
- [x] Full api test suite: 177 pass / 0 fail (`bun test` in `packages/api`)
- [x] Web util tests: 4/4 pass (`getSuggestedPrice`)
- [x] Typecheck: verified via `tsc --build --force` against a pre-plan baseline (repo's `tsc --noEmit` is a known no-op due to a solution-style tsconfig — flagging separately, out of scope for this PR)
- [x] Lint (Biome) clean on all touched files
- [x] Manual smoke test of `/addDesign` via Playwright (Maker Docs section, suggested price display, "Use this price" button) — `DesignEditForm` wiring is structurally identical but not runtime-verified due to a pre-existing, unrelated sandbox limitation (no seeded DB data + mock-auth-server bug)
- [x] 12-task implementation plan executed with a fresh subagent + reviewer per task, plus a final whole-branch review — all clean, zero Critical/Important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)