### PR TITLE
feat: push to Etsy as draft listing (stacked on #36)

### DIFF
--- a/packages/api/src/dependencies/index.test.ts
+++ b/packages/api/src/dependencies/index.test.ts
@@ -72,11 +72,11 @@ describe('Dependencies', () => {
             expect(container.constructors?.[DependencyToken.DesignService]).toBeDefined();
         });
 
-        it('should register exactly 18 dependencies', () => {
+        it('should register exactly 19 dependencies', () => {
             registerDepdendencies();
             const container = dependencyContainer as any;
             const registeredCount = Object.keys(container.constructors || {}).length;
-            expect(registeredCount).toBe(18);
+            expect(registeredCount).toBe(19);
         });
 
         it('should register all expected tokens', () => {

--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -7,6 +7,7 @@ import { DraftService } from '../domain/DraftService';
 import { EtsyClient } from '../domain/EtsyClient';
 import { EtsyConnectionService } from '../domain/EtsyConnectionService';
 import { EtsyOAuthStateStore } from '../domain/EtsyOAuthStateStore';
+import { EtsyPushService } from '../domain/EtsyPushService';
 import { ImageService } from '../domain/ImageService';
 import { MaterialService } from '../domain/MaterialService';
 import { UserSettingsService } from '../domain/UserSettingsService';
@@ -178,6 +179,21 @@ export const registerDepdendencies = () => {
                     dependencyContainer.resolve(DependencyToken.EtsyConnectionRepository),
                     dependencyContainer.resolve(DependencyToken.EtsyOAuthStateStore),
                     config.get('etsyRedirectUri')
+                );
+            }
+        } as any
+    );
+
+    dependencyContainer.registerSingleton(
+        DependencyToken.EtsyPushService,
+        class {
+            constructor() {
+                return new EtsyPushService(
+                    dependencyContainer.resolve(DependencyToken.DesignRepository),
+                    dependencyContainer.resolve(DependencyToken.ImageService),
+                    dependencyContainer.resolve(DependencyToken.EtsyClient),
+                    dependencyContainer.resolve(DependencyToken.EtsyConnectionService),
+                    dependencyContainer.resolve(DependencyToken.UserSettingsService)
                 );
             }
         } as any

--- a/packages/api/src/dependencies/types.ts
+++ b/packages/api/src/dependencies/types.ts
@@ -9,6 +9,7 @@ import type { EtsyClient } from '../domain/EtsyClient';
 import type { EtsyConnectionRepository } from '../domain/EtsyConnectionRepository';
 import type { EtsyConnectionService } from '../domain/EtsyConnectionService';
 import type { EtsyOAuthStateStore } from '../domain/EtsyOAuthStateStore';
+import type { EtsyPushService } from '../domain/EtsyPushService';
 import type { IdGenerator } from '../domain/IdGenerator';
 import type { ImageService } from '../domain/ImageService';
 import type { ImageStore } from '../domain/ImageService/types';
@@ -43,6 +44,7 @@ export enum DependencyToken {
     DraftService = 'DraftService',
     UserSettingsService = 'UserSettingsService',
     EtsyConnectionService = 'EtsyConnectionService',
+    EtsyPushService = 'EtsyPushService',
     // Infrastructure
     IdGenerator = 'IdGenerator',
     ImageStore = 'ImageStore',
@@ -68,6 +70,7 @@ export type Dependencies = {
     [DependencyToken.DraftService]: DraftService;
     [DependencyToken.UserSettingsService]: UserSettingsService;
     [DependencyToken.EtsyConnectionService]: EtsyConnectionService;
+    [DependencyToken.EtsyPushService]: EtsyPushService;
     // Infrastructure
     [DependencyToken.IdGenerator]: IdGenerator;
     [DependencyToken.ImageStore]: ImageStore;

--- a/packages/api/src/domain/EtsyClient/index.test.ts
+++ b/packages/api/src/domain/EtsyClient/index.test.ts
@@ -143,4 +143,168 @@ describe('EtsyClient', () => {
             expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839');
         });
     });
+
+    describe('createDraftListing', () => {
+        it('posts the mapped body to the shop listings endpoint and maps the response', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_id: 999 }), { status: 200 }));
+
+            const result = await client.createDraftListing('at-token', 47408839, {
+                title: 'Silver Ring',
+                description: 'A lovely ring.',
+                price: 25.5,
+                quantity: 3,
+                whoMade: 'i_did',
+                whenMade: 'made_to_order',
+                taxonomyId: 1234,
+            });
+
+            expect(result).toEqual({ listingId: 999 });
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings');
+            expect(options.method).toBe('POST');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+            expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+            const body = JSON.parse(options.body as string);
+            expect(body).toEqual({
+                quantity: 3,
+                title: 'Silver Ring',
+                description: 'A lovely ring.',
+                price: 25.5,
+                who_made: 'i_did',
+                when_made: 'made_to_order',
+                taxonomy_id: 1234,
+            });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ error: 'bad taxonomy' }), { status: 400 }));
+
+            await expect(
+                client.createDraftListing('at', 1, {
+                    title: 't',
+                    description: 'd',
+                    price: 1,
+                    quantity: 1,
+                    whoMade: 'i_did',
+                    whenMade: 'made_to_order',
+                    taxonomyId: 1,
+                })
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('uploadListingImage', () => {
+        it('posts a multipart form with the image and rank', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_image_id: 1 }), { status: 200 }));
+
+            await client.uploadListingImage(
+                'at-token',
+                47408839,
+                999,
+                { buffer: Buffer.from('fake-image-bytes'), contentType: 'image/png', filename: 'photo.png' },
+                1
+            );
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/999/images');
+            expect(options.method).toBe('POST');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+            expect(options.body).toBeInstanceOf(FormData);
+            const form = options.body as FormData;
+            expect(form.get('rank')).toBe('1');
+            expect(form.get('image')).toBeInstanceOf(Blob);
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
+
+            await expect(
+                client.uploadListingImage(
+                    'at',
+                    1,
+                    1,
+                    { buffer: Buffer.from('x'), contentType: 'image/png', filename: 'x.png' },
+                    0
+                )
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('getListingImages', () => {
+        it('fetches and maps the listing image ids', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(JSON.stringify({ results: [{ listing_image_id: 111 }, { listing_image_id: 222 }] }), {
+                    status: 200,
+                })
+            );
+
+            const result = await client.getListingImages('at-token', 999);
+
+            expect(result).toEqual({ imageIds: [111, 222] });
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999/images');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+        });
+    });
+
+    describe('updateListingInventory', () => {
+        it('maps property values and offerings into the Etsy inventory body', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+            await client.updateListingInventory('at-token', 999, [
+                {
+                    propertyValues: [{ propertyName: 'Colour', values: ['Silver'] }],
+                    offering: { price: 25.5, quantity: 3, isEnabled: true },
+                },
+            ]);
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999/inventory');
+            expect(options.method).toBe('PUT');
+            const body = JSON.parse(options.body as string);
+            expect(body).toEqual({
+                products: [
+                    {
+                        property_values: [{ property_id: null, property_name: 'Colour', values: ['Silver'] }],
+                        offerings: [{ price: 25.5, quantity: 3, is_enabled: true }],
+                    },
+                ],
+            });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 400 }));
+
+            await expect(client.updateListingInventory('at', 1, [])).rejects.toThrow();
+        });
+    });
+
+    describe('getSellerTaxonomyNodes', () => {
+        it('fetches and maps the nested taxonomy tree', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        results: [
+                            {
+                                id: 1,
+                                name: 'Jewelry',
+                                children: [{ id: 2, name: 'Rings', children: [] }],
+                            },
+                        ],
+                    }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getSellerTaxonomyNodes();
+
+            expect(result).toEqual([{ id: 1, name: 'Jewelry', children: [{ id: 2, name: 'Rings', children: [] }] }]);
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/seller-taxonomy/nodes');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+        });
+    });
 });

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -245,6 +245,7 @@ export class EtsyClient {
         }
     }
 
+    // fallow-ignore-next-line unused-class-member
     async getSellerTaxonomyNodes(): Promise<EtsyTaxonomyNode[]> {
         const response = await fetch(`${API_BASE}/seller-taxonomy/nodes`, {
             headers: { 'x-api-key': this.apiKeyHeader() },

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -10,6 +10,31 @@ export interface EtsyTokenResponse {
     expiresIn: number;
 }
 
+export interface EtsyDraftListingInput {
+    title: string;
+    description: string;
+    price: number;
+    quantity: number;
+    whoMade: string;
+    whenMade: string;
+    taxonomyId: number;
+}
+
+export interface EtsyListingResult {
+    listingId: number;
+}
+
+export interface EtsyInventoryProduct {
+    propertyValues: Array<{ propertyName: string; values: string[] }>;
+    offering: { price: number; quantity: number; isEnabled: boolean };
+}
+
+export interface EtsyTaxonomyNode {
+    id: number;
+    name: string;
+    children: EtsyTaxonomyNode[];
+}
+
 const base64UrlEncode = (input: Buffer): string =>
     input.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 
@@ -114,5 +139,131 @@ export class EtsyClient {
 
         const body = (await response.json()) as { shop_id: number; shop_name: string };
         return { shopId: body.shop_id, shopName: body.shop_name };
+    }
+
+    async createDraftListing(
+        accessToken: string,
+        shopId: number,
+        input: EtsyDraftListingInput
+    ): Promise<EtsyListingResult> {
+        const response = await fetch(`${API_BASE}/shops/${shopId}/listings`, {
+            method: 'POST',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                quantity: input.quantity,
+                title: input.title,
+                description: input.description,
+                price: input.price,
+                who_made: input.whoMade,
+                when_made: input.whenMade,
+                taxonomy_id: input.taxonomyId,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy createDraftListing failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { listing_id: number };
+        return { listingId: body.listing_id };
+    }
+
+    async uploadListingImage(
+        accessToken: string,
+        shopId: number,
+        listingId: number,
+        image: { buffer: Buffer; contentType: string; filename: string },
+        rank: number
+    ): Promise<void> {
+        const form = new FormData();
+        form.append('image', new Blob([image.buffer], { type: image.contentType }), image.filename);
+        form.append('rank', String(rank));
+
+        const response = await fetch(`${API_BASE}/shops/${shopId}/listings/${listingId}/images`, {
+            method: 'POST',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+            },
+            body: form,
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy uploadListingImage failed: ${response.status} ${await response.text()}`);
+        }
+    }
+
+    async getListingImages(accessToken: string, listingId: number): Promise<{ imageIds: number[] }> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}/images`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getListingImages failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { results: Array<{ listing_image_id: number }> };
+        return { imageIds: body.results.map((r) => r.listing_image_id) };
+    }
+
+    async updateListingInventory(
+        accessToken: string,
+        listingId: number,
+        products: EtsyInventoryProduct[]
+    ): Promise<void> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}/inventory`, {
+            method: 'PUT',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                products: products.map((p) => ({
+                    property_values: p.propertyValues.map((pv) => ({
+                        property_id: null,
+                        property_name: pv.propertyName,
+                        values: pv.values,
+                    })),
+                    offerings: [
+                        {
+                            price: p.offering.price,
+                            quantity: p.offering.quantity,
+                            is_enabled: p.offering.isEnabled,
+                        },
+                    ],
+                })),
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy updateListingInventory failed: ${response.status} ${await response.text()}`);
+        }
+    }
+
+    async getSellerTaxonomyNodes(): Promise<EtsyTaxonomyNode[]> {
+        const response = await fetch(`${API_BASE}/seller-taxonomy/nodes`, {
+            headers: { 'x-api-key': this.apiKeyHeader() },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getSellerTaxonomyNodes failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as {
+            results: Array<{ id: number; name: string; children?: unknown[] }>;
+        };
+
+        const mapNode = (n: { id: number; name: string; children?: unknown[] }): EtsyTaxonomyNode => ({
+            id: n.id,
+            name: n.name,
+            children: ((n.children ?? []) as Array<{ id: number; name: string; children?: unknown[] }>).map(mapNode),
+        });
+
+        return body.results.map(mapNode);
     }
 }

--- a/packages/api/src/domain/EtsyConnectionService/index.test.ts
+++ b/packages/api/src/domain/EtsyConnectionService/index.test.ts
@@ -201,4 +201,27 @@ describe('EtsyConnectionService', () => {
             await expect(service.getValidAccessToken('user-1')).rejects.toThrow();
         });
     });
+
+    describe('getPushCredentials', () => {
+        it('returns the valid access token together with the stored shopId', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(
+                makeConnection({
+                    accessToken: 'still-fresh',
+                    accessTokenExpiresAt: Date.now() + 120_000,
+                    shopId: 47408839,
+                })
+            );
+
+            const result = await service.getPushCredentials('user-1');
+
+            expect(result).toEqual({ accessToken: 'still-fresh', shopId: 47408839 });
+            expect(mockEtsyClient.refreshAccessToken).not.toHaveBeenCalled();
+        });
+
+        it('throws when there is no connection', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(null);
+
+            await expect(service.getPushCredentials('user-1')).rejects.toThrow();
+        });
+    });
 });

--- a/packages/api/src/domain/EtsyConnectionService/index.ts
+++ b/packages/api/src/domain/EtsyConnectionService/index.ts
@@ -74,7 +74,6 @@ export class EtsyConnectionService {
         await this.connectionRepo.deleteByUserId(userId);
     }
 
-    // fallow-ignore-next-line unused-class-member
     async getValidAccessToken(userId: string): Promise<string> {
         const connection = await this.connectionRepo.getByUserId(userId);
         if (!connection) {
@@ -100,5 +99,14 @@ export class EtsyConnectionService {
             await this.connectionRepo.upsert({ ...connection, broken: true });
             throw new APIError('Etsy connection is broken — reconnect required', 409);
         }
+    }
+
+    async getPushCredentials(userId: string): Promise<{ accessToken: string; shopId: number }> {
+        const accessToken = await this.getValidAccessToken(userId);
+        const connection = await this.connectionRepo.getByUserId(userId);
+        if (!connection) {
+            throw new APIError('Etsy is not connected', 400);
+        }
+        return { accessToken, shopId: connection.shopId };
     }
 }

--- a/packages/api/src/domain/EtsyPushService/index.test.ts
+++ b/packages/api/src/domain/EtsyPushService/index.test.ts
@@ -183,6 +183,45 @@ describe('EtsyPushService', () => {
         });
     });
 
+    describe('push — crash safety and resume', () => {
+        it('persists pushIncomplete:true right after listing creation, propagates a later failure, then resumes without re-creating the listing', async () => {
+            // Phase 1: createDraftListing succeeds, uploadListingImage crashes mid-flow.
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+            mockEtsyClient.uploadListingImage.mockRejectedValue(new Error('network fail'));
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow('network fail');
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledTimes(1);
+            expect(mockDesignRepo.update).toHaveBeenCalledTimes(1);
+            expect(mockDesignRepo.update).toHaveBeenCalledWith(
+                'design-1',
+                expect.objectContaining({
+                    etsy: { listingId: 999, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+                })
+            );
+
+            // Phase 2: resumed push picks up the persisted listingId and completes.
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    etsy: { listingId: 999, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+                })
+            );
+            mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [] });
+            mockEtsyClient.uploadListingImage.mockResolvedValue(undefined);
+
+            const result = await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledTimes(1);
+            expect(result.etsy).toEqual({
+                listingId: 999,
+                state: 'draft',
+                lastPushedAt: expect.any(Number),
+                pushIncomplete: false,
+            });
+        });
+    });
+
     describe('push — variations', () => {
         it('builds and puts inventory when the design has variation groups and variants', async () => {
             mockDesignRepo.getByIdAndUserId.mockResolvedValue(

--- a/packages/api/src/domain/EtsyPushService/index.test.ts
+++ b/packages/api/src/domain/EtsyPushService/index.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Readable } from 'node:stream';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import type { ImageService } from '../ImageService';
+import type { UserSettingsService } from '../UserSettingsService';
+import { EtsyPushService } from './index';
+
+const mockDesignRepo = { getByIdAndUserId: mock(), update: mock() };
+const mockImageService = { getImage: mock(), uploadImage: mock() };
+const mockEtsyClient = {
+    createDraftListing: mock(),
+    uploadListingImage: mock(),
+    getListingImages: mock(),
+    updateListingInventory: mock(),
+    getSellerTaxonomyNodes: mock(),
+};
+const mockEtsyConnectionService = { getPushCredentials: mock() };
+const mockUserSettingsService = { get: mock() };
+
+function makeDesign(overrides: Partial<Design> = {}): Design {
+    return {
+        id: 'design-1',
+        userId: 'user-1',
+        name: 'Silver Ring',
+        description: 'A lovely ring.',
+        timeRequired: '01:00',
+        materials: [],
+        imageIds: ['img-1'],
+        diagramImageIds: ['diagram-1'],
+        makingNotes: 'private notes',
+        price: 25,
+        totalMaterialCosts: 10,
+        dateAdded: new Date(),
+        totalQuantity: 2,
+        designType: 'RING' as Design['designType'],
+        ...overrides,
+    };
+}
+
+describe('EtsyPushService', () => {
+    let service: EtsyPushService;
+
+    beforeEach(() => {
+        [
+            ...Object.values(mockDesignRepo),
+            ...Object.values(mockImageService),
+            ...Object.values(mockEtsyClient),
+            ...Object.values(mockEtsyConnectionService),
+            ...Object.values(mockUserSettingsService),
+        ].forEach((m) => {
+            m.mockClear();
+        });
+
+        service = new EtsyPushService(
+            mockDesignRepo as unknown as DesignRepository,
+            mockImageService as unknown as ImageService,
+            mockEtsyClient as unknown as EtsyClient,
+            mockEtsyConnectionService as unknown as EtsyConnectionService,
+            mockUserSettingsService as unknown as UserSettingsService
+        );
+
+        mockEtsyConnectionService.getPushCredentials.mockResolvedValue({
+            accessToken: 'at-token',
+            shopId: 47408839,
+        });
+        mockUserSettingsService.get.mockResolvedValue({
+            userId: 'user-1',
+            hourlyWage: 10,
+            profitMargin: 15,
+            markupMultiplier: 2.5,
+            hourlyRate: 0,
+            etsyDescriptionTemplate: '{description}',
+            etsyTaxonomyMap: { RING: 1234 },
+        });
+        mockImageService.getImage.mockResolvedValue({
+            stream: Readable.from([Buffer.from('fake-image-bytes')]),
+            contentType: 'image/png',
+            cacheControl: 'public',
+        });
+        mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [] });
+    });
+
+    describe('push — new listing (no prior etsy.listingId)', () => {
+        it('creates the listing, uploads only product photos (never diagram images), and persists the etsy block', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            const result = await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledWith(
+                'at-token',
+                47408839,
+                expect.objectContaining({ title: 'Silver Ring', taxonomyId: 1234, quantity: 2 })
+            );
+
+            expect(mockImageService.getImage).toHaveBeenCalledTimes(1);
+            expect(mockImageService.getImage).toHaveBeenCalledWith('img-1');
+            expect(mockImageService.getImage).not.toHaveBeenCalledWith('diagram-1');
+            expect(mockEtsyClient.uploadListingImage).toHaveBeenCalledTimes(1);
+
+            expect(mockEtsyClient.updateListingInventory).not.toHaveBeenCalled();
+
+            expect(result.etsy).toEqual({
+                listingId: 999,
+                state: 'draft',
+                lastPushedAt: expect.any(Number),
+                pushIncomplete: false,
+            });
+
+            const lastUpdateCall = mockDesignRepo.update.mock.calls.at(-1) as [string, Design];
+            expect(lastUpdateCall[1].etsy?.pushIncomplete).toBe(false);
+        });
+
+        it('rejects when the design has more than 2 variation groups, before calling Etsy at all', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    variationGroups: [
+                        { id: 'g1', name: 'A', required: 1, options: [] },
+                        { id: 'g2', name: 'B', required: 1, options: [] },
+                        { id: 'g3', name: 'C', required: 1, options: [] },
+                    ],
+                })
+            );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects when there is no taxonomy mapping for the design type', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({ designType: 'NECKLACE' as Design['designType'] })
+            );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects re-push when the design already has a completed etsy.listingId', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    etsy: { listingId: 555, state: 'draft', lastPushedAt: Date.now(), pushIncomplete: false },
+                })
+            );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('uses the provided description/price overrides instead of re-rendering the template', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            await service.push('design-1', 'user-1', { description: 'Edited by hand', price: 30 });
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledWith(
+                'at-token',
+                47408839,
+                expect.objectContaining({ description: 'Edited by hand', price: 30 })
+            );
+        });
+    });
+
+    describe('push — resume (pushIncomplete: true)', () => {
+        it('does not re-create the listing, and skips images Etsy already has', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    imageIds: ['img-1', 'img-2'],
+                    etsy: { listingId: 999, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+                })
+            );
+            mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [111] });
+
+            await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+            expect(mockImageService.getImage).toHaveBeenCalledTimes(1);
+            expect(mockImageService.getImage).toHaveBeenCalledWith('img-2');
+            expect(mockEtsyClient.uploadListingImage).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('push — variations', () => {
+        it('builds and puts inventory when the design has variation groups and variants', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    variationGroups: [
+                        {
+                            id: 'g1',
+                            name: 'Colour',
+                            required: 1,
+                            options: [{ id: 'opt-1', material: { id: 'm1', name: 'Silver' } as any }],
+                        },
+                    ],
+                    variants: [
+                        {
+                            id: 'v1',
+                            optionIds: ['opt-1'],
+                            name: 'Silver',
+                            totalQuantity: 5,
+                            totalMaterialCosts: 3,
+                            price: 20,
+                        },
+                    ],
+                })
+            );
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.updateListingInventory).toHaveBeenCalledWith(
+                'at-token',
+                999,
+                expect.arrayContaining([
+                    expect.objectContaining({ offering: { price: 20, quantity: 5, isEnabled: true } }),
+                ])
+            );
+        });
+    });
+});

--- a/packages/api/src/domain/EtsyPushService/index.ts
+++ b/packages/api/src/domain/EtsyPushService/index.ts
@@ -1,0 +1,102 @@
+import { APIError } from '@imapps/api-utils/hono';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import type { ImageService } from '../ImageService';
+import type { UserSettingsService } from '../UserSettingsService';
+import { buildDraftListingInput, buildInventoryProducts, renderDescriptionTemplate } from './mappers';
+
+const MAX_VARIATION_GROUPS = 2;
+
+async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as ArrayBufferLike));
+    }
+    return Buffer.concat(chunks);
+}
+
+export class EtsyPushService {
+    constructor(
+        private readonly designRepo: DesignRepository,
+        private readonly imageService: ImageService,
+        private readonly etsyClient: EtsyClient,
+        private readonly etsyConnectionService: EtsyConnectionService,
+        private readonly userSettingsService: UserSettingsService
+    ) {}
+
+    async push(
+        designId: string,
+        userId: string,
+        overrides: { description?: string; price?: number } = {}
+    ): Promise<Design> {
+        const design = await this.designRepo.getByIdAndUserId(designId, userId);
+        if (!design) {
+            throw new APIError('Design not found', 404);
+        }
+
+        if (design.etsy?.listingId && !design.etsy.pushIncomplete) {
+            throw new APIError('Design is already on Etsy', 409);
+        }
+
+        const groups = design.variationGroups ?? [];
+        if (groups.length > MAX_VARIATION_GROUPS) {
+            throw new APIError(`Etsy supports at most ${MAX_VARIATION_GROUPS} variation properties`, 400);
+        }
+
+        const settings = await this.userSettingsService.get(userId);
+        const { accessToken, shopId } = await this.etsyConnectionService.getPushCredentials(userId);
+
+        let listingId = design.etsy?.listingId;
+
+        if (!listingId) {
+            const taxonomyId = design.designType ? settings.etsyTaxonomyMap[design.designType] : undefined;
+            if (!taxonomyId) {
+                throw new APIError('No Etsy category is mapped for this design type', 400);
+            }
+
+            const description =
+                overrides.description ?? renderDescriptionTemplate(settings.etsyDescriptionTemplate, design);
+            const price = overrides.price ?? design.price;
+
+            const draftInput = buildDraftListingInput({ design, description, price, taxonomyId });
+            const created = await this.etsyClient.createDraftListing(accessToken, shopId, draftInput);
+            listingId = created.listingId;
+
+            await this.designRepo.update(designId, {
+                ...design,
+                etsy: { listingId, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+            });
+        }
+
+        const alreadyUploaded = await this.etsyClient.getListingImages(accessToken, listingId);
+        const remainingImageIds = design.imageIds.slice(alreadyUploaded.imageIds.length);
+
+        for (const [index, imageId] of remainingImageIds.entries()) {
+            const image = await this.imageService.getImage(imageId);
+            const buffer = await streamToBuffer(image.stream);
+            await this.etsyClient.uploadListingImage(
+                accessToken,
+                shopId,
+                listingId,
+                { buffer, contentType: image.contentType, filename: imageId },
+                alreadyUploaded.imageIds.length + index + 1
+            );
+        }
+
+        if (groups.length > 0 && design.variants && design.variants.length > 0) {
+            const products = buildInventoryProducts(design.variants, groups);
+            await this.etsyClient.updateListingInventory(accessToken, listingId, products);
+        }
+
+        const updated: Design = {
+            ...design,
+            etsy: { listingId, state: 'draft', lastPushedAt: Date.now(), pushIncomplete: false },
+        };
+        await this.designRepo.update(designId, updated);
+
+        return updated;
+    }
+}

--- a/packages/api/src/domain/EtsyPushService/mappers.test.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'bun:test';
+import type { DesignVariant, RequiredMaterial, VariationGroup } from '@jewellery-catalogue/types';
+
+import { buildDraftListingInput, buildInventoryProducts, renderDescriptionTemplate } from './mappers';
+
+const material = (name: string): RequiredMaterial =>
+    ({ id: `mat-${name}`, name, type: 'BEAD', requiredQuantity: 1 }) as unknown as RequiredMaterial;
+
+describe('renderDescriptionTemplate', () => {
+    it('substitutes {description} and {materials} placeholders', () => {
+        const result = renderDescriptionTemplate('{description}\n\nMaterials: {materials}', {
+            description: 'A lovely ring.',
+            materials: [material('Silver wire'), material('Moonstone bead')],
+        });
+
+        expect(result).toBe('A lovely ring.\n\nMaterials: Silver wire, Moonstone bead');
+    });
+
+    it('handles a template with no placeholders unchanged', () => {
+        const result = renderDescriptionTemplate('Static text only', { description: 'ignored', materials: [] });
+        expect(result).toBe('Static text only');
+    });
+
+    it('handles an empty materials list', () => {
+        const result = renderDescriptionTemplate('{description} ({materials})', {
+            description: 'A ring.',
+            materials: [],
+        });
+        expect(result).toBe('A ring. ()');
+    });
+});
+
+describe('buildDraftListingInput', () => {
+    it('maps design + resolved fields into the fixed-field Etsy draft listing shape', () => {
+        const result = buildDraftListingInput({
+            design: { name: 'Silver Ring', price: 25.5, totalQuantity: 3 },
+            description: 'A lovely ring.',
+            price: 25.5,
+            taxonomyId: 1234,
+        });
+
+        expect(result).toEqual({
+            title: 'Silver Ring',
+            description: 'A lovely ring.',
+            price: 25.5,
+            quantity: 3,
+            whoMade: 'i_did',
+            whenMade: 'made_to_order',
+            taxonomyId: 1234,
+        });
+    });
+
+    it('floors quantity at 1 when totalQuantity is 0', () => {
+        const result = buildDraftListingInput({
+            design: { name: 'Ring', price: 10, totalQuantity: 0 },
+            description: 'd',
+            price: 10,
+            taxonomyId: 1,
+        });
+
+        expect(result.quantity).toBe(1);
+    });
+});
+
+describe('buildInventoryProducts', () => {
+    it('maps each variant to a product with one property value per group and one offering', () => {
+        const groups: VariationGroup[] = [
+            {
+                id: 'group-1',
+                name: 'Colour',
+                required: 1,
+                options: [
+                    { id: 'opt-silver', material: material('Silver') },
+                    { id: 'opt-gold', material: material('Gold') },
+                ],
+            },
+        ];
+        const variants: DesignVariant[] = [
+            {
+                id: 'variant-1',
+                optionIds: ['opt-silver'],
+                name: 'Silver',
+                totalQuantity: 5,
+                totalMaterialCosts: 3,
+                price: 20,
+            },
+            {
+                id: 'variant-2',
+                optionIds: ['opt-gold'],
+                name: 'Gold',
+                totalQuantity: 2,
+                totalMaterialCosts: 4,
+                price: 30,
+            },
+        ];
+
+        const result = buildInventoryProducts(variants, groups);
+
+        expect(result).toEqual([
+            {
+                propertyValues: [{ propertyName: 'Colour', values: ['Silver'] }],
+                offering: { price: 20, quantity: 5, isEnabled: true },
+            },
+            {
+                propertyValues: [{ propertyName: 'Colour', values: ['Gold'] }],
+                offering: { price: 30, quantity: 2, isEnabled: true },
+            },
+        ]);
+    });
+
+    it('maps a variant spanning two groups to two property values', () => {
+        const groups: VariationGroup[] = [
+            {
+                id: 'group-1',
+                name: 'Colour',
+                required: 1,
+                options: [{ id: 'opt-silver', material: material('Silver') }],
+            },
+            {
+                id: 'group-2',
+                name: 'Size',
+                required: 1,
+                options: [{ id: 'opt-small', material: material('Small') }],
+            },
+        ];
+        const variants: DesignVariant[] = [
+            {
+                id: 'variant-1',
+                optionIds: ['opt-silver', 'opt-small'],
+                name: 'Silver / Small',
+                totalQuantity: 1,
+                totalMaterialCosts: 3,
+                price: 20,
+            },
+        ];
+
+        const result = buildInventoryProducts(variants, groups);
+
+        expect(result).toEqual([
+            {
+                propertyValues: [
+                    { propertyName: 'Colour', values: ['Silver'] },
+                    { propertyName: 'Size', values: ['Small'] },
+                ],
+                offering: { price: 20, quantity: 1, isEnabled: true },
+            },
+        ]);
+    });
+});

--- a/packages/api/src/domain/EtsyPushService/mappers.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.ts
@@ -1,0 +1,41 @@
+import type { Design, DesignVariant, RequiredMaterial, VariationGroup } from '@jewellery-catalogue/types';
+
+import type { EtsyDraftListingInput, EtsyInventoryProduct } from '../EtsyClient';
+
+export const renderDescriptionTemplate = (
+    template: string,
+    design: { description: string; materials: RequiredMaterial[] }
+): string => {
+    const materialsList = design.materials.map((m) => m.name).join(', ');
+    return template.replace(/\{description\}/g, design.description).replace(/\{materials\}/g, materialsList);
+};
+
+export const buildDraftListingInput = (args: {
+    design: Pick<Design, 'name' | 'price' | 'totalQuantity'>;
+    description: string;
+    price: number;
+    taxonomyId: number;
+}): EtsyDraftListingInput => ({
+    title: args.design.name,
+    description: args.description,
+    price: args.price,
+    quantity: Math.max(1, args.design.totalQuantity),
+    whoMade: 'i_did',
+    whenMade: 'made_to_order',
+    taxonomyId: args.taxonomyId,
+});
+
+export const buildInventoryProducts = (variants: DesignVariant[], groups: VariationGroup[]): EtsyInventoryProduct[] =>
+    variants.map((variant) => {
+        const propertyValues = groups
+            .map((group) => {
+                const option = group.options.find((o) => variant.optionIds.includes(o.id));
+                return option ? { propertyName: group.name, values: [option.material.name] } : null;
+            })
+            .filter((pv): pv is { propertyName: string; values: string[] } => pv !== null);
+
+        return {
+            propertyValues,
+            offering: { price: variant.price, quantity: variant.totalQuantity, isEnabled: true },
+        };
+    });

--- a/packages/api/src/domain/UserSettingsService/index.test.ts
+++ b/packages/api/src/domain/UserSettingsService/index.test.ts
@@ -67,12 +67,12 @@ describe('UserSettingsService', () => {
     });
 
     describe('get — etsy fields', () => {
-        it('returns empty-string template and empty taxonomy map defaults when no settings stored', async () => {
+        it('returns {description} template and empty taxonomy map defaults when no settings stored', async () => {
             mockSettingsRepo.getByUserId.mockResolvedValue(null);
 
             const result = await service.get('user-1');
 
-            expect(result.etsyDescriptionTemplate).toBe('');
+            expect(result.etsyDescriptionTemplate).toBe('{description}');
             expect(result.etsyTaxonomyMap).toEqual({});
         });
 
@@ -106,7 +106,7 @@ describe('UserSettingsService', () => {
 
             expect(result.markupMultiplier).toBe(2.5);
             expect(result.hourlyRate).toBe(0);
-            expect(result.etsyDescriptionTemplate).toBe('');
+            expect(result.etsyDescriptionTemplate).toBe('{description}');
             expect(result.etsyTaxonomyMap).toEqual({});
             expect(result.hourlyWage).toBe(10);
             expect(result.profitMargin).toBe(15);
@@ -120,6 +120,8 @@ describe('UserSettingsService', () => {
                 profitMargin: 20,
                 markupMultiplier: 2,
                 hourlyRate: 8,
+                etsyDescriptionTemplate: 'test template',
+                etsyTaxonomyMap: { RING: 999 },
             });
 
             expect(result).toEqual({
@@ -128,6 +130,8 @@ describe('UserSettingsService', () => {
                 profitMargin: 20,
                 markupMultiplier: 2,
                 hourlyRate: 8,
+                etsyDescriptionTemplate: 'test template',
+                etsyTaxonomyMap: { RING: 999 },
             });
             expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
         });

--- a/packages/api/src/domain/UserSettingsService/index.test.ts
+++ b/packages/api/src/domain/UserSettingsService/index.test.ts
@@ -66,6 +66,53 @@ describe('UserSettingsService', () => {
         });
     });
 
+    describe('get — etsy fields', () => {
+        it('returns empty-string template and empty taxonomy map defaults when no settings stored', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue(null);
+
+            const result = await service.get('user-1');
+
+            expect(result.etsyDescriptionTemplate).toBe('');
+            expect(result.etsyTaxonomyMap).toEqual({});
+        });
+
+        it('returns stored etsyDescriptionTemplate and etsyTaxonomyMap when present', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue({
+                userId: 'user-1',
+                hourlyWage: 10,
+                profitMargin: 15,
+                markupMultiplier: 2.5,
+                hourlyRate: 0,
+                etsyDescriptionTemplate: '{description}\n\nMaterials: {materials}',
+                etsyTaxonomyMap: { RING: 1234 },
+            });
+
+            const result = await service.get('user-1');
+
+            expect(result.etsyDescriptionTemplate).toBe('{description}\n\nMaterials: {materials}');
+            expect(result.etsyTaxonomyMap).toEqual({ RING: 1234 });
+        });
+
+        it('backfills defaults for a stored document that predates this migration (missing the new fields entirely)', async () => {
+            mockSettingsRepo.getByUserId.mockResolvedValue({
+                userId: 'user-1',
+                hourlyWage: 10,
+                profitMargin: 15,
+                // no markupMultiplier/hourlyRate/etsyDescriptionTemplate/etsyTaxonomyMap — simulates a
+                // pre-sub-project-2 document that Mongo happily stored without the newer required fields
+            } as any);
+
+            const result = await service.get('user-1');
+
+            expect(result.markupMultiplier).toBe(2.5);
+            expect(result.hourlyRate).toBe(0);
+            expect(result.etsyDescriptionTemplate).toBe('');
+            expect(result.etsyTaxonomyMap).toEqual({});
+            expect(result.hourlyWage).toBe(10);
+            expect(result.profitMargin).toBe(15);
+        });
+    });
+
     describe('upsert — price suggestion fields', () => {
         it('persists markupMultiplier and hourlyRate alongside the existing fields', async () => {
             const result = await service.upsert('user-1', {
@@ -81,6 +128,30 @@ describe('UserSettingsService', () => {
                 profitMargin: 20,
                 markupMultiplier: 2,
                 hourlyRate: 8,
+            });
+            expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
+        });
+    });
+
+    describe('upsert — etsy fields', () => {
+        it('persists etsyDescriptionTemplate and etsyTaxonomyMap alongside the existing fields', async () => {
+            const result = await service.upsert('user-1', {
+                hourlyWage: 12,
+                profitMargin: 20,
+                markupMultiplier: 2,
+                hourlyRate: 8,
+                etsyDescriptionTemplate: 'Handmade: {description}',
+                etsyTaxonomyMap: { EARRINGS: 5678 },
+            });
+
+            expect(result).toEqual({
+                userId: 'user-1',
+                hourlyWage: 12,
+                profitMargin: 20,
+                markupMultiplier: 2,
+                hourlyRate: 8,
+                etsyDescriptionTemplate: 'Handmade: {description}',
+                etsyTaxonomyMap: { EARRINGS: 5678 },
             });
             expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
         });

--- a/packages/api/src/domain/UserSettingsService/index.ts
+++ b/packages/api/src/domain/UserSettingsService/index.ts
@@ -7,8 +7,7 @@ const DEFAULT_HOURLY_WAGE = 10;
 const DEFAULT_PROFIT_MARGIN = 15;
 const DEFAULT_MARKUP_MULTIPLIER = 2.5;
 const DEFAULT_HOURLY_RATE = 0;
-const DEFAULT_ETSY_DESCRIPTION_TEMPLATE = '';
-const DEFAULT_ETSY_TAXONOMY_MAP: Record<string, number> = {};
+const DEFAULT_ETSY_DESCRIPTION_TEMPLATE = '{description}';
 
 function parseTimeToHours(timeRequired: string): number {
     const [hoursStr, minutesStr] = timeRequired.split(':');
@@ -39,7 +38,7 @@ export class UserSettingsService {
             markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
             hourlyRate: DEFAULT_HOURLY_RATE,
             etsyDescriptionTemplate: DEFAULT_ETSY_DESCRIPTION_TEMPLATE,
-            etsyTaxonomyMap: DEFAULT_ETSY_TAXONOMY_MAP,
+            etsyTaxonomyMap: {},
         };
         return { ...defaults, ...stored };
     }

--- a/packages/api/src/domain/UserSettingsService/index.ts
+++ b/packages/api/src/domain/UserSettingsService/index.ts
@@ -7,6 +7,8 @@ const DEFAULT_HOURLY_WAGE = 10;
 const DEFAULT_PROFIT_MARGIN = 15;
 const DEFAULT_MARKUP_MULTIPLIER = 2.5;
 const DEFAULT_HOURLY_RATE = 0;
+const DEFAULT_ETSY_DESCRIPTION_TEMPLATE = '';
+const DEFAULT_ETSY_TAXONOMY_MAP: Record<string, number> = {};
 
 function parseTimeToHours(timeRequired: string): number {
     const [hoursStr, minutesStr] = timeRequired.split(':');
@@ -30,20 +32,28 @@ export class UserSettingsService {
 
     async get(userId: string): Promise<UserSettings> {
         const stored = await this.settingsRepo.getByUserId(userId);
-        return (
-            stored ?? {
-                userId,
-                hourlyWage: DEFAULT_HOURLY_WAGE,
-                profitMargin: DEFAULT_PROFIT_MARGIN,
-                markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
-                hourlyRate: DEFAULT_HOURLY_RATE,
-            }
-        );
+        const defaults: UserSettings = {
+            userId,
+            hourlyWage: DEFAULT_HOURLY_WAGE,
+            profitMargin: DEFAULT_PROFIT_MARGIN,
+            markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
+            hourlyRate: DEFAULT_HOURLY_RATE,
+            etsyDescriptionTemplate: DEFAULT_ETSY_DESCRIPTION_TEMPLATE,
+            etsyTaxonomyMap: DEFAULT_ETSY_TAXONOMY_MAP,
+        };
+        return { ...defaults, ...stored };
     }
 
     async upsert(
         userId: string,
-        updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number }
+        updates: {
+            hourlyWage: number;
+            profitMargin: number;
+            markupMultiplier: number;
+            hourlyRate: number;
+            etsyDescriptionTemplate: string;
+            etsyTaxonomyMap: Record<string, number>;
+        }
     ): Promise<UserSettings> {
         const settings: UserSettings = { userId, ...updates };
         await this.settingsRepo.upsert(settings);

--- a/packages/api/src/handlers/Etsy/index.ts
+++ b/packages/api/src/handlers/Etsy/index.ts
@@ -4,6 +4,7 @@ import { config } from '../../config';
 import { dependencyContainer } from '../../dependencies';
 import { DependencyToken } from '../../dependencies/types';
 import type { EtsyConnectionService } from '../../domain/EtsyConnectionService';
+import type { EtsyPushService } from '../../domain/EtsyPushService';
 
 type AuthedCtx = Context<{ Variables: { userId: string } }>;
 
@@ -53,4 +54,22 @@ export const getEtsyConnectionStatus = async (c: AuthedCtx) => c.json(await getS
 export const disconnectEtsyConnection = async (c: AuthedCtx) => {
     await getService().disconnect(c.get('userId'));
     return c.json({ message: 'Etsy connection deleted successfully' }, 200);
+};
+
+const getPushService = (): EtsyPushService => dependencyContainer.resolve(DependencyToken.EtsyPushService);
+
+export const pushDesignToEtsy = async (c: AuthedCtx) => {
+    const { description, price } = (await c.req.json().catch(() => ({}))) as {
+        description?: string;
+        price?: number;
+    };
+
+    const design = await getPushService().push(c.req.param('id'), c.get('userId'), { description, price });
+    return c.json(design, 200);
+};
+
+export const getEtsyTaxonomy = async (c: AuthedCtx) => {
+    const client = dependencyContainer.resolve(DependencyToken.EtsyClient);
+    const nodes = await client.getSellerTaxonomyNodes();
+    return c.json(nodes, 200);
 };

--- a/packages/api/src/handlers/UserSettings/index.ts
+++ b/packages/api/src/handlers/UserSettings/index.ts
@@ -12,20 +12,28 @@ const getService = (): UserSettingsService => dependencyContainer.resolve(Depend
 export const getUserSettings = async (c: Ctx) => c.json(await getService().get(c.get('userId')));
 
 export const updateUserSettings = async (c: Ctx) => {
-    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = (await c.req.json()) as {
-        hourlyWage?: number;
-        profitMargin?: number;
-        markupMultiplier?: number;
-        hourlyRate?: number;
-    };
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate, etsyTaxonomyMap } =
+        (await c.req.json()) as {
+            hourlyWage?: number;
+            profitMargin?: number;
+            markupMultiplier?: number;
+            hourlyRate?: number;
+            etsyDescriptionTemplate?: string;
+            etsyTaxonomyMap?: Record<string, number>;
+        };
 
     if (
         hourlyWage === undefined ||
         profitMargin === undefined ||
         markupMultiplier === undefined ||
-        hourlyRate === undefined
+        hourlyRate === undefined ||
+        etsyDescriptionTemplate === undefined ||
+        etsyTaxonomyMap === undefined
     ) {
-        throw new APIError('hourlyWage, profitMargin, markupMultiplier and hourlyRate are required', 400);
+        throw new APIError(
+            'hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate and etsyTaxonomyMap are required',
+            400
+        );
     }
 
     return c.json(
@@ -34,6 +42,8 @@ export const updateUserSettings = async (c: Ctx) => {
             profitMargin: Number(profitMargin),
             markupMultiplier: Number(markupMultiplier),
             hourlyRate: Number(hourlyRate),
+            etsyDescriptionTemplate,
+            etsyTaxonomyMap,
         })
     );
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -47,6 +47,7 @@ export const onStartup = async () => {
         const materialsCollection = database.getCollection('materials' as any);
         await designsCollection.createIndex({ userId: 1 });
         await designsCollection.createIndex({ id: 1, userId: 1 });
+        await designsCollection.createIndex({ 'etsy.listingId': 1 }, { unique: true, sparse: true });
         await materialsCollection.createIndex({ userId: 1 });
         await materialsCollection.createIndex({ id: 1, userId: 1 });
         const draftsCollection = database.getCollection('drafts' as any);

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -5,7 +5,14 @@ import { dependencyContainer } from '../dependencies';
 import { DependencyToken } from '../dependencies/types';
 import { addDesign, deleteDesign, editDesignProperties, getDesign, getDesigns, updateDesign } from '../handlers/Design';
 import { createDraft, deleteDraft, getDraft, getDrafts, updateDraft, uploadDraftImage } from '../handlers/Draft';
-import { disconnectEtsyConnection, etsyOAuthCallback, getEtsyConnectionStatus, startEtsyOAuth } from '../handlers/Etsy';
+import {
+    disconnectEtsyConnection,
+    etsyOAuthCallback,
+    getEtsyConnectionStatus,
+    getEtsyTaxonomy,
+    pushDesignToEtsy,
+    startEtsyOAuth,
+} from '../handlers/Etsy';
 import { getImage, uploadImage } from '../handlers/Image';
 import {
     addMaterial,
@@ -38,6 +45,8 @@ export const createRoutes = (): Hono<Env> => {
     app.get('/api/etsy/oauth/callback', etsyOAuthCallback);
     app.get('/api/etsy/connection', authenticate, getEtsyConnectionStatus);
     app.delete('/api/etsy/connection', authenticate, disconnectEtsyConnection);
+    app.post('/api/designs/:id/etsy-push', authenticate, pushDesignToEtsy);
+    app.get('/api/etsy/taxonomy', authenticate, getEtsyTaxonomy);
 
     app.get('/api/designs', authenticate, getDesigns);
     app.post('/api/designs', authenticate, addDesign);

--- a/packages/types/src/design/index.ts
+++ b/packages/types/src/design/index.ts
@@ -7,6 +7,17 @@ import { DesignType } from './enum';
 
 export { DesignType } from './enum';
 
+export const etsyListingStateSchema = z.enum(['draft', 'active', 'inactive']);
+export type EtsyListingState = z.infer<typeof etsyListingStateSchema>;
+
+export const designEtsySchema = z.object({
+    listingId: z.number(),
+    state: etsyListingStateSchema,
+    lastPushedAt: z.number().nullable(),
+    pushIncomplete: z.boolean().optional(),
+});
+export type DesignEtsy = z.infer<typeof designEtsySchema>;
+
 export const designSchema = z.object({
     id: z.string(),
     userId: z.string(),
@@ -25,6 +36,7 @@ export const designSchema = z.object({
     variationGroups: z.array(variationGroupSchema).optional(),
     variants: z.array(designVariantSchema).optional(),
     designType: z.nativeEnum(DesignType).optional(),
+    etsy: designEtsySchema.optional(),
 });
 
 export type Design = z.infer<typeof designSchema>;

--- a/packages/types/src/userSettings/index.ts
+++ b/packages/types/src/userSettings/index.ts
@@ -6,6 +6,8 @@ export const userSettingsSchema = z.object({
     profitMargin: z.number().nonnegative(),
     markupMultiplier: z.number().nonnegative(),
     hourlyRate: z.number().nonnegative(),
+    etsyDescriptionTemplate: z.string(),
+    etsyTaxonomyMap: z.record(z.string(), z.number()),
 });
 
 export type UserSettings = z.infer<typeof userSettingsSchema>;

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -6,6 +6,7 @@ export const RECALCULATE_PRICES_ENDPOINT = '/api/designs/recalculate-prices';
 export const IMAGES_ENDPOINT = '/api/images';
 export const ETSY_OAUTH_START_ENDPOINT = '/api/etsy/oauth/start';
 export const ETSY_CONNECTION_ENDPOINT = '/api/etsy/connection';
+export const ETSY_TAXONOMY_ENDPOINT = '/api/etsy/taxonomy';
 
 export const getMaterialRecalculatePricesEndpoint = (materialId: string) =>
     `${MATERIALS_ENDPOINT}/${materialId}/recalculate-prices`;

--- a/packages/web/src/api/endpoints/etsyPush/index.ts
+++ b/packages/web/src/api/endpoints/etsyPush/index.ts
@@ -1,0 +1,25 @@
+import { type Design, MethodType } from '@jewellery-catalogue/types';
+
+import { DESIGNS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export const makePushDesignToEtsyRequest = (
+    designId: string,
+    overrides: { description?: string; price?: number },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<Design>(
+        {
+            pathname: `${DESIGNS_ENDPOINT}/${designId}/etsy-push`,
+            method: MethodType.POST,
+            headers: { 'Content-Type': 'application/json' },
+            operationString: 'push design to etsy',
+            body: overrides,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );

--- a/packages/web/src/api/endpoints/etsyTaxonomy/index.ts
+++ b/packages/web/src/api/endpoints/etsyTaxonomy/index.ts
@@ -1,0 +1,27 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { ETSY_TAXONOMY_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export interface EtsyTaxonomyNode {
+    id: number;
+    name: string;
+    children: EtsyTaxonomyNode[];
+}
+
+export const makeGetEtsyTaxonomyRequest = (
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<EtsyTaxonomyNode[]>(
+        {
+            pathname: ETSY_TAXONOMY_ENDPOINT,
+            method: MethodType.GET,
+            operationString: 'fetch etsy taxonomy',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );

--- a/packages/web/src/api/endpoints/userSettings/index.ts
+++ b/packages/web/src/api/endpoints/userSettings/index.ts
@@ -21,7 +21,14 @@ export const makeGetUserSettingsRequest = (
     );
 
 export const makeUpdateUserSettingsRequest = (
-    updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number },
+    updates: {
+        hourlyWage: number;
+        profitMargin: number;
+        markupMultiplier: number;
+        hourlyRate: number;
+        etsyDescriptionTemplate: string;
+        etsyTaxonomyMap: Record<string, number>;
+    },
     getAccessToken: () => string,
     onTokenRefresh: (newToken: string) => void,
     onTokenClear: () => void

--- a/packages/web/src/components/EtsyPushDialog/index.tsx
+++ b/packages/web/src/components/EtsyPushDialog/index.tsx
@@ -1,0 +1,115 @@
+import type { Design } from '@jewellery-catalogue/types';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+import { useEtsyPush } from '../../hooks/useEtsyPush';
+import { useUserSettings } from '../../hooks/useUserSettings';
+
+interface EtsyPushDialogProps {
+    design: Design;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+const renderTemplate = (template: string, description: string, materials: Array<{ name: string }>): string =>
+    template
+        .replace(/\{description\}/g, description)
+        .replace(/\{materials\}/g, materials.map((m) => m.name).join(', '));
+
+const EtsyPushDialog: React.FC<EtsyPushDialogProps> = ({ design, open, onOpenChange }) => {
+    const { etsyDescriptionTemplate, etsyTaxonomyMap } = useUserSettings();
+    const { push, isPushing, pushError } = useEtsyPush(design.id);
+
+    const [description, setDescription] = useState(() =>
+        renderTemplate(etsyDescriptionTemplate, design.description, design.materials)
+    );
+    const [price, setPrice] = useState(design.price);
+
+    const taxonomyId = design.designType ? etsyTaxonomyMap[design.designType] : undefined;
+
+    const handleSend = async () => {
+        await push({ description, price });
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Send to Etsy</DialogTitle>
+                    <DialogDescription>Review before creating the draft listing on Etsy.</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <div className="space-y-1.5">
+                        <Label>Description</Label>
+                        <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={6} />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Category</Label>
+                        <p className="text-sm text-muted-foreground">
+                            {taxonomyId
+                                ? `Taxonomy #${taxonomyId} (set for ${design.designType} in Settings)`
+                                : 'No category mapped for this design type — set one in Settings before sending.'}
+                        </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Price</Label>
+                        <InputGroup className="max-w-[160px]">
+                            <InputGroupAddon align="inline-start">
+                                <InputGroupText>£</InputGroupText>
+                            </InputGroupAddon>
+                            <InputGroupInput
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={price}
+                                onChange={(e) => setPrice(Number(e.target.value))}
+                            />
+                        </InputGroup>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Photos</Label>
+                        <p className="text-sm text-muted-foreground">
+                            {design.imageIds.length > 0
+                                ? `${design.imageIds.length} product photo(s) will be sent.`
+                                : 'No product photos — you can add them on Etsy before publishing.'}
+                        </p>
+                    </div>
+
+                    {pushError && (
+                        <p className="text-sm text-destructive">
+                            {pushError instanceof Error ? pushError.message : 'Failed to send to Etsy.'}
+                        </p>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPushing}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSend} disabled={isPushing || !taxonomyId}>
+                        {isPushing ? 'Sending…' : 'Send to Etsy'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default EtsyPushDialog;

--- a/packages/web/src/components/EtsyPushDialog/index.tsx
+++ b/packages/web/src/components/EtsyPushDialog/index.tsx
@@ -1,5 +1,5 @@
 import type { Design } from '@jewellery-catalogue/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -36,6 +36,14 @@ const EtsyPushDialog: React.FC<EtsyPushDialogProps> = ({ design, open, onOpenCha
         renderTemplate(etsyDescriptionTemplate, design.description, design.materials)
     );
     const [price, setPrice] = useState(design.price);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: only re-seed on open/design change, not on every template or materials change
+    useEffect(() => {
+        if (open) {
+            setDescription(renderTemplate(etsyDescriptionTemplate, design.description, design.materials));
+            setPrice(design.price);
+        }
+    }, [open, design.id]);
 
     const taxonomyId = design.designType ? etsyTaxonomyMap[design.designType] : undefined;
 

--- a/packages/web/src/hooks/useEtsyPush.ts
+++ b/packages/web/src/hooks/useEtsyPush.ts
@@ -1,0 +1,23 @@
+import { useAuth } from '@imapps/web-utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { makePushDesignToEtsyRequest } from '../api/endpoints/etsyPush';
+
+export const useEtsyPush = (designId: string) => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    const pushMutation = useMutation({
+        mutationFn: (overrides: { description?: string; price?: number }) =>
+            makePushDesignToEtsyRequest(designId, overrides, () => accessToken, login, logout),
+        onSuccess: (updated) => {
+            queryClient.setQueryData(['design', designId], updated);
+        },
+    });
+
+    return {
+        push: pushMutation.mutateAsync,
+        isPushing: pushMutation.isPending,
+        pushError: pushMutation.error,
+    };
+};

--- a/packages/web/src/hooks/useEtsyTaxonomy.ts
+++ b/packages/web/src/hooks/useEtsyTaxonomy.ts
@@ -1,0 +1,21 @@
+import { useAuth } from '@imapps/web-utils';
+import { useQuery } from '@tanstack/react-query';
+
+import { makeGetEtsyTaxonomyRequest } from '../api/endpoints/etsyTaxonomy';
+import { flattenTaxonomyNodes } from '../utils/flattenTaxonomyNodes';
+
+export const useEtsyTaxonomy = (enabled: boolean) => {
+    const { accessToken, login, logout } = useAuth();
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['etsy-taxonomy'],
+        queryFn: () => makeGetEtsyTaxonomyRequest(() => accessToken, login, logout),
+        enabled: enabled && !!accessToken,
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+
+    return {
+        options: flattenTaxonomyNodes(data ?? []),
+        isLoading,
+    };
+};

--- a/packages/web/src/hooks/useUserSettings.ts
+++ b/packages/web/src/hooks/useUserSettings.ts
@@ -25,6 +25,8 @@ export const useUserSettings = () => {
             profitMargin: number;
             markupMultiplier: number;
             hourlyRate: number;
+            etsyDescriptionTemplate: string;
+            etsyTaxonomyMap: Record<string, number>;
         }) => makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
         onSuccess: (updated) => {
             queryClient.setQueryData(QUERY_KEY, updated);
@@ -43,6 +45,8 @@ export const useUserSettings = () => {
         profitMargin: data?.profitMargin ?? 15,
         markupMultiplier: data?.markupMultiplier ?? 2.5,
         hourlyRate: data?.hourlyRate ?? 0,
+        etsyDescriptionTemplate: data?.etsyDescriptionTemplate ?? '',
+        etsyTaxonomyMap: data?.etsyTaxonomyMap ?? {},
         isLoading,
         updateSettings: updateMutation.mutateAsync,
         recalculate: recalculateMutation.mutateAsync,

--- a/packages/web/src/pages/Settings/index.tsx
+++ b/packages/web/src/pages/Settings/index.tsx
@@ -1,3 +1,4 @@
+import { DesignType } from '@jewellery-catalogue/types';
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -6,8 +7,10 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 
 import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import { useEtsyTaxonomy } from '../../hooks/useEtsyTaxonomy';
 import { useUserSettings } from '../../hooks/useUserSettings';
 
 const Settings = () => {
@@ -31,15 +34,20 @@ const Settings = () => {
         profitMargin,
         markupMultiplier,
         hourlyRate,
+        etsyDescriptionTemplate,
+        etsyTaxonomyMap,
         updateSettings,
         recalculate,
         isLoading: pricingLoading,
     } = useUserSettings();
+    const { options: taxonomyOptions, isLoading: taxonomyLoading } = useEtsyTaxonomy(connected);
 
     const [localWage, setLocalWage] = useState<number | ''>(hourlyWage);
     const [localMargin, setLocalMargin] = useState<number | ''>(profitMargin);
     const [localMarkupMultiplier, setLocalMarkupMultiplier] = useState<number | ''>(markupMultiplier);
     const [localHourlyRate, setLocalHourlyRate] = useState<number | ''>(hourlyRate);
+    const [localEtsyDescriptionTemplate, setLocalEtsyDescriptionTemplate] = useState(etsyDescriptionTemplate);
+    const [localEtsyTaxonomyMap, setLocalEtsyTaxonomyMap] = useState<Record<string, number>>(etsyTaxonomyMap);
     const [pricingStatus, setPricingStatus] = useState<'idle' | 'saving' | 'recalculating' | 'success' | 'error'>(
         'idle'
     );
@@ -53,7 +61,9 @@ const Settings = () => {
         setLocalMargin(profitMargin);
         setLocalMarkupMultiplier(markupMultiplier);
         setLocalHourlyRate(hourlyRate);
-    }, [hourlyWage, profitMargin, markupMultiplier, hourlyRate]);
+        setLocalEtsyDescriptionTemplate(etsyDescriptionTemplate);
+        setLocalEtsyTaxonomyMap(etsyTaxonomyMap);
+    }, [hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate, etsyTaxonomyMap]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount to strip the ?etsy param from the URL
     useEffect(() => {
@@ -82,6 +92,8 @@ const Settings = () => {
                 profitMargin: margin,
                 markupMultiplier: Number(localMarkupMultiplier),
                 hourlyRate: Number(localHourlyRate),
+                etsyDescriptionTemplate: localEtsyDescriptionTemplate,
+                etsyTaxonomyMap: localEtsyTaxonomyMap,
             });
             if (thenRecalculate) {
                 setPricingStatus('recalculating');
@@ -262,6 +274,57 @@ const Settings = () => {
                     {pricingStatus === 'error' && <p className="text-sm text-destructive">{pricingError}</p>}
                 </CardContent>
             </Card>
+
+            {connected && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Etsy Defaults</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="space-y-1.5">
+                            <Label>Description template</Label>
+                            <Textarea
+                                value={localEtsyDescriptionTemplate}
+                                onChange={(e) => setLocalEtsyDescriptionTemplate(e.target.value)}
+                                placeholder="{description}\n\nMaterials: {materials}"
+                                rows={4}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Use {'{description}'} and {'{materials}'} as placeholders.
+                            </p>
+                        </div>
+
+                        <div className="space-y-3">
+                            <Label>Category by design type</Label>
+                            {Object.values(DesignType).map((designType) => (
+                                <div key={designType} className="flex items-center gap-3">
+                                    <span className="w-28 text-sm">{designType}</span>
+                                    <select
+                                        className="flex-1 rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+                                        disabled={taxonomyLoading}
+                                        value={localEtsyTaxonomyMap[designType] ?? ''}
+                                        onChange={(e) =>
+                                            setLocalEtsyTaxonomyMap((prev) => ({
+                                                ...prev,
+                                                [designType]: Number(e.target.value),
+                                            }))
+                                        }
+                                    >
+                                        <option value="" disabled>
+                                            Select a category…
+                                        </option>
+                                        {taxonomyOptions.map((opt) => (
+                                            <option key={opt.id} value={opt.id}>
+                                                {opt.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
         </div>
     );
 };

--- a/packages/web/src/pages/Settings/index.tsx
+++ b/packages/web/src/pages/Settings/index.tsx
@@ -286,7 +286,7 @@ const Settings = () => {
                             <Textarea
                                 value={localEtsyDescriptionTemplate}
                                 onChange={(e) => setLocalEtsyDescriptionTemplate(e.target.value)}
-                                placeholder="{description}\n\nMaterials: {materials}"
+                                placeholder={'{description}\n\nMaterials: {materials}'}
                                 rows={4}
                             />
                             <p className="text-xs text-muted-foreground">

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -1,6 +1,6 @@
 import { useAuth, useUser } from '@imapps/web-utils';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronLeft, ChevronRight, Edit, PackageOpen } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Edit, ExternalLink, PackageOpen } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
@@ -8,6 +8,7 @@ import { getDesignQuery } from '../../api/endpoints/getDesign';
 import DesignDescription from '../../components/DesignDescription';
 import DesignEditForm from '../../components/DesignEditForm';
 import DesignUpdateForm from '../../components/DesignUpdateForm';
+import EtsyPushDialog from '../../components/EtsyPushDialog';
 import { Image } from '../../components/Image';
 import LoadingScreen from '../../components/Loading';
 import { Badge } from '../../components/ui/badge';
@@ -15,6 +16,7 @@ import { Button } from '../../components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
 import { MATERIALS_PAGE } from '../../constants/routes';
+import { useEtsyConnection } from '../../hooks/useEtsyConnection';
 import {
     DESIGN_TYPE_LABELS,
     MATERIAL_TYPE_LABELS,
@@ -30,6 +32,8 @@ const ViewDesign = () => {
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [editPropertiesDialogOpen, setEditPropertiesDialogOpen] = useState(false);
     const [imageIndex, setImageIndex] = useState(0);
+    const { connected: etsyConnected } = useEtsyConnection();
+    const [etsyDialogOpen, setEtsyDialogOpen] = useState(false);
 
     const {
         data: design,
@@ -56,6 +60,7 @@ const ViewDesign = () => {
         designType,
         diagramImageIds,
         makingNotes,
+        etsy,
     } = design ?? {};
 
     const hasDescription = description && description !== '<p></p>';
@@ -111,6 +116,34 @@ const ViewDesign = () => {
                             <PackageOpen className="h-4 w-4 mr-2" />
                             Manage Inventory
                         </Button>
+                        {etsyConnected && (
+                            <>
+                                {etsy?.listingId && (
+                                    <a
+                                        href={`https://www.etsy.com/your/shops/me/listing-editor/edit/${etsy.listingId}`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+                                    >
+                                        {etsy.state === 'active' ? 'Active' : 'Draft'} on Etsy
+                                        <ExternalLink className="h-3 w-3" />
+                                    </a>
+                                )}
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    disabled={!!etsy?.listingId && !etsy.pushIncomplete}
+                                    title={
+                                        etsy?.listingId && !etsy.pushIncomplete
+                                            ? 'This design is already on Etsy'
+                                            : undefined
+                                    }
+                                    onClick={() => setEtsyDialogOpen(true)}
+                                >
+                                    Send to Etsy
+                                </Button>
+                            </>
+                        )}
                     </div>
                 </div>
 
@@ -396,6 +429,8 @@ const ViewDesign = () => {
                     )}
                 </DialogContent>
             </Dialog>
+
+            {design && <EtsyPushDialog design={design} open={etsyDialogOpen} onOpenChange={setEtsyDialogOpen} />}
         </>
     );
 };

--- a/packages/web/src/utils/flattenTaxonomyNodes/index.test.ts
+++ b/packages/web/src/utils/flattenTaxonomyNodes/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+
+import { flattenTaxonomyNodes } from './index';
+
+describe('flattenTaxonomyNodes', () => {
+    it('flattens a nested tree into a list with breadcrumb labels', () => {
+        const result = flattenTaxonomyNodes([
+            {
+                id: 1,
+                name: 'Jewelry',
+                children: [
+                    { id: 2, name: 'Rings', children: [] },
+                    { id: 3, name: 'Necklaces', children: [{ id: 4, name: 'Chokers', children: [] }] },
+                ],
+            },
+        ]);
+
+        expect(result).toEqual([
+            { id: 1, label: 'Jewelry' },
+            { id: 2, label: 'Jewelry > Rings' },
+            { id: 3, label: 'Jewelry > Necklaces' },
+            { id: 4, label: 'Jewelry > Necklaces > Chokers' },
+        ]);
+    });
+
+    it('returns an empty array for an empty tree', () => {
+        expect(flattenTaxonomyNodes([])).toEqual([]);
+    });
+});

--- a/packages/web/src/utils/flattenTaxonomyNodes/index.ts
+++ b/packages/web/src/utils/flattenTaxonomyNodes/index.ts
@@ -1,0 +1,12 @@
+import type { EtsyTaxonomyNode } from '../../api/endpoints/etsyTaxonomy';
+
+export interface FlatTaxonomyOption {
+    id: number;
+    label: string;
+}
+
+export const flattenTaxonomyNodes = (nodes: EtsyTaxonomyNode[], prefix = ''): FlatTaxonomyOption[] =>
+    nodes.flatMap((node) => {
+        const label = prefix ? `${prefix} > ${node.name}` : node.name;
+        return [{ id: node.id, label }, ...flattenTaxonomyNodes(node.children, label)];
+    });


### PR DESCRIPTION
## Summary
Sub-project 3 of the Etsy integration spec — lets the shop owner push a Design to Etsy as a draft listing via a "Send to Etsy" button and review dialog.

**Stacked PR**: based on `feat/design-authoring-upgrades` (#36), not `main` directly. Do not merge before #36 — this PR's diff will shrink to just this sub-project's commits once #36 merges.

- Server flow: create draft listing → upload product photos (never diagrams) → put variation inventory → persist `etsy` state, with crash-safety/resume semantics (a failed push resumes without duplicating the Etsy listing).
- Etsy's 2-variation-property cap enforced before any Etsy API call; re-push blocked once a design is fully pushed.
- New Settings sections: Etsy description template + designType→category mapping (fed by `getSellerTaxonomyNodes`).
- "Send to Etsy" button + Etsy state chip on the design detail page, gated entirely behind an active Etsy connection.

## Test plan
- [x] Full api test suite: 206 pass / 0 fail (`bun test` in `packages/api`), including a dedicated crash-safety/resume test for `EtsyPushService`
- [x] Web util tests: `flattenTaxonomyNodes` 2/2 pass
- [x] Typecheck: verified via `tsc --build --force` against this branch's own pre-plan baseline (repo's `tsc --noEmit` is a known no-op, tracked separately, out of scope here)
- [x] Lint (Biome) clean; `fallow-audit` dead-code/duplication gate passing (one false-positive dead-code flag suppressed with the same convention already used elsewhere in this file)
- [x] 11-task implementation plan executed with a fresh subagent + reviewer per task, two fix rounds (missing crash-safety test, dialog stale-state-on-reopen bug), plus a final whole-branch review — all clean, zero unresolved Critical/Important findings
- [ ] **Manual, human-required**: live smoke test against the real Etsy sandbox (push one real draft with photos + variations, verify in Shop Manager, then delete) — the spec calls this out as a manual gate; this sandbox has no live Etsy credentials to run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)