### PR TITLE
Etsy status refresh + Listings page (sub-project 4)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-design-authoring-upgrades.md
+++ b/docs/superpowers/plans/2026-07-18-design-authoring-upgrades.md
@@ -1,0 +1,1650 @@
+# Design Authoring Upgrades (Sub-project 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give designs private "maker docs" (diagram photos + free-text notes that never reach Etsy) and a read-only price-suggestion formula beside the price field — Sub-project 2 of `docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md`. No Etsy API calls of any kind; this sub-project doesn't depend on the OAuth connection working.
+
+**Architecture:** Follows the exact patterns already in place for product images and the existing pricing panel: `diagramImageIds`/`makingNotes` are new `Design` fields uploaded/edited through the same multipart-form + `ImageService` pipeline as `imageIds`, just under separate field names so they never get mixed into the Etsy-facing photo list. The price suggestion is a pure, client-only formula (never persisted, never auto-applied) driven by two new `UserSettings` fields.
+
+**Tech Stack:** Same as sub-project 1 — Bun + TypeScript + Hono (api), React + react-hook-form + Zod (web), MongoDB.
+
+## Global Constraints
+
+- `diagramImageIds`/`makingNotes` are **private maker documentation** — the push-to-Etsy mapper (built in sub-project 3, not this one) will only ever read a whitelisted field set from `Design`, and these two fields must never be added to that whitelist. This plan does not touch any Etsy code; the constraint just governs field naming/placement so a future reader doesn't assume they're photo-list candidates.
+- Suggested price formula (verbatim from spec): `suggestedPrice = totalMaterialCosts × markupMultiplier + parsedTimeRequired(hours) × hourlyRate`. Defaults: `markupMultiplier = 2.5`, `hourlyRate = 0`.
+- The suggestion is **read-only display only** — never auto-applied to the `price` field. A click on a "Use this price" button copies the value in; nothing else may mutate `price` from the suggestion.
+- `timeRequired` is stored `"HH:MM"` string format; reuse the existing `getWageCosts(time: string): number` util (`packages/web/src/utils/getWageCost/index.ts`) to parse it to hours — do not reimplement time parsing.
+- Diagram images reuse the exact upload/storage pipeline as product images (`ImageService.uploadImage`, same Mongo/bucket infra) — just a separate field name (`diagramImageIds` vs `imageIds`) so they're never confused with product photos.
+- Follow the existing repo's layered pattern exactly: `packages/types` (zod schemas) → `packages/api/src/domain/DesignService` + `packages/api/src/handlers/Design` (server) → `packages/web/src/api/endpoints/*` + `packages/web/src/pages/*` + `packages/web/src/components/*` (client). Don't introduce a different pattern.
+- Tests: `bun:test` for api (mocks via `mock()`, following `DesignService/index.test.ts` conventions), no new web test framework — this repo's web package doesn't have a unit-test runner wired up for components (only Playwright e2e exists under `packages/web/tests/e2e`); web-side changes in this plan are UI wiring with no new pure-logic web unit beyond `getSuggestedPrice`, which does get a `bun:test`-style unit test (the util is plain TS, testable the same way api utils are — see `packages/api/src/utils/material-conversion.test.ts` for the pattern, but this file lives in `packages/web` so use `packages/web/src/utils/getSuggestedPrice/index.test.ts` with the same `bun:test` API since the whole repo uses Bun as the test runner).
+- Lint/format: `bun run lint` (Biome) must pass on touched files before each commit.
+
+---
+
+## File Structure
+
+```
+packages/types/src/design/index.ts                        # + diagramImageIds, makingNotes
+packages/types/src/formDesign/index.ts                     # + diagramImages, makingNotes
+packages/types/src/editDesign/index.ts                     # + diagramImageIds, makingNotes (optional)
+packages/types/src/uploadDesign/index.ts                   # + makingNotes
+packages/types/src/userSettings/index.ts                   # + markupMultiplier, hourlyRate
+
+packages/api/src/domain/DesignService/index.ts              # addDesign/editDesignProperties: diagram images + makingNotes
+packages/api/src/handlers/Design/index.ts                   # addDesign/editDesignProperties: parse diagramFiles/existingDiagramImageIds/keepDiagramImageIds/makingNotes
+packages/api/src/domain/UserSettingsService/index.ts        # + markupMultiplier, hourlyRate defaults + upsert fields
+
+packages/web/src/utils/getSuggestedPrice/index.ts            # new pure formula util
+packages/web/src/utils/getSuggestedPrice/index.test.ts
+packages/web/src/api/endpoints/addDesign/index.ts            # + diagramImages FormData handling
+packages/web/src/api/endpoints/editDesign/index.ts           # + diagramImages FormData handling
+packages/web/src/api/endpoints/userSettings/index.ts         # + markupMultiplier, hourlyRate
+packages/web/src/hooks/useUserSettings.ts                    # + markupMultiplier, hourlyRate
+packages/web/src/components/MakerDocsSection/index.tsx       # new shared "Maker docs" form section (diagram upload + notes)
+packages/web/src/components/SuggestedPrice/index.tsx         # new read-only suggestion + "Use this price" button
+packages/web/src/pages/AddDesign/index.tsx                   # + Maker docs section, + suggested price
+packages/web/src/components/DesignEditForm/index.tsx         # + Maker docs section, + suggested price
+packages/web/src/components/VariationGroupBuilder/index.tsx  # + per-variant suggested price column
+packages/web/src/pages/Settings/index.tsx                    # + markupMultiplier, hourlyRate fields (Pricing section)
+packages/web/src/pages/ViewDesign/index.tsx                  # + Maker docs display (diagram gallery + notes)
+```
+
+---
+
+### Task 1: Types — schema additions
+
+**Files:**
+- Modify: `packages/types/src/design/index.ts`
+- Modify: `packages/types/src/formDesign/index.ts`
+- Modify: `packages/types/src/editDesign/index.ts`
+- Modify: `packages/types/src/uploadDesign/index.ts`
+- Modify: `packages/types/src/userSettings/index.ts`
+
+**Interfaces:**
+- Produces: `Design.diagramImageIds: string[]`, `Design.makingNotes: string`, `FormDesign.diagramImages: Array<File|string>`, `FormDesign.makingNotes: string`, `EditDesign.diagramImageIds?: string[]`, `EditDesign.makingNotes?: string`, `UploadDesign.makingNotes: string`, `UserSettings.markupMultiplier: number`, `UserSettings.hourlyRate: number` — consumed by every later task in this plan.
+
+- [ ] **Step 1: Add fields to `designSchema`**
+
+In `packages/types/src/design/index.ts`, add two lines to the `z.object({...})` (after `imageIds`):
+
+```typescript
+    imageIds: z.array(z.string()),
+    diagramImageIds: z.array(z.string()).default([]),
+    makingNotes: z.string().default(''),
+```
+
+- [ ] **Step 2: Add fields to `formDesignSchema`**
+
+In `packages/types/src/formDesign/index.ts`, add to the `.object({...})` (after `images`):
+
+```typescript
+        images: z
+            .array(z.union([z.instanceof(File), z.string()]))
+            .optional()
+            .default([]),
+        diagramImages: z
+            .array(z.union([z.instanceof(File), z.string()]))
+            .optional()
+            .default([]),
+        makingNotes: z.string().optional().default(''),
+```
+
+- [ ] **Step 3: Add fields to `editDesignSchema`**
+
+In `packages/types/src/editDesign/index.ts`, add (both optional, matching every other field in this schema):
+
+```typescript
+    diagramImageIds: z.array(z.string()).optional(),
+    makingNotes: z.string().optional(),
+```
+
+- [ ] **Step 4: Add field to `UploadDesign`**
+
+In `packages/types/src/uploadDesign/index.ts`, add to the interface:
+
+```typescript
+export interface UploadDesign {
+    materials: string;
+    name: string;
+    description: string;
+    timeRequired: string;
+    image: PersistentFile;
+    totalMaterialCosts: number;
+    price: number;
+    lowStockThreshold?: number;
+    variationGroups?: string;
+    variants?: string;
+    designType?: DesignType;
+    makingNotes?: string;
+}
+```
+
+- [ ] **Step 5: Add fields to `userSettingsSchema`**
+
+In `packages/types/src/userSettings/index.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const userSettingsSchema = z.object({
+    userId: z.string(),
+    hourlyWage: z.number().nonnegative(),
+    profitMargin: z.number().nonnegative(),
+    markupMultiplier: z.number().nonnegative(),
+    hourlyRate: z.number().nonnegative(),
+});
+
+export type UserSettings = z.infer<typeof userSettingsSchema>;
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd packages/types && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/types/src/design/index.ts packages/types/src/formDesign/index.ts packages/types/src/editDesign/index.ts packages/types/src/uploadDesign/index.ts packages/types/src/userSettings/index.ts
+git commit -m "feat(types): add maker-docs and price-suggestion fields"
+```
+
+---
+
+### Task 2: API — diagram images + makingNotes on the create-design flow
+
+**Files:**
+- Modify: `packages/api/src/domain/DesignService/index.ts` (the `addDesign` method)
+- Modify: `packages/api/src/domain/DesignService/index.test.ts`
+- Modify: `packages/api/src/handlers/Design/index.ts` (the `addDesign` handler)
+
+**Interfaces:**
+- Consumes: `Design.diagramImageIds`/`makingNotes`, `UploadDesign.makingNotes` (Task 1).
+- Produces: `DesignService.addDesign(designData: UploadDesign, imageBuffers, existingImageIds, diagramImageBuffers: Array<{buffer: Buffer; contentType: string}>, existingDiagramImageIds: string[], userId: string): Promise<Design>` (note the two new parameters, inserted after `existingImageIds` and before `userId`) — consumed by the handler in this task and reviewed by later tasks for signature consistency.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/api/src/domain/DesignService/index.test.ts`, inside the existing `describe('DesignService')` block (find the existing `describe('addDesign', ...)` block and add this test inside it — read the file first to match the existing mock setup exactly, in particular reuse the existing `mockDesignRepo`/`mockImageService`/`mockIdGenerator` from the top of the file):
+
+```typescript
+describe('addDesign — maker docs', () => {
+    it('uploads diagram images separately from product images and stores both id lists plus makingNotes', async () => {
+        mockIdGenerator.generate
+            .mockReturnValueOnce('design-1')
+            .mockReturnValueOnce('product-img-1')
+            .mockReturnValueOnce('diagram-img-1');
+        mockImageService.uploadImage.mockResolvedValue(undefined);
+
+        const designData = {
+            name: 'Test',
+            description: 'desc',
+            timeRequired: '01:00',
+            materials: JSON.stringify([]),
+            totalMaterialCosts: 10,
+            price: 20,
+            image: undefined,
+            makingNotes: 'Solder the clasp before adding the chain.',
+        } as any;
+
+        const result = await service.addDesign(
+            designData,
+            [{ buffer: Buffer.from('product'), contentType: 'image/png' }],
+            [],
+            [{ buffer: Buffer.from('diagram'), contentType: 'image/png' }],
+            [],
+            'user-1'
+        );
+
+        expect(result.imageIds).toEqual(['product-img-1']);
+        expect(result.diagramImageIds).toEqual(['diagram-img-1']);
+        expect(result.makingNotes).toBe('Solder the clasp before adding the chain.');
+        expect(mockImageService.uploadImage).toHaveBeenCalledTimes(2);
+    });
+
+    it('defaults makingNotes to empty string and diagramImageIds to empty array when omitted', async () => {
+        mockIdGenerator.generate.mockReturnValueOnce('design-2');
+
+        const designData = {
+            name: 'Test',
+            description: 'desc',
+            timeRequired: '01:00',
+            materials: JSON.stringify([]),
+            totalMaterialCosts: 10,
+            price: 20,
+            image: undefined,
+        } as any;
+
+        const result = await service.addDesign(designData, [], [], [], [], 'user-1');
+
+        expect(result.diagramImageIds).toEqual([]);
+        expect(result.makingNotes).toBe('');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/DesignService/index.test.ts`
+Expected: FAIL — `service.addDesign` called with 6 args but current signature only accepts 4 (TypeScript error or wrong-arity runtime behavior)
+
+- [ ] **Step 3: Update `DesignService.addDesign`**
+
+In `packages/api/src/domain/DesignService/index.ts`, replace the `addDesign` method signature and body:
+
+```typescript
+    async addDesign(
+        designData: UploadDesign,
+        imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        existingImageIds: string[],
+        diagramImageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        existingDiagramImageIds: string[],
+        userId: string
+    ): Promise<Design> {
+        if (!userId) {
+            throw Object.assign(new Error('User ID is required'), { status: 400 });
+        }
+
+        const designId = this.idGenerator.generate();
+
+        const newImageIds = await Promise.all(
+            imageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
+        const newDiagramImageIds = await Promise.all(
+            diagramImageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
+        const imageIds = [...existingImageIds, ...newImageIds];
+        const diagramImageIds = [...existingDiagramImageIds, ...newDiagramImageIds];
+
+        let materials: Array<RequiredMaterial>;
+
+        try {
+            materials =
+                typeof designData.materials === 'string' ? JSON.parse(designData.materials) : designData.materials;
+        } catch {
+            throw Object.assign(new Error('Invalid materials format'), { status: 400 });
+        }
+
+        let variationGroups: VariationGroup[] | undefined;
+        let variants: DesignVariant[] | undefined;
+
+        if (designData.variationGroups) {
+            try {
+                variationGroups =
+                    typeof designData.variationGroups === 'string'
+                        ? JSON.parse(designData.variationGroups)
+                        : designData.variationGroups;
+            } catch {
+                throw Object.assign(new Error('Invalid variationGroups format'), { status: 400 });
+            }
+        }
+
+        if (designData.variants) {
+            try {
+                const parsed: DesignVariant[] =
+                    typeof designData.variants === 'string' ? JSON.parse(designData.variants) : designData.variants;
+                variants = parsed.map((v) => ({ ...v, totalQuantity: 0 }));
+            } catch {
+                throw Object.assign(new Error('Invalid variants format'), { status: 400 });
+            }
+        }
+
+        const design: Design = {
+            id: designId,
+            userId: userId,
+            name: designData.name,
+            description: designData.description,
+            timeRequired: designData.timeRequired,
+            totalMaterialCosts: designData.totalMaterialCosts,
+            price: designData.price,
+            imageIds,
+            diagramImageIds,
+            makingNotes: designData.makingNotes ?? '',
+            materials,
+            dateAdded: new Date(),
+            totalQuantity: 0,
+            lowStockThreshold: designData.lowStockThreshold,
+            variationGroups,
+            variants,
+            designType: designData.designType,
+        };
+
+        await this.designRepo.insert(design);
+
+        return design;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/DesignService/index.test.ts`
+Expected: PASS (including all pre-existing `addDesign` tests — check none of them broke from the new required parameters; if any pre-existing test calls `service.addDesign(...)` with the old 4-arg signature, update those call sites to pass `[]` and `[]` for the two new params, since this is a source-compatible-but-not-binary-compatible internal method change)
+
+- [ ] **Step 5: Update the `addDesign` handler**
+
+In `packages/api/src/handlers/Design/index.ts`, replace the `addDesign` handler:
+
+```typescript
+export const addDesign = async (c: Ctx) => {
+    const userId = c.get('userId');
+    const isJson = (c.req.header('content-type') ?? '').includes('application/json');
+    const body = isJson ? await c.req.json() : await c.req.parseBody({ all: true });
+    const files = isJson ? [] : collectFiles(body.files);
+    const diagramFiles = isJson ? [] : collectFiles(body.diagramFiles);
+
+    const {
+        name,
+        description,
+        timeRequired,
+        materials,
+        totalMaterialCosts,
+        price,
+        lowStockThreshold,
+        variationGroups,
+        variants,
+        designType,
+        makingNotes,
+        existingImageIds: existingImageIdsRaw,
+        existingDiagramImageIds: existingDiagramImageIdsRaw,
+    } = body as unknown as Partial<UploadDesign> & {
+        existingImageIds?: string;
+        existingDiagramImageIds?: string;
+        designType?: string;
+    };
+
+    const existingImageIds: string[] =
+        typeof existingImageIdsRaw === 'string' && existingImageIdsRaw ? JSON.parse(existingImageIdsRaw) : [];
+    const existingDiagramImageIds: string[] =
+        typeof existingDiagramImageIdsRaw === 'string' && existingDiagramImageIdsRaw
+            ? JSON.parse(existingDiagramImageIdsRaw)
+            : [];
+
+    if (files.length === 0 && existingImageIds.length === 0) {
+        throw new APIError('At least one image file or imageId is required', 400);
+    }
+
+    const designData: UploadDesign = {
+        name: name!,
+        description: description!,
+        timeRequired: timeRequired!,
+        materials: materials!,
+        totalMaterialCosts: Number(totalMaterialCosts),
+        price: Number(price),
+        image: files[0]! as unknown as UploadDesign['image'],
+        lowStockThreshold: lowStockThreshold !== undefined ? Number(lowStockThreshold) : undefined,
+        variationGroups,
+        variants,
+        designType,
+        makingNotes,
+    };
+
+    const imageBuffers = await Promise.all(files.map(toImageBuffer));
+    const diagramImageBuffers = await Promise.all(diagramFiles.map(toImageBuffer));
+    const design = await getDesignService().addDesign(
+        designData,
+        imageBuffers,
+        existingImageIds,
+        diagramImageBuffers,
+        existingDiagramImageIds,
+        userId
+    );
+    return c.json(design, 200);
+};
+```
+
+- [ ] **Step 6: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all tests pass (including `handlers/Design/index.test.ts` — if it directly asserts on `addDesign`'s call arguments to `DesignService`, check and update those assertions for the new parameters)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api/src/domain/DesignService/index.ts packages/api/src/domain/DesignService/index.test.ts packages/api/src/handlers/Design/index.ts
+git commit -m "feat(api): support diagram images and making notes on design create"
+```
+
+---
+
+### Task 3: API — diagram images + makingNotes on the edit-design flow
+
+**Files:**
+- Modify: `packages/api/src/domain/DesignService/index.ts` (the `editDesignProperties` method)
+- Modify: `packages/api/src/domain/DesignService/index.test.ts`
+- Modify: `packages/api/src/handlers/Design/index.ts` (the `editDesignProperties` handler)
+
+**Interfaces:**
+- Consumes: `Design.diagramImageIds`/`makingNotes`, `EditDesign.diagramImageIds`/`makingNotes` (Task 1).
+- Produces: `DesignService.editDesignProperties(id, updates: EditDesign, imageBuffers, keepImageIds: string[], diagramImageBuffers: Array<{buffer: Buffer; contentType: string}>, keepDiagramImageIds: string[], userId: string): Promise<Design>` (two new parameters inserted after `keepImageIds` and before `userId`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/api/src/domain/DesignService/index.test.ts`, inside the existing `describe('editDesignProperties', ...)` block:
+
+```typescript
+describe('editDesignProperties — maker docs', () => {
+    it('merges kept + newly uploaded diagram image ids and updates makingNotes', async () => {
+        const existing: Design = {
+            id: 'design-1',
+            userId: 'user-1',
+            name: 'Existing',
+            description: 'desc',
+            timeRequired: '01:00',
+            materials: [],
+            imageIds: ['product-1'],
+            diagramImageIds: ['old-diagram-1', 'old-diagram-2'],
+            makingNotes: 'Old notes',
+            price: 20,
+            totalMaterialCosts: 10,
+            dateAdded: new Date(),
+            totalQuantity: 0,
+        };
+        mockDesignRepo.getByIdAndUserId.mockResolvedValue(existing);
+        mockIdGenerator.generate.mockReturnValueOnce('new-diagram-1');
+        mockImageService.uploadImage.mockResolvedValue(undefined);
+
+        const result = await service.editDesignProperties(
+            'design-1',
+            { makingNotes: 'Updated notes' },
+            [],
+            ['product-1'],
+            [{ buffer: Buffer.from('diagram'), contentType: 'image/png' }],
+            ['old-diagram-1'],
+            'user-1'
+        );
+
+        expect(result.diagramImageIds).toEqual(['old-diagram-1', 'new-diagram-1']);
+        expect(result.makingNotes).toBe('Updated notes');
+        expect(result.imageIds).toEqual(['product-1']);
+    });
+
+    it('leaves diagramImageIds and makingNotes unchanged when not part of the update', async () => {
+        const existing: Design = {
+            id: 'design-1',
+            userId: 'user-1',
+            name: 'Existing',
+            description: 'desc',
+            timeRequired: '01:00',
+            materials: [],
+            imageIds: ['product-1'],
+            diagramImageIds: ['old-diagram-1'],
+            makingNotes: 'Keep me',
+            price: 20,
+            totalMaterialCosts: 10,
+            dateAdded: new Date(),
+            totalQuantity: 0,
+        };
+        mockDesignRepo.getByIdAndUserId.mockResolvedValue(existing);
+
+        const result = await service.editDesignProperties(
+            'design-1',
+            { name: 'Renamed' },
+            [],
+            ['product-1'],
+            [],
+            ['old-diagram-1'],
+            'user-1'
+        );
+
+        expect(result.diagramImageIds).toEqual(['old-diagram-1']);
+        expect(result.makingNotes).toBe('Keep me');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/DesignService/index.test.ts`
+Expected: FAIL — wrong arity / `diagramImageIds` not merged
+
+- [ ] **Step 3: Update `DesignService.editDesignProperties`**
+
+In `packages/api/src/domain/DesignService/index.ts`, replace the `editDesignProperties` method:
+
+```typescript
+    async editDesignProperties(
+        id: string,
+        updates: EditDesign,
+        imageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        keepImageIds: string[],
+        diagramImageBuffers: Array<{ buffer: Buffer; contentType: string }>,
+        keepDiagramImageIds: string[],
+        userId: string
+    ): Promise<Design> {
+        if (!id) {
+            throw Object.assign(new Error('Design ID is required'), { status: 400 });
+        }
+
+        const existing = await this.designRepo.getByIdAndUserId(id, userId);
+
+        if (!existing) {
+            throw Object.assign(new Error('Design not found'), { status: 404 });
+        }
+
+        const newImageIds = await Promise.all(
+            imageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
+        const newDiagramImageIds = await Promise.all(
+            diagramImageBuffers.map(async ({ buffer, contentType }) => {
+                const imageId = this.idGenerator.generate();
+                await this.imageService.uploadImage(imageId, buffer, contentType);
+                return imageId;
+            })
+        );
+
+        const imageIds = [...keepImageIds, ...newImageIds];
+        const diagramImageIds = [...keepDiagramImageIds, ...newDiagramImageIds];
+
+        let materials = existing.materials;
+        if (updates.materials) {
+            materials = typeof updates.materials === 'string' ? JSON.parse(updates.materials) : updates.materials;
+        }
+
+        let variationGroups = existing.variationGroups;
+        let variants = existing.variants;
+
+        if (updates.variationGroups !== undefined) {
+            variationGroups = updates.variationGroups;
+        }
+
+        if (updates.variants !== undefined) {
+            variants = mergeVariants(existing.variants ?? [], updates.variants);
+        }
+
+        const updated: Design = {
+            ...existing,
+            ...updates,
+            materials,
+            imageIds,
+            diagramImageIds,
+            makingNotes: updates.makingNotes ?? existing.makingNotes,
+            variationGroups,
+            variants,
+        };
+
+        await this.designRepo.update(id, updated);
+
+        return updated;
+    }
+```
+
+Note: `diagramImageIds` is always recomputed from `keepDiagramImageIds`/new uploads (same as `imageIds` already does) rather than falling through `...updates`, so it can't be silently overwritten by a stray `updates.diagramImageIds` — this mirrors exactly how `imageIds` already avoids that trap in this method.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/DesignService/index.test.ts`
+Expected: PASS (fix any pre-existing `editDesignProperties` test call sites the same way as Task 2 — pass `[]` and the design's current `diagramImageIds` for the two new params)
+
+- [ ] **Step 5: Update the `editDesignProperties` handler**
+
+In `packages/api/src/handlers/Design/index.ts`, replace the `editDesignProperties` handler:
+
+```typescript
+export const editDesignProperties = async (c: Ctx) => {
+    const userId = c.get('userId');
+    const body = await c.req.parseBody({ all: true });
+    const files = collectFiles(body.files);
+    const diagramFiles = collectFiles(body.diagramFiles);
+
+    const {
+        name,
+        description,
+        timeRequired,
+        materials,
+        totalMaterialCosts,
+        price,
+        lowStockThreshold,
+        variationGroups,
+        variants,
+        designType,
+        makingNotes,
+        keepImageIds: keepImageIdsRaw,
+        keepDiagramImageIds: keepDiagramImageIdsRaw,
+    } = body as unknown as Partial<EditDesign> & {
+        lowStockThreshold?: string;
+        variationGroups?: string;
+        variants?: string;
+        keepImageIds?: string;
+        keepDiagramImageIds?: string;
+        designType?: string;
+    };
+
+    const keepImageIds: string[] =
+        typeof keepImageIdsRaw === 'string' && keepImageIdsRaw ? JSON.parse(keepImageIdsRaw) : [];
+    const keepDiagramImageIds: string[] =
+        typeof keepDiagramImageIdsRaw === 'string' && keepDiagramImageIdsRaw ? JSON.parse(keepDiagramImageIdsRaw) : [];
+
+    const imageBuffers = await Promise.all(files.map(toImageBuffer));
+    const diagramImageBuffers = await Promise.all(diagramFiles.map(toImageBuffer));
+    const updates: EditDesign = {};
+
+    if (name) updates.name = name as EditDesign['name'];
+    if (description !== undefined) updates.description = description as EditDesign['description'];
+    if (timeRequired) updates.timeRequired = timeRequired as EditDesign['timeRequired'];
+    if (materials) updates.materials = materials as EditDesign['materials'];
+    if (totalMaterialCosts !== undefined) updates.totalMaterialCosts = Number(totalMaterialCosts);
+    if (price !== undefined) updates.price = Number(price);
+    if (variationGroups !== undefined) {
+        updates.variationGroups = typeof variationGroups === 'string' ? JSON.parse(variationGroups) : variationGroups;
+    }
+    if (variants !== undefined) {
+        updates.variants = typeof variants === 'string' ? JSON.parse(variants) : variants;
+    }
+    if (designType !== undefined) updates.designType = designType as EditDesign['designType'];
+    if (lowStockThreshold !== undefined) updates.lowStockThreshold = Number(lowStockThreshold);
+    if (makingNotes !== undefined) updates.makingNotes = makingNotes as EditDesign['makingNotes'];
+
+    const design = await getDesignService().editDesignProperties(
+        c.req.param('id'),
+        updates,
+        imageBuffers,
+        keepImageIds,
+        diagramImageBuffers,
+        keepDiagramImageIds,
+        userId
+    );
+    return c.json(design, 200);
+};
+```
+
+- [ ] **Step 6: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api/src/domain/DesignService/index.ts packages/api/src/domain/DesignService/index.test.ts packages/api/src/handlers/Design/index.ts
+git commit -m "feat(api): support diagram images and making notes on design edit"
+```
+
+---
+
+### Task 4: API — price-suggestion settings on `UserSettingsService`
+
+**Files:**
+- Modify: `packages/api/src/domain/UserSettingsService/index.ts`
+- Modify: `packages/api/src/domain/UserSettingsService/index.test.ts` (create if it doesn't already exist — check first; if `UserSettingsService` currently has no test file, follow `DesignService/index.test.ts`'s mock-based style to create one covering both the pre-existing behavior and the new fields, since this task is extending untested code)
+- Modify: `packages/api/src/handlers/UserSettings/index.ts`
+
+**Interfaces:**
+- Consumes: `UserSettings.markupMultiplier`/`hourlyRate` (Task 1).
+- Produces: `UserSettingsService.get(userId)` now returns `markupMultiplier`/`hourlyRate` with defaults `2.5`/`0` when unset; `UserSettingsService.upsert(userId, { hourlyWage, profitMargin, markupMultiplier, hourlyRate })`.
+
+- [ ] **Step 1: Check for an existing test file**
+
+Run: `ls packages/api/src/domain/UserSettingsService/`
+If `index.test.ts` exists, add to it. If not, create it fresh with a `describe('UserSettingsService')` block mirroring `DesignService/index.test.ts`'s mock style (`mockSettingsRepo`, `mockDesignRepo` mocks, `beforeEach` clearing them).
+
+- [ ] **Step 2: Write the failing tests**
+
+```typescript
+describe('get', () => {
+    it('returns markupMultiplier 2.5 and hourlyRate 0 defaults when no settings stored', async () => {
+        mockSettingsRepo.getByUserId.mockResolvedValue(null);
+
+        const result = await service.get('user-1');
+
+        expect(result.markupMultiplier).toBe(2.5);
+        expect(result.hourlyRate).toBe(0);
+    });
+
+    it('returns stored markupMultiplier and hourlyRate when present', async () => {
+        mockSettingsRepo.getByUserId.mockResolvedValue({
+            userId: 'user-1',
+            hourlyWage: 10,
+            profitMargin: 15,
+            markupMultiplier: 3,
+            hourlyRate: 5,
+        });
+
+        const result = await service.get('user-1');
+
+        expect(result.markupMultiplier).toBe(3);
+        expect(result.hourlyRate).toBe(5);
+    });
+});
+
+describe('upsert — price suggestion fields', () => {
+    it('persists markupMultiplier and hourlyRate alongside the existing fields', async () => {
+        const result = await service.upsert('user-1', {
+            hourlyWage: 12,
+            profitMargin: 20,
+            markupMultiplier: 2,
+            hourlyRate: 8,
+        });
+
+        expect(result).toEqual({
+            userId: 'user-1',
+            hourlyWage: 12,
+            profitMargin: 20,
+            markupMultiplier: 2,
+            hourlyRate: 8,
+        });
+        expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/UserSettingsService/index.test.ts`
+Expected: FAIL — `markupMultiplier`/`hourlyRate` undefined, or wrong-arity `upsert` call
+
+- [ ] **Step 4: Update `UserSettingsService`**
+
+In `packages/api/src/domain/UserSettingsService/index.ts`:
+
+```typescript
+import type { UserSettings } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { UserSettingsRepository } from '../UserSettingsRepository';
+
+const DEFAULT_HOURLY_WAGE = 10;
+const DEFAULT_PROFIT_MARGIN = 15;
+const DEFAULT_MARKUP_MULTIPLIER = 2.5;
+const DEFAULT_HOURLY_RATE = 0;
+
+function parseTimeToHours(timeRequired: string): number {
+    const [hoursStr, minutesStr] = timeRequired.split(':');
+    const hours = parseInt(hoursStr, 10);
+    const minutes = parseInt(minutesStr, 10);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return 0;
+    return hours + minutes / 60;
+}
+
+function calcPrice(materialsCost: number, timeRequired: string, hourlyWage: number, profitMargin: number): number {
+    const hours = parseTimeToHours(timeRequired);
+    const labour = hours * hourlyWage;
+    return parseFloat(((materialsCost + labour) * (1 + profitMargin / 100)).toFixed(2));
+}
+
+export class UserSettingsService {
+    constructor(
+        private readonly settingsRepo: UserSettingsRepository,
+        private readonly designRepo: DesignRepository
+    ) {}
+
+    async get(userId: string): Promise<UserSettings> {
+        const stored = await this.settingsRepo.getByUserId(userId);
+        return (
+            stored ?? {
+                userId,
+                hourlyWage: DEFAULT_HOURLY_WAGE,
+                profitMargin: DEFAULT_PROFIT_MARGIN,
+                markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
+                hourlyRate: DEFAULT_HOURLY_RATE,
+            }
+        );
+    }
+
+    async upsert(
+        userId: string,
+        updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number }
+    ): Promise<UserSettings> {
+        const settings: UserSettings = { userId, ...updates };
+        await this.settingsRepo.upsert(settings);
+        return settings;
+    }
+
+    // ... recalculatePricesForMaterial and recalculatePrices are unchanged — do not touch them, they don't use markupMultiplier/hourlyRate
+```
+
+(Leave `recalculatePricesForMaterial` and `recalculatePrices` exactly as they are — they use `hourlyWage`/`profitMargin` only, which is a deliberately separate mechanism from the new `markupMultiplier`/`hourlyRate` price-suggestion formula per the spec.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/UserSettingsService/index.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Update the `updateUserSettings` handler**
+
+In `packages/api/src/handlers/UserSettings/index.ts`, replace `updateUserSettings`:
+
+```typescript
+export const updateUserSettings = async (c: Ctx) => {
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = (await c.req.json()) as {
+        hourlyWage?: number;
+        profitMargin?: number;
+        markupMultiplier?: number;
+        hourlyRate?: number;
+    };
+
+    if (
+        hourlyWage === undefined ||
+        profitMargin === undefined ||
+        markupMultiplier === undefined ||
+        hourlyRate === undefined
+    ) {
+        throw new APIError('hourlyWage, profitMargin, markupMultiplier and hourlyRate are required', 400);
+    }
+
+    return c.json(
+        await getService().upsert(c.get('userId'), {
+            hourlyWage: Number(hourlyWage),
+            profitMargin: Number(profitMargin),
+            markupMultiplier: Number(markupMultiplier),
+            hourlyRate: Number(hourlyRate),
+        })
+    );
+};
+```
+
+- [ ] **Step 7: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass — check `handlers/UserSettings` has no dedicated test file to update (per Task 5 of the sub-project 1 plan's precedent, `UserSettingsDialog`/settings handlers weren't independently tested; if you find a test file here, update it the same way)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/api/src/domain/UserSettingsService packages/api/src/handlers/UserSettings/index.ts
+git commit -m "feat(api): add markupMultiplier and hourlyRate to user settings"
+```
+
+---
+
+### Task 5: Web — `getSuggestedPrice` util
+
+**Files:**
+- Create: `packages/web/src/utils/getSuggestedPrice/index.ts`
+- Create: `packages/web/src/utils/getSuggestedPrice/index.test.ts`
+
+**Interfaces:**
+- Consumes: `getWageCosts` from `packages/web/src/utils/getWageCost/index.ts` (existing, `(time: string) => number`, returns hours).
+- Produces: `getSuggestedPrice(args: { materialsCost: number; timeRequired: string; markupMultiplier: number; hourlyRate: number }): number` — consumed by Tasks 8, 9, 10.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/web/src/utils/getSuggestedPrice/index.test.ts
+import { describe, expect, it } from 'bun:test';
+
+import { getSuggestedPrice } from './index';
+
+describe('getSuggestedPrice', () => {
+    it('applies materialsCost × markupMultiplier + hours × hourlyRate', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 10,
+            timeRequired: '02:00',
+            markupMultiplier: 2.5,
+            hourlyRate: 5,
+        });
+
+        // 10 * 2.5 = 25, + 2 hours * 5 = 10 -> 35
+        expect(result).toBe(35);
+    });
+
+    it('handles minutes correctly (partial hours)', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 0,
+            timeRequired: '00:30',
+            markupMultiplier: 1,
+            hourlyRate: 10,
+        });
+
+        // 0.5 hours * 10 = 5
+        expect(result).toBe(5);
+    });
+
+    it('rounds to 2 decimal places', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 10,
+            timeRequired: '00:10',
+            markupMultiplier: 1.111,
+            hourlyRate: 3,
+        });
+
+        // 10 * 1.111 = 11.11, + (10/60)*3 = 0.5 -> 11.61
+        expect(result).toBeCloseTo(11.61, 2);
+    });
+
+    it('returns 0 for an unparseable timeRequired without throwing', () => {
+        const result = getSuggestedPrice({
+            materialsCost: 5,
+            timeRequired: '',
+            markupMultiplier: 2,
+            hourlyRate: 10,
+        });
+
+        // materialsCost * markupMultiplier = 10, + 0 hours (unparseable -> NaN -> treated as 0)
+        expect(result).toBe(10);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/web && bun test src/utils/getSuggestedPrice/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/web/src/utils/getSuggestedPrice/index.ts
+import { getWageCosts } from '../getWageCost';
+
+interface GetSuggestedPriceArgs {
+    materialsCost: number;
+    timeRequired: string;
+    markupMultiplier: number;
+    hourlyRate: number;
+}
+
+export const getSuggestedPrice = ({
+    materialsCost,
+    timeRequired,
+    markupMultiplier,
+    hourlyRate,
+}: GetSuggestedPriceArgs): number => {
+    const hours = timeRequired ? getWageCosts(timeRequired) : 0;
+    const safeHours = Number.isFinite(hours) ? hours : 0;
+    const suggested = materialsCost * markupMultiplier + safeHours * hourlyRate;
+    return parseFloat(suggested.toFixed(2));
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/web && bun test src/utils/getSuggestedPrice/index.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/utils/getSuggestedPrice
+git commit -m "feat(web): add getSuggestedPrice formula util"
+```
+
+---
+
+### Task 6: Web — API client changes (diagram images + settings fields)
+
+**Files:**
+- Modify: `packages/web/src/api/endpoints/addDesign/index.ts`
+- Modify: `packages/web/src/api/endpoints/editDesign/index.ts`
+- Modify: `packages/web/src/api/endpoints/userSettings/index.ts`
+
+**Interfaces:**
+- Consumes: `FormDesign.diagramImages` (Task 1), `UserSettings.markupMultiplier`/`hourlyRate` (Task 1).
+- Produces: `makeAddDesignRequest`/`makeEditDesignRequest` now send `diagramFiles`/`existingDiagramImageIds`/`keepDiagramImageIds` alongside the existing `files`/`existingImageIds`/`keepImageIds`; `makeUpdateUserSettingsRequest` now accepts/sends `markupMultiplier`/`hourlyRate`.
+
+- [ ] **Step 1: Update `makeAddDesignRequest`**
+
+In `packages/web/src/api/endpoints/addDesign/index.ts`, add diagram handling right after the existing image handling block (before the `for (const key in formDesign)` loop), and exclude `diagramImages` from that generic loop the same way `images` already is:
+
+```typescript
+    const images = formDesign.images ?? [];
+    const existingImageIds = images.filter((v): v is string => typeof v === 'string');
+    const newFiles = images.filter((v): v is File => v instanceof File);
+
+    for (const file of newFiles) {
+        formData.append('files', file);
+    }
+
+    if (existingImageIds.length > 0) {
+        formData.append('existingImageIds', JSON.stringify(existingImageIds));
+    }
+
+    const diagramImages = formDesign.diagramImages ?? [];
+    const existingDiagramImageIds = diagramImages.filter((v): v is string => typeof v === 'string');
+    const newDiagramFiles = diagramImages.filter((v): v is File => v instanceof File);
+
+    for (const file of newDiagramFiles) {
+        formData.append('diagramFiles', file);
+    }
+
+    if (existingDiagramImageIds.length > 0) {
+        formData.append('existingDiagramImageIds', JSON.stringify(existingDiagramImageIds));
+    }
+
+    for (const key in formDesign) {
+        if (Object.hasOwn(formDesign, key)) {
+            const value = formDesign[key as keyof typeof formDesign];
+
+            if (key === 'images' || key === 'diagramImages') {
+                // handled above
+            } else if (
+                (key === 'materials' || key === 'variationGroups' || key === 'variants') &&
+                Array.isArray(value)
+            ) {
+                formData.append(key, JSON.stringify(value));
+            } else if (typeof value === 'string' || typeof value === 'number') {
+                formData.append(key, value.toString());
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Update `makeEditDesignRequest`**
+
+In `packages/web/src/api/endpoints/editDesign/index.ts`, apply the same pattern (using `keepDiagramImageIds` instead of `existingDiagramImageIds`, matching the existing `keepImageIds` naming in this file):
+
+```typescript
+    const images = formDesign.images ?? [];
+    const keepImageIds = images.filter((v): v is string => typeof v === 'string');
+    const newFiles = images.filter((v): v is File => v instanceof File);
+
+    for (const file of newFiles) {
+        formData.append('files', file);
+    }
+
+    formData.append('keepImageIds', JSON.stringify(keepImageIds));
+
+    const diagramImages = formDesign.diagramImages ?? [];
+    const keepDiagramImageIds = diagramImages.filter((v): v is string => typeof v === 'string');
+    const newDiagramFiles = diagramImages.filter((v): v is File => v instanceof File);
+
+    for (const file of newDiagramFiles) {
+        formData.append('diagramFiles', file);
+    }
+
+    formData.append('keepDiagramImageIds', JSON.stringify(keepDiagramImageIds));
+
+    for (const key in formDesign) {
+        if (Object.hasOwn(formDesign, key)) {
+            const value = formDesign[key as keyof FormDesign];
+
+            if (key === 'images' || key === 'diagramImages') {
+                // handled above
+            } else if (
+                (key === 'materials' || key === 'variationGroups' || key === 'variants') &&
+                Array.isArray(value)
+            ) {
+                formData.append(key, JSON.stringify(value));
+            } else if (typeof value === 'string' || typeof value === 'number') {
+                formData.append(key, value.toString());
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Update `userSettings` endpoint functions**
+
+In `packages/web/src/api/endpoints/userSettings/index.ts`, update `makeUpdateUserSettingsRequest`'s parameter type and body:
+
+```typescript
+export const makeUpdateUserSettingsRequest = (
+    updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<UserSettings>(
+        {
+            pathname: USER_SETTINGS_ENDPOINT,
+            method: MethodType.PUT,
+            headers: { 'Content-Type': 'application/json' },
+            operationString: 'update user settings',
+            body: updates,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+(`makeGetUserSettingsRequest`/`makeRecalculatePricesRequest` are unchanged — leave them exactly as they are.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: errors at every call site of `makeUpdateUserSettingsRequest` that doesn't yet pass `markupMultiplier`/`hourlyRate` — this is expected; Task 7 fixes the one call site (`useUserSettings.ts`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/api/endpoints/addDesign packages/web/src/api/endpoints/editDesign packages/web/src/api/endpoints/userSettings
+git commit -m "feat(web): send diagram images and price-suggestion settings to the api"
+```
+
+(Typecheck errors from Step 4 are expected to persist until Task 7 — do not try to fix `useUserSettings.ts` in this task, it's the next one.)
+
+---
+
+### Task 7: Web — `useUserSettings` hook
+
+**Files:**
+- Modify: `packages/web/src/hooks/useUserSettings.ts`
+
+**Interfaces:**
+- Consumes: `makeUpdateUserSettingsRequest` (Task 6).
+- Produces: `useUserSettings()` now also returns `markupMultiplier: number` and `hourlyRate: number`; `updateSettings` now accepts `{ hourlyWage, profitMargin, markupMultiplier, hourlyRate }` — consumed by Tasks 8, 9, 11.
+
+- [ ] **Step 1: Update the hook**
+
+Replace `packages/web/src/hooks/useUserSettings.ts` in full:
+
+```typescript
+import { useAuth } from '@imapps/web-utils';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+    makeGetUserSettingsRequest,
+    makeRecalculatePricesRequest,
+    makeUpdateUserSettingsRequest,
+} from '../api/endpoints/userSettings';
+
+const QUERY_KEY = ['user-settings'];
+
+export const useUserSettings = () => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    const { data, isLoading } = useQuery({
+        queryKey: QUERY_KEY,
+        queryFn: () => makeGetUserSettingsRequest(() => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: (updates: { hourlyWage: number; profitMargin: number; markupMultiplier: number; hourlyRate: number }) =>
+            makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
+        onSuccess: (updated) => {
+            queryClient.setQueryData(QUERY_KEY, updated);
+        },
+    });
+
+    const recalculateMutation = useMutation({
+        mutationFn: () => makeRecalculatePricesRequest(() => accessToken, login, logout),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['designs'] });
+        },
+    });
+
+    return {
+        hourlyWage: data?.hourlyWage ?? 10,
+        profitMargin: data?.profitMargin ?? 15,
+        markupMultiplier: data?.markupMultiplier ?? 2.5,
+        hourlyRate: data?.hourlyRate ?? 0,
+        isLoading,
+        updateSettings: updateMutation.mutateAsync,
+        recalculate: recalculateMutation.mutateAsync,
+        isRecalculating: recalculateMutation.isPending,
+        recalculateResult: recalculateMutation.data,
+        recalculateError: recalculateMutation.error,
+    };
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: this fixes the `useUserSettings.ts` call site from Task 6; new errors will appear at every caller of `updateSettings(...)` in `packages/web/src/pages/Settings/index.tsx` that doesn't yet pass the two new fields — expected, fixed in Task 11
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/src/hooks/useUserSettings.ts
+git commit -m "feat(web): expose markupMultiplier and hourlyRate from useUserSettings"
+```
+
+---
+
+### Task 8: Web — shared "Maker docs" and "Suggested price" components
+
+**Files:**
+- Create: `packages/web/src/components/MakerDocsSection/index.tsx`
+- Create: `packages/web/src/components/SuggestedPrice/index.tsx`
+
+**Interfaces:**
+- Consumes: `MultiImageUpload` (existing, `packages/web/src/components/MultiImageUpload`), `Textarea` (existing, `packages/web/src/components/ui/textarea`), `getSuggestedPrice` (Task 5), react-hook-form `Control`/`FormField` primitives (existing, `packages/web/src/components/ui/form`).
+- Produces: `<MakerDocsSection control={form.control} />` — a self-contained pair of `FormField`s for `diagramImages` (via `MultiImageUpload`) and `makingNotes` (via `Textarea`), matching the "Upload Images"/"Add Description" section markup pattern in `AddDesign`/`DesignEditForm` exactly (12-column grid, `hr` separators are added by the caller, not this component — this component renders only the inner content of one section). `<SuggestedPrice materialsCost={number} timeRequired={string} markupMultiplier={number} hourlyRate={number} onUse={(price: number) => void} />` — renders the read-only suggestion text and a "Use this price" button that calls `onUse` with the computed value.
+
+- [ ] **Step 1: Write `MakerDocsSection`**
+
+```typescript
+// packages/web/src/components/MakerDocsSection/index.tsx
+import type { Control } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+
+import MultiImageUpload from '../MultiImageUpload';
+
+interface MakerDocsSectionProps {
+    control: Control<any>;
+}
+
+const MakerDocsSection: React.FC<MakerDocsSectionProps> = ({ control }) => (
+    <div className="space-y-4">
+        <FormField
+            control={control}
+            name="diagramImages"
+            render={({ field, fieldState }) => (
+                <FormItem>
+                    <FormLabel>Diagrams (private — never shown on Etsy)</FormLabel>
+                    <FormControl>
+                        <MultiImageUpload
+                            value={field.value ?? []}
+                            onChange={field.onChange}
+                            hasError={!!fieldState.error}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+        <FormField
+            control={control}
+            name="makingNotes"
+            render={({ field }) => (
+                <FormItem>
+                    <FormLabel>Making notes (private — never shown on Etsy)</FormLabel>
+                    <FormControl>
+                        <Textarea
+                            placeholder="Steps, measurements, gotchas for making this design again..."
+                            value={field.value ?? ''}
+                            onChange={field.onChange}
+                            rows={4}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    </div>
+);
+
+export default MakerDocsSection;
+```
+
+- [ ] **Step 2: Write `SuggestedPrice`**
+
+```typescript
+// packages/web/src/components/SuggestedPrice/index.tsx
+import { Button } from '@/components/ui/button';
+
+import { getSuggestedPrice } from '../../utils/getSuggestedPrice';
+
+interface SuggestedPriceProps {
+    materialsCost: number;
+    timeRequired: string;
+    markupMultiplier: number;
+    hourlyRate: number;
+    onUse: (price: number) => void;
+}
+
+const SuggestedPrice: React.FC<SuggestedPriceProps> = ({
+    materialsCost,
+    timeRequired,
+    markupMultiplier,
+    hourlyRate,
+    onUse,
+}) => {
+    const suggested = getSuggestedPrice({ materialsCost, timeRequired, markupMultiplier, hourlyRate });
+
+    return (
+        <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">
+                Suggested: <span className="font-mono text-foreground">£{suggested.toFixed(2)}</span>
+            </span>
+            <Button type="button" variant="ghost" size="sm" onClick={() => onUse(suggested)}>
+                Use this price
+            </Button>
+        </div>
+    );
+};
+
+export default SuggestedPrice;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: no errors from these two new files (unused-export warnings are fine — they're consumed starting Task 9)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/components/MakerDocsSection packages/web/src/components/SuggestedPrice
+git commit -m "feat(web): add MakerDocsSection and SuggestedPrice components"
+```
+
+---
+
+### Task 9: Web — wire Maker docs + suggested price into `AddDesign` and `DesignEditForm`
+
+**Files:**
+- Modify: `packages/web/src/pages/AddDesign/index.tsx`
+- Modify: `packages/web/src/components/DesignEditForm/index.tsx`
+
+**Interfaces:**
+- Consumes: `MakerDocsSection`, `SuggestedPrice` (Task 8), `useUserSettings().markupMultiplier`/`hourlyRate` (Task 7).
+- Produces: both forms gain a "Maker Docs" section (after "Upload Images", before "Add Materials" — matches the spec's stated form order intent of grouping maker-only content near the top) and a `SuggestedPrice` shown beside the "Final Price" field, non-variant case only (the variant case already shows "Varies per variant" text — Task 10 adds a per-variant suggestion column separately, not here).
+
+- [ ] **Step 1: Update `AddDesign`**
+
+In `packages/web/src/pages/AddDesign/index.tsx`:
+
+1. Add the import:
+
+```typescript
+import MakerDocsSection from '../../components/MakerDocsSection';
+import SuggestedPrice from '../../components/SuggestedPrice';
+```
+
+2. Add `diagramImages: []` and `makingNotes: ''` to the `defaultValues` object (alongside the existing `images: []`).
+
+3. Destructure `markupMultiplier`/`hourlyRate` alongside the existing `hourlyWage`/`profitMargin`:
+
+```typescript
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate } = useUserSettings();
+```
+
+4. Insert a new section immediately after the "Upload Images Section" `<hr />` (i.e., right after the closing `</div>` of that section's grid, before the "Add Materials Section" comment):
+
+```typescript
+                        <hr className="border-t border-border" />
+
+                        {/* Maker Docs Section */}
+                        <div className="grid grid-cols-12 gap-4">
+                            <div className="col-span-4">
+                                <h2 className="text-lg font-medium text-center">Maker Docs</h2>
+                                <p className="text-xs text-muted-foreground text-center mt-1">
+                                    Private — diagrams and notes never sent to Etsy
+                                </p>
+                            </div>
+                            <div className="col-span-8">
+                                <MakerDocsSection control={form.control} />
+                            </div>
+                        </div>
+```
+
+5. In the non-variant branch of the "Final Price" `FormField` (inside `PriceBreakdown`'s `priceField` prop), add `<SuggestedPrice>` right after the closing `</InputGroup>` and before `<FormDescription>`:
+
+```typescript
+                                                        </InputGroup>
+                                                    </FormControl>
+                                                    <SuggestedPrice
+                                                        materialsCost={form.watch('totalMaterialCosts') ?? 0}
+                                                        timeRequired={currentTimeRequired}
+                                                        markupMultiplier={markupMultiplier}
+                                                        hourlyRate={hourlyRate}
+                                                        onUse={(price) => field.onChange(price)}
+                                                    />
+                                                    <FormDescription>
+```
+
+- [ ] **Step 2: Update `DesignEditForm`**
+
+Apply the identical four changes to `packages/web/src/components/DesignEditForm/index.tsx`:
+1. Same two imports.
+2. Add `diagramImages: design.diagramImageIds ?? []` and `makingNotes: design.makingNotes ?? ''` to `defaultValues` (note: unlike `AddDesign`, this form pre-fills from an existing `design` prop — follow the exact pattern already used for `images: design.imageIds`).
+3. Same `markupMultiplier`/`hourlyRate` destructure from `useUserSettings()`.
+4. Same Maker Docs section insertion after "Upload Images Section", and same `<SuggestedPrice>` insertion in the non-variant price field branch.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 4: Manual smoke test**
+
+Run the web+api dev servers (check root `package.json` for `bun run start` or `bun run start:with-mock`), navigate to `/addDesign`, confirm: the Maker Docs section renders with a diagram upload area and notes textarea; entering a materials cost + time shows a "Suggested: £X.XX" line beside the Final Price field with a working "Use this price" button that copies the value in without changing anything else. Repeat on an existing design's "Edit Details" dialog (`DesignEditForm`, reached from `/designs/:id`) — confirm existing diagram images (none yet, since this is the first design to have any) and notes prefill correctly, i.e. render as empty without crashing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/pages/AddDesign/index.tsx packages/web/src/components/DesignEditForm/index.tsx
+git commit -m "feat(web): wire Maker Docs section and price suggestion into design forms"
+```
+
+---
+
+### Task 10: Web — per-variant suggested price column
+
+**Files:**
+- Modify: `packages/web/src/components/VariationGroupBuilder/index.tsx`
+
+**Interfaces:**
+- Consumes: `getSuggestedPrice` (Task 5).
+- Produces: the variant preview table gains a "Suggested" column next to the existing "Price" column, computed per-row from that variant's `totalMaterialCosts` and the shared design-level `timeRequired`.
+
+- [ ] **Step 1: Read the current table structure**
+
+Read `packages/web/src/components/VariationGroupBuilder/index.tsx` around the table rendering (near the `<TableCell>£{v.totalMaterialCosts.toFixed(2)}</TableCell>` / `<TableCell>£{v.price.toFixed(2)}</TableCell>` lines found earlier) to see the exact `<TableHeader>`/`<TableRow>` structure and what props (`hourlyWage`, `profitMargin`, `timeRequired`) this component already receives — this task adds two more props (`markupMultiplier`, `hourlyRate`) alongside those existing ones, following the identical prop-passing pattern.
+
+- [ ] **Step 2: Add the two new props**
+
+Add `markupMultiplier: number` and `hourlyRate: number` to this component's props interface, next to the existing `hourlyWage`/`profitMargin` props.
+
+- [ ] **Step 3: Add the import and table column**
+
+Add the import:
+
+```typescript
+import { getSuggestedPrice } from '../../utils/getSuggestedPrice';
+```
+
+In the `<TableHeader>`'s row, add a new `<TableHead>Suggested</TableHead>` immediately after the existing `<TableHead>Price</TableHead>` (or equivalent — match whatever the existing price column header text is).
+
+In the variant preview `<TableRow>` mapping, add a new `<TableCell>` immediately after the existing `<TableCell>£{v.price.toFixed(2)}</TableCell>`:
+
+```typescript
+                            <TableCell>
+                                £
+                                {getSuggestedPrice({
+                                    materialsCost: v.totalMaterialCosts,
+                                    timeRequired,
+                                    markupMultiplier,
+                                    hourlyRate,
+                                }).toFixed(2)}
+                            </TableCell>
+```
+
+- [ ] **Step 4: Update both callers to pass the new props**
+
+In `packages/web/src/pages/AddDesign/index.tsx` and `packages/web/src/components/DesignEditForm/index.tsx`, find the existing `<VariationGroupBuilder ... hourlyWage={hourlyWage} profitMargin={profitMargin} timeRequired={currentTimeRequired} />` usage and add:
+
+```typescript
+                                        markupMultiplier={markupMultiplier}
+                                        hourlyRate={hourlyRate}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 6: Manual smoke test**
+
+On `/addDesign`, add a variation group with at least one option, confirm the variant preview table now shows a "Suggested" column with a plausible value that updates as materials/time change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/components/VariationGroupBuilder/index.tsx packages/web/src/pages/AddDesign/index.tsx packages/web/src/components/DesignEditForm/index.tsx
+git commit -m "feat(web): show per-variant suggested price in variation preview"
+```
+
+---
+
+### Task 11: Web — price-suggestion settings on the Settings page
+
+**Files:**
+- Modify: `packages/web/src/pages/Settings/index.tsx`
+
+**Interfaces:**
+- Consumes: `useUserSettings()` (Task 7, now returning/accepting `markupMultiplier`/`hourlyRate`).
+- Produces: the existing "Pricing" section on `/settings` gains two more fields; `handleSavePricing` sends all four values on save.
+
+- [ ] **Step 1: Read the current Pricing section**
+
+Read `packages/web/src/pages/Settings/index.tsx`'s Pricing `<section>` (built in the sub-project 1 plan — has "Hourly Wage" and "Profit Margin" `InputGroup` fields, `localWage`/`localMargin` local state, and a `handleSavePricing` function that calls `updateSettings({ hourlyWage, profitMargin })`).
+
+- [ ] **Step 2: Add local state for the two new fields**
+
+Alongside the existing `localWage`/`localMargin` `useState` declarations, add:
+
+```typescript
+    const [localMarkupMultiplier, setLocalMarkupMultiplier] = useState<number | ''>(markupMultiplier);
+    const [localHourlyRate, setLocalHourlyRate] = useState<number | ''>(hourlyRate);
+```
+
+Destructure `markupMultiplier`, `hourlyRate` from `useUserSettings()` alongside the existing `hourlyWage`, `profitMargin`.
+
+In the existing `useEffect` that syncs local state when `hourlyWage`/`profitMargin` change, add the same sync for the two new fields (same dependency-array pattern).
+
+- [ ] **Step 3: Update `handleSavePricing` to include the new fields**
+
+Wherever `handleSavePricing` currently calls `updateSettings({ hourlyWage: wage, profitMargin: margin })`, change it to:
+
+```typescript
+            await updateSettings({
+                hourlyWage: wage,
+                profitMargin: margin,
+                markupMultiplier: Number(localMarkupMultiplier),
+                hourlyRate: Number(localHourlyRate),
+            });
+```
+
+- [ ] **Step 4: Add the two new fields to the Pricing section markup**
+
+Immediately after the existing "Profit Margin" `InputGroup` block in the Pricing `<section>`, add:
+
+```typescript
+                <div className="space-y-1.5">
+                    <Label>Etsy Price Suggestion — Markup Multiplier</Label>
+                    <InputGroup className="max-w-[140px]">
+                        <InputGroupInput
+                            type="number"
+                            min="0"
+                            step="0.1"
+                            disabled={pricingBusy}
+                            value={localMarkupMultiplier}
+                            onChange={(e) =>
+                                setLocalMarkupMultiplier(e.target.value === '' ? '' : parseFloat(e.target.value))
+                            }
+                        />
+                        <InputGroupAddon align="inline-end">
+                            <InputGroupText>×</InputGroupText>
+                        </InputGroupAddon>
+                    </InputGroup>
+                </div>
+                <div className="space-y-1.5">
+                    <Label>Etsy Price Suggestion — Hourly Rate</Label>
+                    <InputGroup className="max-w-[160px]">
+                        <InputGroupAddon align="inline-start">
+                            <InputGroupText>£</InputGroupText>
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            type="number"
+                            min="0"
+                            step="0.50"
+                            disabled={pricingBusy}
+                            value={localHourlyRate}
+                            onChange={(e) =>
+                                setLocalHourlyRate(e.target.value === '' ? '' : parseFloat(e.target.value))
+                            }
+                        />
+                        <InputGroupAddon align="inline-end">
+                            <InputGroupText>/hr</InputGroupText>
+                        </InputGroupAddon>
+                    </InputGroup>
+                </div>
+```
+
+(Uses the existing `pricingBusy` derived flag already present on this page from the sub-project 1 fix — reuse it, don't reintroduce a new disabled-state variable.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 6: Manual smoke test**
+
+Navigate to `/settings`, confirm the two new fields appear under Pricing with the correct defaults (2.5 and 0 for a fresh user), edit them, save, refresh the page, confirm the values persisted.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/pages/Settings/index.tsx
+git commit -m "feat(web): add price-suggestion fields to Settings pricing section"
+```
+
+---
+
+### Task 12: Web — Maker docs display on `ViewDesign`
+
+**Files:**
+- Modify: `packages/web/src/pages/ViewDesign/index.tsx`
+
+**Interfaces:**
+- Consumes: `Design.diagramImageIds`/`makingNotes` (Task 1), `Image` component (existing, `packages/web/src/components/Image`).
+- Produces: a new "Maker Docs" display section on the design detail page, visible only to the design's owner (this page is already scoped to the logged-in user's own designs via `getDesignQuery`, so no extra auth check is needed — every design shown here already belongs to the viewer).
+
+- [ ] **Step 1: Destructure the new fields**
+
+In the existing destructure of `design` (the block starting `const { timeRequired, imageIds, name, ... } = design ?? {};`), add `diagramImageIds` and `makingNotes`.
+
+- [ ] **Step 2: Add a display section**
+
+Find a sensible spot in the existing 2-column layout (near the existing description/materials display — read the rest of the file past line 120 to find where `description`/`hasDescription` is rendered, and add the Maker Docs block immediately after that same section, following its markup style):
+
+```typescript
+                {(diagramImageIds && diagramImageIds.length > 0) || makingNotes ? (
+                    <div className="mt-8 rounded-lg border border-border bg-muted/30 p-6">
+                        <h2 className="text-lg font-medium mb-1">Maker Docs</h2>
+                        <p className="text-xs text-muted-foreground mb-4">Private — never shown on Etsy</p>
+
+                        {diagramImageIds && diagramImageIds.length > 0 && (
+                            <div className="flex flex-wrap gap-3 mb-4">
+                                {diagramImageIds.map((id) => (
+                                    <div
+                                        key={id}
+                                        className="w-24 h-24 rounded-md overflow-hidden border border-border"
+                                    >
+                                        <Image imageId={id} />
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {makingNotes && <p className="text-sm whitespace-pre-wrap">{makingNotes}</p>}
+                    </div>
+                ) : null}
+```
+
+Adjust the exact placement/wrapping `<div>` nesting to match whatever container the description section already lives in — read the surrounding JSX before inserting, since this page's layout (2-column grid split at line 116) means the right place is inside the right-hand ("info") column, not the left-hand ("image") column.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd packages/web && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 4: Manual smoke test**
+
+Add a design with diagram images + notes via `/addDesign`, view it at `/designs/:id`, confirm the Maker Docs section renders the diagrams and notes. Add a design with neither, confirm the section doesn't render at all (no empty box).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/pages/ViewDesign/index.tsx
+git commit -m "feat(web): display maker docs on the design detail page"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Schema (`diagramImageIds`/`makingNotes` on `Design`, private-by-construction since the Etsy push mapper in sub-project 3 simply won't read these fields — Task 1) · Forms get a "Maker docs" section reusing the existing image pipeline (Task 8, 9) · Drafts autosave "covers new fields for free" — verified true for `makingNotes` (plain string flows through `useDraftAutosave`'s generic `serializableData` spread) and accepted as the same pre-existing limitation as multi-image drafts for `diagramImages` File objects (documented in Global Constraints, not a new gap) · Pricing suggestion formula, defaults, settings fields (Task 4, 5) · shown read-only beside price input on design and per-variant, never auto-applied, one-click copy (Task 9, 10, 11).
+- **Placeholder scan:** no TBD/TODO markers; every step has runnable code or an exact command. Two steps (Task 9 Step 1.2/2, Task 12 Step 2) ask the implementer to read surrounding code before inserting rather than giving a full-file diff — this is intentional, not a placeholder: the exact insertion point depends on file content already described precisely enough to locate (a named comment/JSX block), and reproducing the entire 400+ line surrounding file for context would fail DRY without adding accuracy.
+- **Type consistency:** `DesignService.addDesign`/`editDesignProperties` new parameter order (`diagramImageBuffers`, then `existingDiagramImageIds`/`keepDiagramImageIds`, both before `userId`) is used identically in Task 2/3's tests, implementation, and handler call sites. `getSuggestedPrice`'s parameter object shape (`materialsCost`, `timeRequired`, `markupMultiplier`, `hourlyRate`) matches exactly between Task 5's definition and every consumer (Tasks 8, 9, 10). `useUserSettings()`'s returned/accepted field names (`markupMultiplier`, `hourlyRate`) match `UserSettings` (Task 1) and `UserSettingsService` (Task 4) throughout.

--- a/docs/superpowers/plans/2026-07-18-push-to-etsy-as-draft.md
+++ b/docs/superpowers/plans/2026-07-18-push-to-etsy-as-draft.md
@@ -1,0 +1,2224 @@
+# Push to Etsy as Draft (Sub-project 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Mari push a Design to Etsy as a draft listing (fields, photos, variations) from a "Send to Etsy" button on the design page — Sub-project 3 of `docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md`. Builds on sub-project 1 (OAuth connection, merged) and sub-project 2 (maker docs + price suggestion, branch `feat/design-authoring-upgrades`). This branch stacks on top of `feat/design-authoring-upgrades` — it is not based on `main`.
+
+**Architecture:** Same layered pattern as sub-projects 1/2: `types` (zod) → `domain` (`EtsyClient` gains push-related HTTP methods; new `EtsyPushService` orchestrates the push using pure, independently-tested mapper functions; `EtsyConnectionService`/`UserSettingsService` gain small additions) → `handlers`/`routes` → web (`api/endpoints` + a `useEtsyPush`/`useEtsyTaxonomy` hook pair + a push-review dialog + `ViewDesign`/`Settings` wiring). The Etsy wire-format mapping (design → `createDraftListing` body, variants → inventory body, template rendering) lives in pure, unit-tested functions per the spec's Testing section — `EtsyClient`'s job is only to be a thin, tested HTTP wrapper around already-mapped input.
+
+**Tech Stack:** Bun + TypeScript + Hono (api), React + react-query + react-hook-form (web), MongoDB, Zod, bun:test.
+
+## Global Constraints
+
+- `createDraftListing` required fields (verbatim from spec): `quantity, title, description, price, who_made, when_made, taxonomy_id`. Fixed values (spec, sub-project 3 section): `who_made=i_did`, `when_made=made_to_order`, `quantity` from design `totalQuantity` (minimum 1).
+- Photos: only product photos (`design.imageIds`) are pushed — `diagramImageIds` are private maker docs and must NEVER be sent to Etsy in any payload. Pushing with zero product photos is allowed (Etsy only requires ≥1 image to *publish*, not to create a draft).
+- Variations: Etsy caps at 2 variation properties. If `design.variationGroups.length > 2`, reject the push with a clear error before calling Etsy at all. Mapping (verbatim from spec): variation group name → Etsy property name, option material names → property values, each variant → offering `{ price, quantity, is_enabled }`.
+- Re-push is blocked in v1: if a design already has `etsy.listingId` set and `etsy.pushIncomplete` is not `true`, reject with "already on Etsy" — no update/re-push flow exists yet (spec Non-goals).
+- Failure/resume model (verbatim from spec): steps are sequential (create listing → upload images → put inventory → persist). On failure after listing creation, the listing id is persisted immediately with `pushIncomplete: true` so a retry can resume: images are only uploaded if Etsy doesn't already have them (checked via `getListingImages`, not blindly re-uploaded), inventory is always safely re-put (Etsy's inventory endpoint is a full overwrite `PUT`, so re-calling it is idempotent by construction). Etsy 4xx error bodies surface verbatim to the caller; no partial design mutation happens beyond the `pushIncomplete` flag.
+- Description composition: per-user template (`UserSettings.etsyDescriptionTemplate`, plain text with `{description}`/`{materials}` placeholders) rendered against the design's own `description` and `materials` (material `name`s, comma-joined), editable by the caller before send (the dialog sends the final, possibly-edited string; the API never re-renders it — the template is only ever used to produce the dialog's *initial* value).
+- Category: `designType → taxonomy_id` map in user settings (`UserSettings.etsyTaxonomyMap: Record<string, number>`, keyed by the `DesignType` enum's string values). Missing mapping for the design's `designType` (or a design with no `designType` at all) blocks the push with a clear error — there is no fallback category.
+- Etsy `x-api-key` header format is colon-joined `<keystring>:<shared_secret>` (same as sub-project 1's `EtsyClient` — reuse `apiKeyHeader()`, do not duplicate the header-building logic).
+- All new `EtsyClient` HTTP methods take `accessToken`/`shopId` as explicit parameters (the client stays stateless per-call, matching the existing `getMe(accessToken)`/`getShop(shopId)` methods from sub-project 1) — do not give `EtsyClient` its own notion of "the current user."
+- Follow the existing repo's layered pattern exactly (`DesignService`/`UserSettingsService`/`EtsyConnectionService` are the reference shape) — do not introduce a different pattern. `EtsyPushService` is a new, separate domain service (not a method bag bolted onto `DesignService`), constructed from `DesignRepository`, `ImageService`, `EtsyClient`, `EtsyConnectionService`, `UserSettingsService`.
+- Tests: `bun:test`, mocks via `mock()`, following `DesignService/index.test.ts`/`EtsyConnectionService/index.test.ts` conventions. Mapper functions (Task 5) are pure and get their own dedicated unit tests with zero mocking.
+- Lint/format: `bun run lint` (Biome) must pass on touched files before each commit.
+- **Typecheck caveat (carried over from sub-project 2):** `bunx tsc --noEmit` inside `packages/web` (and the repo's CI `bun run tsc --noEmit`) is a silent no-op — the tsconfig is solution-style (`files: []`, no `include`), so it always exits 0 having checked nothing. Use `bunx tsc --build --force` from the repo root for a real check, then `git clean -fd -- packages/` to remove the generated `.d.ts`/`.tsbuildinfo`/`.js` artifacts it leaves behind (do NOT use `-x`, do NOT run `git clean` outside `packages/`). A pre-existing baseline of ~39-41 unrelated errors exists on `main` (react-hook-form version conflicts, a couple of deep-import resolution errors, etc.) — diff against that baseline rather than expecting a clean run. `packages/api` and `packages/types` do NOT have this problem; `bunx tsc --noEmit` works normally there.
+- This plan does not implement Status refresh (sub-project 4) or the one-time linking script (sub-project 5) — those are separate plans. It also does not implement re-push/update-after-push (spec Non-goal for v1).
+
+---
+
+## File Structure
+
+```
+packages/types/src/design/index.ts                            # + etsy field
+packages/types/src/userSettings/index.ts                       # + etsyDescriptionTemplate, etsyTaxonomyMap
+
+packages/api/src/domain/EtsyClient/index.ts                    # + createDraftListing, uploadListingImage, getListingImages, updateListingInventory, getSellerTaxonomyNodes
+packages/api/src/domain/EtsyClient/index.test.ts
+packages/api/src/domain/EtsyConnectionService/index.ts         # + getPushCredentials
+packages/api/src/domain/EtsyConnectionService/index.test.ts
+packages/api/src/domain/UserSettingsService/index.ts           # + etsyDescriptionTemplate/etsyTaxonomyMap defaults + upsert
+packages/api/src/domain/UserSettingsService/index.test.ts
+packages/api/src/domain/EtsyPushService/mappers.ts              # new: pure, unit-tested mapper functions
+packages/api/src/domain/EtsyPushService/mappers.test.ts
+packages/api/src/domain/EtsyPushService/index.ts                 # new: push orchestration
+packages/api/src/domain/EtsyPushService/index.test.ts
+packages/api/src/handlers/Etsy/index.ts                         # + pushDesignToEtsy, getEtsyTaxonomy handlers
+packages/api/src/handlers/UserSettings/index.ts                  # + etsyDescriptionTemplate/etsyTaxonomyMap in updateUserSettings
+packages/api/src/dependencies/types.ts                           # + EtsyPushService token
+packages/api/src/dependencies/index.ts                           # + registration
+packages/api/src/routes/index.ts                                 # + POST /api/designs/:id/etsy-push, GET /api/etsy/taxonomy
+packages/api/src/index.ts                                        # + unique sparse index on etsy.listingId
+
+packages/web/src/api/endpoints.ts                                # + ETSY_PUSH_ENDPOINT-building helper, ETSY_TAXONOMY_ENDPOINT
+packages/web/src/api/endpoints/etsyPush/index.ts                  # new
+packages/web/src/api/endpoints/etsyTaxonomy/index.ts               # new
+packages/web/src/api/endpoints/userSettings/index.ts               # + etsyDescriptionTemplate/etsyTaxonomyMap
+packages/web/src/utils/flattenTaxonomyNodes/index.ts                # new pure util
+packages/web/src/utils/flattenTaxonomyNodes/index.test.ts
+packages/web/src/hooks/useEtsyPush.ts                                # new
+packages/web/src/hooks/useEtsyTaxonomy.ts                            # new
+packages/web/src/hooks/useUserSettings.ts                            # + etsyDescriptionTemplate/etsyTaxonomyMap
+packages/web/src/components/EtsyPushDialog/index.tsx                  # new
+packages/web/src/pages/ViewDesign/index.tsx                           # + Etsy chip + "Send to Etsy" button + dialog
+packages/web/src/pages/Settings/index.tsx                             # + Etsy description template + taxonomy map sections
+```
+
+---
+
+### Task 1: Types — `Design.etsy` + `UserSettings` Etsy fields
+
+**Files:**
+- Modify: `packages/types/src/design/index.ts`
+- Modify: `packages/types/src/userSettings/index.ts`
+
+**Interfaces:**
+- Produces: `Design.etsy?: { listingId: number; state: 'draft' | 'active' | 'inactive'; lastPushedAt: number | null; pushIncomplete?: boolean }`, `UserSettings.etsyDescriptionTemplate: string`, `UserSettings.etsyTaxonomyMap: Record<string, number>` — consumed by every later task in this plan.
+
+- [ ] **Step 1: Add `etsy` to `designSchema`**
+
+In `packages/types/src/design/index.ts`, add the schema (after `designType`) and its type export:
+
+```typescript
+export const etsyListingStateSchema = z.enum(['draft', 'active', 'inactive']);
+export type EtsyListingState = z.infer<typeof etsyListingStateSchema>;
+
+export const designEtsySchema = z.object({
+    listingId: z.number(),
+    state: etsyListingStateSchema,
+    lastPushedAt: z.number().nullable(),
+    pushIncomplete: z.boolean().optional(),
+});
+export type DesignEtsy = z.infer<typeof designEtsySchema>;
+```
+
+Then add the field to `designSchema`'s `z.object({...})`, after `designType: z.nativeEnum(DesignType).optional(),`:
+
+```typescript
+    designType: z.nativeEnum(DesignType).optional(),
+    etsy: designEtsySchema.optional(),
+```
+
+- [ ] **Step 2: Add fields to `userSettingsSchema`**
+
+In `packages/types/src/userSettings/index.ts`, replace the file in full:
+
+```typescript
+import { z } from 'zod';
+
+export const userSettingsSchema = z.object({
+    userId: z.string(),
+    hourlyWage: z.number().nonnegative(),
+    profitMargin: z.number().nonnegative(),
+    markupMultiplier: z.number().nonnegative(),
+    hourlyRate: z.number().nonnegative(),
+    etsyDescriptionTemplate: z.string(),
+    etsyTaxonomyMap: z.record(z.string(), z.number()),
+});
+
+export type UserSettings = z.infer<typeof userSettingsSchema>;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd packages/types && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/types/src/design/index.ts packages/types/src/userSettings/index.ts
+git commit -m "feat(types): add Design.etsy and UserSettings Etsy push fields"
+```
+
+---
+
+### Task 2: API — `EtsyClient` push-related HTTP methods
+
+**Files:**
+- Modify: `packages/api/src/domain/EtsyClient/index.ts`
+- Modify: `packages/api/src/domain/EtsyClient/index.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (this is the same file sub-project 1 created; this task only adds methods to the existing `EtsyClient` class).
+- Produces (all new, added to the existing `EtsyClient` class from sub-project 1 — do not remove or modify `buildAuthorizationUrl`/`exchangeCodeForToken`/`refreshAccessToken`/`getMe`/`getShop`):
+  - `interface EtsyDraftListingInput { title: string; description: string; price: number; quantity: number; whoMade: string; whenMade: string; taxonomyId: number }`
+  - `interface EtsyListingResult { listingId: number }`
+  - `createDraftListing(accessToken: string, shopId: number, input: EtsyDraftListingInput): Promise<EtsyListingResult>`
+  - `uploadListingImage(accessToken: string, shopId: number, listingId: number, image: { buffer: Buffer; contentType: string; filename: string }, rank: number): Promise<void>`
+  - `getListingImages(accessToken: string, listingId: number): Promise<{ imageIds: number[] }>`
+  - `interface EtsyInventoryProduct { propertyValues: Array<{ propertyName: string; values: string[] }>; offering: { price: number; quantity: number; isEnabled: boolean } }`
+  - `updateListingInventory(accessToken: string, listingId: number, products: EtsyInventoryProduct[]): Promise<void>`
+  - `interface EtsyTaxonomyNode { id: number; name: string; children: EtsyTaxonomyNode[] }`
+  - `getSellerTaxonomyNodes(): Promise<EtsyTaxonomyNode[]>`
+  - consumed by `EtsyPushService` (Tasks 5/6) and `handlers/Etsy` (Task 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/api/src/domain/EtsyClient/index.test.ts`, inside the existing `describe('EtsyClient', ...)` block (it already has a `beforeEach` that constructs `client = new EtsyClient('key123', 'secret456')` and mocks `globalThis.fetch` — reuse that setup, add these as sibling `describe`s to the existing `buildAuthorizationUrl`/`exchangeCodeForToken`/`refreshAccessToken` blocks):
+
+```typescript
+    describe('createDraftListing', () => {
+        it('posts the mapped body to the shop listings endpoint and maps the response', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_id: 999 }), { status: 200 }));
+
+            const result = await client.createDraftListing('at-token', 47408839, {
+                title: 'Silver Ring',
+                description: 'A lovely ring.',
+                price: 25.5,
+                quantity: 3,
+                whoMade: 'i_did',
+                whenMade: 'made_to_order',
+                taxonomyId: 1234,
+            });
+
+            expect(result).toEqual({ listingId: 999 });
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings');
+            expect(options.method).toBe('POST');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+            expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+            const body = JSON.parse(options.body as string);
+            expect(body).toEqual({
+                quantity: 3,
+                title: 'Silver Ring',
+                description: 'A lovely ring.',
+                price: 25.5,
+                who_made: 'i_did',
+                when_made: 'made_to_order',
+                taxonomy_id: 1234,
+            });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ error: 'bad taxonomy' }), { status: 400 }));
+
+            await expect(
+                client.createDraftListing('at', 1, {
+                    title: 't',
+                    description: 'd',
+                    price: 1,
+                    quantity: 1,
+                    whoMade: 'i_did',
+                    whenMade: 'made_to_order',
+                    taxonomyId: 1,
+                })
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('uploadListingImage', () => {
+        it('posts a multipart form with the image and rank', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_image_id: 1 }), { status: 200 }));
+
+            await client.uploadListingImage(
+                'at-token',
+                47408839,
+                999,
+                { buffer: Buffer.from('fake-image-bytes'), contentType: 'image/png', filename: 'photo.png' },
+                1
+            );
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/999/images');
+            expect(options.method).toBe('POST');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+            expect(options.body).toBeInstanceOf(FormData);
+            const form = options.body as FormData;
+            expect(form.get('rank')).toBe('1');
+            expect(form.get('image')).toBeInstanceOf(Blob);
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
+
+            await expect(
+                client.uploadListingImage(
+                    'at',
+                    1,
+                    1,
+                    { buffer: Buffer.from('x'), contentType: 'image/png', filename: 'x.png' },
+                    0
+                )
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('getListingImages', () => {
+        it('fetches and maps the listing image ids', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({ results: [{ listing_image_id: 111 }, { listing_image_id: 222 }] }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getListingImages('at-token', 999);
+
+            expect(result).toEqual({ imageIds: [111, 222] });
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999/images');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+        });
+    });
+
+    describe('updateListingInventory', () => {
+        it('maps property values and offerings into the Etsy inventory body', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+            await client.updateListingInventory('at-token', 999, [
+                {
+                    propertyValues: [{ propertyName: 'Colour', values: ['Silver'] }],
+                    offering: { price: 25.5, quantity: 3, isEnabled: true },
+                },
+            ]);
+
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999/inventory');
+            expect(options.method).toBe('PUT');
+            const body = JSON.parse(options.body as string);
+            expect(body).toEqual({
+                products: [
+                    {
+                        property_values: [{ property_id: null, property_name: 'Colour', values: ['Silver'] }],
+                        offerings: [{ price: 25.5, quantity: 3, is_enabled: true }],
+                    },
+                ],
+            });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 400 }));
+
+            await expect(client.updateListingInventory('at', 1, [])).rejects.toThrow();
+        });
+    });
+
+    describe('getSellerTaxonomyNodes', () => {
+        it('fetches and maps the nested taxonomy tree', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        results: [
+                            {
+                                id: 1,
+                                name: 'Jewelry',
+                                children: [{ id: 2, name: 'Rings', children: [] }],
+                            },
+                        ],
+                    }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getSellerTaxonomyNodes();
+
+            expect(result).toEqual([
+                { id: 1, name: 'Jewelry', children: [{ id: 2, name: 'Rings', children: [] }] },
+            ]);
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/seller-taxonomy/nodes');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+        });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: FAIL — the new methods don't exist yet (TypeScript compile error / `client.createDraftListing is not a function`, etc.)
+
+- [ ] **Step 3: Implement the new methods**
+
+In `packages/api/src/domain/EtsyClient/index.ts`, add these exported interfaces above the `EtsyClient` class (alongside the existing `EtsyTokenResponse`):
+
+```typescript
+export interface EtsyDraftListingInput {
+    title: string;
+    description: string;
+    price: number;
+    quantity: number;
+    whoMade: string;
+    whenMade: string;
+    taxonomyId: number;
+}
+
+export interface EtsyListingResult {
+    listingId: number;
+}
+
+export interface EtsyInventoryProduct {
+    propertyValues: Array<{ propertyName: string; values: string[] }>;
+    offering: { price: number; quantity: number; isEnabled: boolean };
+}
+
+export interface EtsyTaxonomyNode {
+    id: number;
+    name: string;
+    children: EtsyTaxonomyNode[];
+}
+```
+
+Then add these methods inside the `EtsyClient` class (after `getShop`, before the closing `}`):
+
+```typescript
+    async createDraftListing(
+        accessToken: string,
+        shopId: number,
+        input: EtsyDraftListingInput
+    ): Promise<EtsyListingResult> {
+        const response = await fetch(`${API_BASE}/shops/${shopId}/listings`, {
+            method: 'POST',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                quantity: input.quantity,
+                title: input.title,
+                description: input.description,
+                price: input.price,
+                who_made: input.whoMade,
+                when_made: input.whenMade,
+                taxonomy_id: input.taxonomyId,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy createDraftListing failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { listing_id: number };
+        return { listingId: body.listing_id };
+    }
+
+    async uploadListingImage(
+        accessToken: string,
+        shopId: number,
+        listingId: number,
+        image: { buffer: Buffer; contentType: string; filename: string },
+        rank: number
+    ): Promise<void> {
+        const form = new FormData();
+        form.append('image', new Blob([image.buffer], { type: image.contentType }), image.filename);
+        form.append('rank', String(rank));
+
+        const response = await fetch(`${API_BASE}/shops/${shopId}/listings/${listingId}/images`, {
+            method: 'POST',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+            },
+            body: form,
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy uploadListingImage failed: ${response.status} ${await response.text()}`);
+        }
+    }
+
+    async getListingImages(accessToken: string, listingId: number): Promise<{ imageIds: number[] }> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}/images`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getListingImages failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { results: Array<{ listing_image_id: number }> };
+        return { imageIds: body.results.map((r) => r.listing_image_id) };
+    }
+
+    async updateListingInventory(
+        accessToken: string,
+        listingId: number,
+        products: EtsyInventoryProduct[]
+    ): Promise<void> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}/inventory`, {
+            method: 'PUT',
+            headers: {
+                'x-api-key': this.apiKeyHeader(),
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                products: products.map((p) => ({
+                    property_values: p.propertyValues.map((pv) => ({
+                        property_id: null,
+                        property_name: pv.propertyName,
+                        values: pv.values,
+                    })),
+                    offerings: [
+                        {
+                            price: p.offering.price,
+                            quantity: p.offering.quantity,
+                            is_enabled: p.offering.isEnabled,
+                        },
+                    ],
+                })),
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy updateListingInventory failed: ${response.status} ${await response.text()}`);
+        }
+    }
+
+    async getSellerTaxonomyNodes(): Promise<EtsyTaxonomyNode[]> {
+        const response = await fetch(`${API_BASE}/seller-taxonomy/nodes`, {
+            headers: { 'x-api-key': this.apiKeyHeader() },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getSellerTaxonomyNodes failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as {
+            results: Array<{ id: number; name: string; children?: unknown[] }>;
+        };
+
+        const mapNode = (n: { id: number; name: string; children?: unknown[] }): EtsyTaxonomyNode => ({
+            id: n.id,
+            name: n.name,
+            children: ((n.children ?? []) as Array<{ id: number; name: string; children?: unknown[] }>).map(mapNode),
+        });
+
+        return body.results.map(mapNode);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: PASS (including all pre-existing `EtsyClient`/PKCE tests from sub-project 1 — unaffected, this task is purely additive)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyClient/index.ts packages/api/src/domain/EtsyClient/index.test.ts
+git commit -m "feat(api): add Etsy listing/inventory/taxonomy HTTP methods to EtsyClient"
+```
+
+---
+
+### Task 3: API — `EtsyConnectionService.getPushCredentials`
+
+**Files:**
+- Modify: `packages/api/src/domain/EtsyConnectionService/index.ts`
+- Modify: `packages/api/src/domain/EtsyConnectionService/index.test.ts`
+
+**Interfaces:**
+- Consumes: `EtsyConnectionRepository.getByUserId` (existing), `this.getValidAccessToken` (existing, sub-project 1 — do not modify its behavior).
+- Produces: `EtsyConnectionService.getPushCredentials(userId: string): Promise<{ accessToken: string; shopId: number }>` — consumed by `EtsyPushService` (Task 6).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/api/src/domain/EtsyConnectionService/index.test.ts`, inside the existing `describe('EtsyConnectionService', ...)` block, as a sibling to the existing `describe('getValidAccessToken', ...)` block (reuse the file's existing `mockConnectionRepo`/`mockEtsyClient`/`makeConnection` helper — read the file first to confirm their exact shape before writing):
+
+```typescript
+    describe('getPushCredentials', () => {
+        it('returns the valid access token together with the stored shopId', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(
+                makeConnection({ accessToken: 'still-fresh', accessTokenExpiresAt: Date.now() + 120_000, shopId: 47408839 })
+            );
+
+            const result = await service.getPushCredentials('user-1');
+
+            expect(result).toEqual({ accessToken: 'still-fresh', shopId: 47408839 });
+            expect(mockEtsyClient.refreshAccessToken).not.toHaveBeenCalled();
+        });
+
+        it('throws when there is no connection', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(null);
+
+            await expect(service.getPushCredentials('user-1')).rejects.toThrow();
+        });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyConnectionService/index.test.ts`
+Expected: FAIL — `service.getPushCredentials is not a function`
+
+- [ ] **Step 3: Implement**
+
+In `packages/api/src/domain/EtsyConnectionService/index.ts`, remove the `// fallow-ignore-next-line unused-class-member` comment directly above `getValidAccessToken` (it now has a real consumer being added in this task's own file — `getPushCredentials` calls it — so the dead-code suppression is no longer needed), and add this new method directly after `getValidAccessToken`:
+
+```typescript
+    async getPushCredentials(userId: string): Promise<{ accessToken: string; shopId: number }> {
+        const accessToken = await this.getValidAccessToken(userId);
+        const connection = await this.connectionRepo.getByUserId(userId);
+        if (!connection) {
+            throw new APIError('Etsy is not connected', 400);
+        }
+        return { accessToken, shopId: connection.shopId };
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyConnectionService/index.test.ts`
+Expected: PASS (all pre-existing tests plus the two new ones)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyConnectionService/index.ts packages/api/src/domain/EtsyConnectionService/index.test.ts
+git commit -m "feat(api): add getPushCredentials to EtsyConnectionService"
+```
+
+---
+
+### Task 4: API — `UserSettingsService` Etsy template/taxonomy fields
+
+**Files:**
+- Modify: `packages/api/src/domain/UserSettingsService/index.ts`
+- Modify: `packages/api/src/domain/UserSettingsService/index.test.ts`
+- Modify: `packages/api/src/handlers/UserSettings/index.ts`
+
+**Interfaces:**
+- Consumes: `UserSettings.etsyDescriptionTemplate`/`etsyTaxonomyMap` (Task 1).
+- Produces: `UserSettingsService.get(userId)` now also returns `etsyDescriptionTemplate`/`etsyTaxonomyMap` with defaults `''`/`{}` when unset; `UserSettingsService.upsert(userId, { ..., etsyDescriptionTemplate, etsyTaxonomyMap })`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/api/src/domain/UserSettingsService/index.test.ts`, inside the existing `describe('get', ...)` and `describe('upsert — price suggestion fields', ...)` blocks (read the file first — it was created in sub-project 2 mirroring `DesignService/index.test.ts`'s mock style):
+
+```typescript
+describe('get — etsy fields', () => {
+    it('returns empty-string template and empty taxonomy map defaults when no settings stored', async () => {
+        mockSettingsRepo.getByUserId.mockResolvedValue(null);
+
+        const result = await service.get('user-1');
+
+        expect(result.etsyDescriptionTemplate).toBe('');
+        expect(result.etsyTaxonomyMap).toEqual({});
+    });
+
+    it('returns stored etsyDescriptionTemplate and etsyTaxonomyMap when present', async () => {
+        mockSettingsRepo.getByUserId.mockResolvedValue({
+            userId: 'user-1',
+            hourlyWage: 10,
+            profitMargin: 15,
+            markupMultiplier: 2.5,
+            hourlyRate: 0,
+            etsyDescriptionTemplate: '{description}\n\nMaterials: {materials}',
+            etsyTaxonomyMap: { RING: 1234 },
+        });
+
+        const result = await service.get('user-1');
+
+        expect(result.etsyDescriptionTemplate).toBe('{description}\n\nMaterials: {materials}');
+        expect(result.etsyTaxonomyMap).toEqual({ RING: 1234 });
+    });
+
+    it('backfills defaults for a stored document that predates this migration (missing the new fields entirely)', async () => {
+        mockSettingsRepo.getByUserId.mockResolvedValue({
+            userId: 'user-1',
+            hourlyWage: 10,
+            profitMargin: 15,
+            // no markupMultiplier/hourlyRate/etsyDescriptionTemplate/etsyTaxonomyMap — simulates a
+            // pre-sub-project-2 document that Mongo happily stored without the newer required fields
+        } as any);
+
+        const result = await service.get('user-1');
+
+        expect(result.markupMultiplier).toBe(2.5);
+        expect(result.hourlyRate).toBe(0);
+        expect(result.etsyDescriptionTemplate).toBe('');
+        expect(result.etsyTaxonomyMap).toEqual({});
+        expect(result.hourlyWage).toBe(10);
+        expect(result.profitMargin).toBe(15);
+    });
+});
+
+describe('upsert — etsy fields', () => {
+    it('persists etsyDescriptionTemplate and etsyTaxonomyMap alongside the existing fields', async () => {
+        const result = await service.upsert('user-1', {
+            hourlyWage: 12,
+            profitMargin: 20,
+            markupMultiplier: 2,
+            hourlyRate: 8,
+            etsyDescriptionTemplate: 'Handmade: {description}',
+            etsyTaxonomyMap: { EARRINGS: 5678 },
+        });
+
+        expect(result).toEqual({
+            userId: 'user-1',
+            hourlyWage: 12,
+            profitMargin: 20,
+            markupMultiplier: 2,
+            hourlyRate: 8,
+            etsyDescriptionTemplate: 'Handmade: {description}',
+            etsyTaxonomyMap: { EARRINGS: 5678 },
+        });
+        expect(mockSettingsRepo.upsert).toHaveBeenCalledWith(result);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/UserSettingsService/index.test.ts`
+Expected: FAIL — `etsyDescriptionTemplate`/`etsyTaxonomyMap` undefined, or wrong-arity `upsert` call
+
+- [ ] **Step 3: Update `UserSettingsService`**
+
+In `packages/api/src/domain/UserSettingsService/index.ts`, add the two new default constants near the top (alongside `DEFAULT_MARKUP_MULTIPLIER`/`DEFAULT_HOURLY_RATE`):
+
+```typescript
+const DEFAULT_ETSY_DESCRIPTION_TEMPLATE = '';
+const DEFAULT_ETSY_TAXONOMY_MAP: Record<string, number> = {};
+```
+
+Update the `get` method to defensively merge defaults under whatever was actually stored, rather than returning `stored` as-is. This fixes a latent bug that predates this task: Mongo doesn't enforce the Zod schema at rest, so a settings document persisted before this migration (or before sub-project 2's `markupMultiplier`/`hourlyRate` migration) is missing the newer fields entirely — the old `stored ?? { ...defaults }` pattern returned that partial document unchanged, so `etsyTaxonomyMap`/`etsyDescriptionTemplate` (and previously `markupMultiplier`/`hourlyRate`) would be `undefined` at runtime despite the TS type claiming they're always present, silently producing `NaN`/crashes downstream. Spread defaults first, then the stored partial document on top, so any field genuinely present in storage still wins:
+
+```typescript
+    async get(userId: string): Promise<UserSettings> {
+        const stored = await this.settingsRepo.getByUserId(userId);
+        const defaults: UserSettings = {
+            userId,
+            hourlyWage: DEFAULT_HOURLY_WAGE,
+            profitMargin: DEFAULT_PROFIT_MARGIN,
+            markupMultiplier: DEFAULT_MARKUP_MULTIPLIER,
+            hourlyRate: DEFAULT_HOURLY_RATE,
+            etsyDescriptionTemplate: DEFAULT_ETSY_DESCRIPTION_TEMPLATE,
+            etsyTaxonomyMap: DEFAULT_ETSY_TAXONOMY_MAP,
+        };
+        return { ...defaults, ...stored };
+    }
+```
+
+Update `upsert`'s parameter type and body:
+
+```typescript
+    async upsert(
+        userId: string,
+        updates: {
+            hourlyWage: number;
+            profitMargin: number;
+            markupMultiplier: number;
+            hourlyRate: number;
+            etsyDescriptionTemplate: string;
+            etsyTaxonomyMap: Record<string, number>;
+        }
+    ): Promise<UserSettings> {
+        const settings: UserSettings = { userId, ...updates };
+        await this.settingsRepo.upsert(settings);
+        return settings;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/UserSettingsService/index.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Update the `updateUserSettings` handler**
+
+In `packages/api/src/handlers/UserSettings/index.ts`, replace `updateUserSettings`:
+
+```typescript
+export const updateUserSettings = async (c: Ctx) => {
+    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate, etsyTaxonomyMap } =
+        (await c.req.json()) as {
+            hourlyWage?: number;
+            profitMargin?: number;
+            markupMultiplier?: number;
+            hourlyRate?: number;
+            etsyDescriptionTemplate?: string;
+            etsyTaxonomyMap?: Record<string, number>;
+        };
+
+    if (
+        hourlyWage === undefined ||
+        profitMargin === undefined ||
+        markupMultiplier === undefined ||
+        hourlyRate === undefined ||
+        etsyDescriptionTemplate === undefined ||
+        etsyTaxonomyMap === undefined
+    ) {
+        throw new APIError(
+            'hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate and etsyTaxonomyMap are required',
+            400
+        );
+    }
+
+    return c.json(
+        await getService().upsert(c.get('userId'), {
+            hourlyWage: Number(hourlyWage),
+            profitMargin: Number(profitMargin),
+            markupMultiplier: Number(markupMultiplier),
+            hourlyRate: Number(hourlyRate),
+            etsyDescriptionTemplate,
+            etsyTaxonomyMap,
+        })
+    );
+};
+```
+
+- [ ] **Step 6: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api/src/domain/UserSettingsService packages/api/src/handlers/UserSettings/index.ts
+git commit -m "feat(api): add etsyDescriptionTemplate and etsyTaxonomyMap to user settings"
+```
+
+---
+
+### Task 5: API — `EtsyPushService` pure mappers
+
+**Files:**
+- Create: `packages/api/src/domain/EtsyPushService/mappers.ts`
+- Create: `packages/api/src/domain/EtsyPushService/mappers.test.ts`
+
+**Interfaces:**
+- Consumes: `Design`, `VariationGroup`, `DesignVariant`, `RequiredMaterial` (existing, `@jewellery-catalogue/types`), `EtsyDraftListingInput`, `EtsyInventoryProduct` (Task 2).
+- Produces:
+  - `renderDescriptionTemplate(template: string, design: { description: string; materials: RequiredMaterial[] }): string`
+  - `buildDraftListingInput(args: { design: Pick<Design, 'name' | 'price' | 'totalQuantity'>; description: string; price: number; taxonomyId: number }): EtsyDraftListingInput`
+  - `buildInventoryProducts(variants: DesignVariant[], groups: VariationGroup[]): EtsyInventoryProduct[]`
+  - all consumed by `EtsyPushService` (Task 6).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/api/src/domain/EtsyPushService/mappers.test.ts
+import { describe, expect, it } from 'bun:test';
+import type { DesignVariant, RequiredMaterial, VariationGroup } from '@jewellery-catalogue/types';
+
+import { buildDraftListingInput, buildInventoryProducts, renderDescriptionTemplate } from './mappers';
+
+const material = (name: string): RequiredMaterial =>
+    ({ id: `mat-${name}`, name, type: 'BEAD', requiredQuantity: 1 }) as unknown as RequiredMaterial;
+
+describe('renderDescriptionTemplate', () => {
+    it('substitutes {description} and {materials} placeholders', () => {
+        const result = renderDescriptionTemplate('{description}\n\nMaterials: {materials}', {
+            description: 'A lovely ring.',
+            materials: [material('Silver wire'), material('Moonstone bead')],
+        });
+
+        expect(result).toBe('A lovely ring.\n\nMaterials: Silver wire, Moonstone bead');
+    });
+
+    it('handles a template with no placeholders unchanged', () => {
+        const result = renderDescriptionTemplate('Static text only', { description: 'ignored', materials: [] });
+        expect(result).toBe('Static text only');
+    });
+
+    it('handles an empty materials list', () => {
+        const result = renderDescriptionTemplate('{description} ({materials})', {
+            description: 'A ring.',
+            materials: [],
+        });
+        expect(result).toBe('A ring. ()');
+    });
+});
+
+describe('buildDraftListingInput', () => {
+    it('maps design + resolved fields into the fixed-field Etsy draft listing shape', () => {
+        const result = buildDraftListingInput({
+            design: { name: 'Silver Ring', price: 25.5, totalQuantity: 3 },
+            description: 'A lovely ring.',
+            price: 25.5,
+            taxonomyId: 1234,
+        });
+
+        expect(result).toEqual({
+            title: 'Silver Ring',
+            description: 'A lovely ring.',
+            price: 25.5,
+            quantity: 3,
+            whoMade: 'i_did',
+            whenMade: 'made_to_order',
+            taxonomyId: 1234,
+        });
+    });
+
+    it('floors quantity at 1 when totalQuantity is 0', () => {
+        const result = buildDraftListingInput({
+            design: { name: 'Ring', price: 10, totalQuantity: 0 },
+            description: 'd',
+            price: 10,
+            taxonomyId: 1,
+        });
+
+        expect(result.quantity).toBe(1);
+    });
+});
+
+describe('buildInventoryProducts', () => {
+    it('maps each variant to a product with one property value per group and one offering', () => {
+        const groups: VariationGroup[] = [
+            {
+                id: 'group-1',
+                name: 'Colour',
+                required: 1,
+                options: [
+                    { id: 'opt-silver', material: material('Silver') },
+                    { id: 'opt-gold', material: material('Gold') },
+                ],
+            },
+        ];
+        const variants: DesignVariant[] = [
+            {
+                id: 'variant-1',
+                optionIds: ['opt-silver'],
+                name: 'Silver',
+                totalQuantity: 5,
+                totalMaterialCosts: 3,
+                price: 20,
+            },
+            {
+                id: 'variant-2',
+                optionIds: ['opt-gold'],
+                name: 'Gold',
+                totalQuantity: 2,
+                totalMaterialCosts: 4,
+                price: 30,
+            },
+        ];
+
+        const result = buildInventoryProducts(variants, groups);
+
+        expect(result).toEqual([
+            {
+                propertyValues: [{ propertyName: 'Colour', values: ['Silver'] }],
+                offering: { price: 20, quantity: 5, isEnabled: true },
+            },
+            {
+                propertyValues: [{ propertyName: 'Colour', values: ['Gold'] }],
+                offering: { price: 30, quantity: 2, isEnabled: true },
+            },
+        ]);
+    });
+
+    it('maps a variant spanning two groups to two property values', () => {
+        const groups: VariationGroup[] = [
+            {
+                id: 'group-1',
+                name: 'Colour',
+                required: 1,
+                options: [{ id: 'opt-silver', material: material('Silver') }],
+            },
+            {
+                id: 'group-2',
+                name: 'Size',
+                required: 1,
+                options: [{ id: 'opt-small', material: material('Small') }],
+            },
+        ];
+        const variants: DesignVariant[] = [
+            {
+                id: 'variant-1',
+                optionIds: ['opt-silver', 'opt-small'],
+                name: 'Silver / Small',
+                totalQuantity: 1,
+                totalMaterialCosts: 3,
+                price: 20,
+            },
+        ];
+
+        const result = buildInventoryProducts(variants, groups);
+
+        expect(result).toEqual([
+            {
+                propertyValues: [
+                    { propertyName: 'Colour', values: ['Silver'] },
+                    { propertyName: 'Size', values: ['Small'] },
+                ],
+                offering: { price: 20, quantity: 1, isEnabled: true },
+            },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyPushService/mappers.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/api/src/domain/EtsyPushService/mappers.ts
+import type { Design, DesignVariant, RequiredMaterial, VariationGroup } from '@jewellery-catalogue/types';
+
+import type { EtsyDraftListingInput, EtsyInventoryProduct } from '../EtsyClient';
+
+export const renderDescriptionTemplate = (
+    template: string,
+    design: { description: string; materials: RequiredMaterial[] }
+): string => {
+    const materialsList = design.materials.map((m) => m.name).join(', ');
+    return template.replace(/\{description\}/g, design.description).replace(/\{materials\}/g, materialsList);
+};
+
+export const buildDraftListingInput = (args: {
+    design: Pick<Design, 'name' | 'price' | 'totalQuantity'>;
+    description: string;
+    price: number;
+    taxonomyId: number;
+}): EtsyDraftListingInput => ({
+    title: args.design.name,
+    description: args.description,
+    price: args.price,
+    quantity: Math.max(1, args.design.totalQuantity),
+    whoMade: 'i_did',
+    whenMade: 'made_to_order',
+    taxonomyId: args.taxonomyId,
+});
+
+export const buildInventoryProducts = (
+    variants: DesignVariant[],
+    groups: VariationGroup[]
+): EtsyInventoryProduct[] =>
+    variants.map((variant) => {
+        const propertyValues = groups
+            .map((group) => {
+                const option = group.options.find((o) => variant.optionIds.includes(o.id));
+                return option ? { propertyName: group.name, values: [option.material.name] } : null;
+            })
+            .filter((pv): pv is { propertyName: string; values: string[] } => pv !== null);
+
+        return {
+            propertyValues,
+            offering: { price: variant.price, quantity: variant.totalQuantity, isEnabled: true },
+        };
+    });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyPushService/mappers.test.ts`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyPushService/mappers.ts packages/api/src/domain/EtsyPushService/mappers.test.ts
+git commit -m "feat(api): add pure Etsy push payload mappers"
+```
+
+---
+
+### Task 6: API — `EtsyPushService` orchestration
+
+**Files:**
+- Create: `packages/api/src/domain/EtsyPushService/index.ts`
+- Create: `packages/api/src/domain/EtsyPushService/index.test.ts`
+
+**Interfaces:**
+- Consumes: `DesignRepository` (existing, `getByIdAndUserId`/`update`), `ImageService` (existing, `getImage`), `EtsyClient` (Task 2), `EtsyConnectionService.getPushCredentials` (Task 3), `UserSettingsService.get` (Task 4), `renderDescriptionTemplate`/`buildDraftListingInput`/`buildInventoryProducts` (Task 5).
+- Produces: `class EtsyPushService { constructor(designRepo, imageService, etsyClient, etsyConnectionService, userSettingsService); push(designId: string, userId: string, overrides?: { description?: string; price?: number }): Promise<Design> }` — consumed by `handlers/Etsy` (Task 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/api/src/domain/EtsyPushService/index.test.ts
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Design } from '@jewellery-catalogue/types';
+import { Readable } from 'node:stream';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import type { ImageService } from '../ImageService';
+import type { UserSettingsService } from '../UserSettingsService';
+import { EtsyPushService } from './index';
+
+const mockDesignRepo = { getByIdAndUserId: mock(), update: mock() };
+const mockImageService = { getImage: mock(), uploadImage: mock() };
+const mockEtsyClient = {
+    createDraftListing: mock(),
+    uploadListingImage: mock(),
+    getListingImages: mock(),
+    updateListingInventory: mock(),
+    getSellerTaxonomyNodes: mock(),
+};
+const mockEtsyConnectionService = { getPushCredentials: mock() };
+const mockUserSettingsService = { get: mock() };
+
+function makeDesign(overrides: Partial<Design> = {}): Design {
+    return {
+        id: 'design-1',
+        userId: 'user-1',
+        name: 'Silver Ring',
+        description: 'A lovely ring.',
+        timeRequired: '01:00',
+        materials: [],
+        imageIds: ['img-1'],
+        diagramImageIds: ['diagram-1'],
+        makingNotes: 'private notes',
+        price: 25,
+        totalMaterialCosts: 10,
+        dateAdded: new Date(),
+        totalQuantity: 2,
+        designType: 'RING' as Design['designType'],
+        ...overrides,
+    };
+}
+
+describe('EtsyPushService', () => {
+    let service: EtsyPushService;
+
+    beforeEach(() => {
+        [
+            ...Object.values(mockDesignRepo),
+            ...Object.values(mockImageService),
+            ...Object.values(mockEtsyClient),
+            ...Object.values(mockEtsyConnectionService),
+            ...Object.values(mockUserSettingsService),
+        ].forEach((m) => m.mockClear());
+
+        service = new EtsyPushService(
+            mockDesignRepo as unknown as DesignRepository,
+            mockImageService as unknown as ImageService,
+            mockEtsyClient as unknown as EtsyClient,
+            mockEtsyConnectionService as unknown as EtsyConnectionService,
+            mockUserSettingsService as unknown as UserSettingsService
+        );
+
+        mockEtsyConnectionService.getPushCredentials.mockResolvedValue({
+            accessToken: 'at-token',
+            shopId: 47408839,
+        });
+        mockUserSettingsService.get.mockResolvedValue({
+            userId: 'user-1',
+            hourlyWage: 10,
+            profitMargin: 15,
+            markupMultiplier: 2.5,
+            hourlyRate: 0,
+            etsyDescriptionTemplate: '{description}',
+            etsyTaxonomyMap: { RING: 1234 },
+        });
+        mockImageService.getImage.mockResolvedValue({
+            stream: Readable.from([Buffer.from('fake-image-bytes')]),
+            contentType: 'image/png',
+            cacheControl: 'public',
+        });
+        mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [] });
+    });
+
+    describe('push — new listing (no prior etsy.listingId)', () => {
+        it('creates the listing, uploads only product photos (never diagram images), and persists the etsy block', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            const result = await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledWith(
+                'at-token',
+                47408839,
+                expect.objectContaining({ title: 'Silver Ring', taxonomyId: 1234, quantity: 2 })
+            );
+
+            expect(mockImageService.getImage).toHaveBeenCalledTimes(1);
+            expect(mockImageService.getImage).toHaveBeenCalledWith('img-1');
+            expect(mockImageService.getImage).not.toHaveBeenCalledWith('diagram-1');
+            expect(mockEtsyClient.uploadListingImage).toHaveBeenCalledTimes(1);
+
+            expect(mockEtsyClient.updateListingInventory).not.toHaveBeenCalled();
+
+            expect(result.etsy).toEqual({ listingId: 999, state: 'draft', lastPushedAt: expect.any(Number), pushIncomplete: false });
+
+            const lastUpdateCall = mockDesignRepo.update.mock.calls.at(-1) as [string, Design];
+            expect(lastUpdateCall[1].etsy?.pushIncomplete).toBe(false);
+        });
+
+        it('rejects when the design has more than 2 variation groups, before calling Etsy at all', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    variationGroups: [
+                        { id: 'g1', name: 'A', required: 1, options: [] },
+                        { id: 'g2', name: 'B', required: 1, options: [] },
+                        { id: 'g3', name: 'C', required: 1, options: [] },
+                    ],
+                })
+            );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects when there is no taxonomy mapping for the design type', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign({ designType: 'NECKLACE' as Design['designType'] }));
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects re-push when the design already has a completed etsy.listingId', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({ etsy: { listingId: 555, state: 'draft', lastPushedAt: Date.now(), pushIncomplete: false } })
+            );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('uses the provided description/price overrides instead of re-rendering the template', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            await service.push('design-1', 'user-1', { description: 'Edited by hand', price: 30 });
+
+            expect(mockEtsyClient.createDraftListing).toHaveBeenCalledWith(
+                'at-token',
+                47408839,
+                expect.objectContaining({ description: 'Edited by hand', price: 30 })
+            );
+        });
+    });
+
+    describe('push — resume (pushIncomplete: true)', () => {
+        it('does not re-create the listing, and skips images Etsy already has', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    imageIds: ['img-1', 'img-2'],
+                    etsy: { listingId: 999, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+                })
+            );
+            mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [111] });
+
+            await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+            expect(mockImageService.getImage).toHaveBeenCalledTimes(1);
+            expect(mockImageService.getImage).toHaveBeenCalledWith('img-2');
+            expect(mockEtsyClient.uploadListingImage).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('push — variations', () => {
+        it('builds and puts inventory when the design has variation groups and variants', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({
+                    variationGroups: [
+                        {
+                            id: 'g1',
+                            name: 'Colour',
+                            required: 1,
+                            options: [{ id: 'opt-1', material: { id: 'm1', name: 'Silver' } as any }],
+                        },
+                    ],
+                    variants: [
+                        {
+                            id: 'v1',
+                            optionIds: ['opt-1'],
+                            name: 'Silver',
+                            totalQuantity: 5,
+                            totalMaterialCosts: 3,
+                            price: 20,
+                        },
+                    ],
+                })
+            );
+            mockEtsyClient.createDraftListing.mockResolvedValue({ listingId: 999 });
+
+            await service.push('design-1', 'user-1');
+
+            expect(mockEtsyClient.updateListingInventory).toHaveBeenCalledWith(
+                'at-token',
+                999,
+                expect.arrayContaining([
+                    expect.objectContaining({ offering: { price: 20, quantity: 5, isEnabled: true } }),
+                ])
+            );
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyPushService/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/api/src/domain/EtsyPushService/index.ts
+import { APIError } from '@imapps/api-utils/hono';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import type { ImageService } from '../ImageService';
+import type { UserSettingsService } from '../UserSettingsService';
+import { buildDraftListingInput, buildInventoryProducts, renderDescriptionTemplate } from './mappers';
+
+const MAX_VARIATION_GROUPS = 2;
+
+async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as ArrayBufferLike));
+    }
+    return Buffer.concat(chunks);
+}
+
+export class EtsyPushService {
+    constructor(
+        private readonly designRepo: DesignRepository,
+        private readonly imageService: ImageService,
+        private readonly etsyClient: EtsyClient,
+        private readonly etsyConnectionService: EtsyConnectionService,
+        private readonly userSettingsService: UserSettingsService
+    ) {}
+
+    async push(designId: string, userId: string, overrides: { description?: string; price?: number } = {}): Promise<Design> {
+        const design = await this.designRepo.getByIdAndUserId(designId, userId);
+        if (!design) {
+            throw new APIError('Design not found', 404);
+        }
+
+        if (design.etsy?.listingId && !design.etsy.pushIncomplete) {
+            throw new APIError('Design is already on Etsy', 409);
+        }
+
+        const groups = design.variationGroups ?? [];
+        if (groups.length > MAX_VARIATION_GROUPS) {
+            throw new APIError(`Etsy supports at most ${MAX_VARIATION_GROUPS} variation properties`, 400);
+        }
+
+        const settings = await this.userSettingsService.get(userId);
+        const { accessToken, shopId } = await this.etsyConnectionService.getPushCredentials(userId);
+
+        let listingId = design.etsy?.listingId;
+
+        if (!listingId) {
+            const taxonomyId = design.designType ? settings.etsyTaxonomyMap[design.designType] : undefined;
+            if (!taxonomyId) {
+                throw new APIError('No Etsy category is mapped for this design type', 400);
+            }
+
+            const description = overrides.description ?? renderDescriptionTemplate(settings.etsyDescriptionTemplate, design);
+            const price = overrides.price ?? design.price;
+
+            const draftInput = buildDraftListingInput({ design, description, price, taxonomyId });
+            const created = await this.etsyClient.createDraftListing(accessToken, shopId, draftInput);
+            listingId = created.listingId;
+
+            await this.designRepo.update(designId, {
+                ...design,
+                etsy: { listingId, state: 'draft', lastPushedAt: null, pushIncomplete: true },
+            });
+        }
+
+        const alreadyUploaded = await this.etsyClient.getListingImages(accessToken, listingId);
+        const remainingImageIds = design.imageIds.slice(alreadyUploaded.imageIds.length);
+
+        for (const [index, imageId] of remainingImageIds.entries()) {
+            const image = await this.imageService.getImage(imageId);
+            const buffer = await streamToBuffer(image.stream);
+            await this.etsyClient.uploadListingImage(
+                accessToken,
+                shopId,
+                listingId,
+                { buffer, contentType: image.contentType, filename: imageId },
+                alreadyUploaded.imageIds.length + index + 1
+            );
+        }
+
+        if (groups.length > 0 && design.variants && design.variants.length > 0) {
+            const products = buildInventoryProducts(design.variants, groups);
+            await this.etsyClient.updateListingInventory(accessToken, listingId, products);
+        }
+
+        const updated: Design = {
+            ...design,
+            etsy: { listingId, state: 'draft', lastPushedAt: Date.now(), pushIncomplete: false },
+        };
+        await this.designRepo.update(designId, updated);
+
+        return updated;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyPushService/index.test.ts`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyPushService/index.ts packages/api/src/domain/EtsyPushService/index.test.ts
+git commit -m "feat(api): add EtsyPushService orchestrating design pushes to Etsy"
+```
+
+---
+
+### Task 7: API — handlers, routes, DI wiring, Mongo index
+
+**Files:**
+- Modify: `packages/api/src/handlers/Etsy/index.ts`
+- Modify: `packages/api/src/dependencies/types.ts`
+- Modify: `packages/api/src/dependencies/index.ts`
+- Modify: `packages/api/src/routes/index.ts`
+- Modify: `packages/api/src/index.ts`
+
+**Interfaces:**
+- Consumes: `EtsyPushService.push` (Task 6), `EtsyClient.getSellerTaxonomyNodes` (Task 2).
+- Produces: `POST /api/designs/:id/etsy-push` (body `{ description?: string; price?: number }`, returns the updated `Design`), `GET /api/etsy/taxonomy` (returns `EtsyTaxonomyNode[]`) — consumed by the web layer (Task 8).
+
+- [ ] **Step 1: Read the existing DI wiring for `EtsyConnectionService`**
+
+Read `packages/api/src/dependencies/types.ts` and `packages/api/src/dependencies/index.ts` — find the existing `DependencyToken.EtsyConnectionService`/`DependencyToken.EtsyClient` entries and their registration factories (sub-project 1). This task's registration for `EtsyPushService` follows the identical pattern, just with more constructor dependencies resolved from the container.
+
+- [ ] **Step 2: Add the `EtsyPushService` token**
+
+In `packages/api/src/dependencies/types.ts`, add to the `DependencyToken` enum (alongside `EtsyConnectionService`):
+
+```typescript
+    EtsyPushService = 'EtsyPushService',
+```
+
+And add to the token→type map (alongside the `EtsyConnectionService` entry):
+
+```typescript
+    [DependencyToken.EtsyPushService]: EtsyPushService;
+```
+
+Add the import at the top of the file:
+
+```typescript
+import type { EtsyPushService } from '../domain/EtsyPushService';
+```
+
+- [ ] **Step 3: Register `EtsyPushService`**
+
+In `packages/api/src/dependencies/index.ts`, add the import:
+
+```typescript
+import { EtsyPushService } from '../domain/EtsyPushService';
+```
+
+Add the registration (mirror the existing `EtsyConnectionService` registration's structure — read it first for the exact `dependencyContainer.register(...)` call shape used in this file, then add):
+
+```typescript
+        DependencyToken.EtsyPushService,
+        () =>
+            new EtsyPushService(
+                dependencyContainer.resolve(DependencyToken.DesignRepository),
+                dependencyContainer.resolve(DependencyToken.ImageService),
+                dependencyContainer.resolve(DependencyToken.EtsyClient),
+                dependencyContainer.resolve(DependencyToken.EtsyConnectionService),
+                dependencyContainer.resolve(DependencyToken.UserSettingsService)
+            )
+```
+
+(Match this task's registration call to the exact `register(token, factory)` / `registerSingleton` API this file already uses for its other entries — read the surrounding code and mirror it precisely rather than guessing the call shape.)
+
+- [ ] **Step 4: Add the handlers**
+
+In `packages/api/src/handlers/Etsy/index.ts`, add the import:
+
+```typescript
+import type { EtsyPushService } from '../../domain/EtsyPushService';
+```
+
+Add these two handlers at the end of the file:
+
+```typescript
+const getPushService = (): EtsyPushService => dependencyContainer.resolve(DependencyToken.EtsyPushService);
+
+export const pushDesignToEtsy = async (c: AuthedCtx) => {
+    const { description, price } = (await c.req.json().catch(() => ({}))) as {
+        description?: string;
+        price?: number;
+    };
+
+    const design = await getPushService().push(c.req.param('id'), c.get('userId'), { description, price });
+    return c.json(design, 200);
+};
+
+export const getEtsyTaxonomy = async (c: AuthedCtx) => {
+    const client = dependencyContainer.resolve(DependencyToken.EtsyClient);
+    const nodes = await client.getSellerTaxonomyNodes();
+    return c.json(nodes, 200);
+};
+```
+
+- [ ] **Step 5: Add the routes**
+
+In `packages/api/src/routes/index.ts`, update the `handlers/Etsy` import to include the two new handlers:
+
+```typescript
+import {
+    disconnectEtsyConnection,
+    etsyOAuthCallback,
+    getEtsyConnectionStatus,
+    getEtsyTaxonomy,
+    pushDesignToEtsy,
+    startEtsyOAuth,
+} from '../handlers/Etsy';
+```
+
+Add the two new routes directly after the existing `/api/etsy/connection` routes:
+
+```typescript
+    app.post('/api/designs/:id/etsy-push', authenticate, pushDesignToEtsy);
+    app.get('/api/etsy/taxonomy', authenticate, getEtsyTaxonomy);
+```
+
+- [ ] **Step 6: Add the unique sparse index**
+
+In `packages/api/src/index.ts`, directly after the existing `await designsCollection.createIndex({ id: 1, userId: 1 });` line, add:
+
+```typescript
+        await designsCollection.createIndex({ 'etsy.listingId': 1 }, { unique: true, sparse: true });
+```
+
+(`sparse: true` is required — most designs have no `etsy` field at all, and a non-sparse unique index would reject every second design lacking the field as a duplicate `null`.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd packages/api && bunx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 8: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 9: Run lint**
+
+Run: `bun run lint` from repo root on touched files — must pass (Biome).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/api/src/handlers/Etsy/index.ts packages/api/src/dependencies/types.ts packages/api/src/dependencies/index.ts packages/api/src/routes/index.ts packages/api/src/index.ts
+git commit -m "feat(api): wire up the Etsy push and taxonomy endpoints"
+```
+
+---
+
+### Task 8: Web — API client + hooks (push + taxonomy)
+
+**Files:**
+- Modify: `packages/web/src/api/endpoints.ts`
+- Create: `packages/web/src/api/endpoints/etsyPush/index.ts`
+- Create: `packages/web/src/api/endpoints/etsyTaxonomy/index.ts`
+- Modify: `packages/web/src/api/endpoints/userSettings/index.ts`
+- Create: `packages/web/src/utils/flattenTaxonomyNodes/index.ts`
+- Create: `packages/web/src/utils/flattenTaxonomyNodes/index.test.ts`
+- Create: `packages/web/src/hooks/useEtsyPush.ts`
+- Create: `packages/web/src/hooks/useEtsyTaxonomy.ts`
+- Modify: `packages/web/src/hooks/useUserSettings.ts`
+
+**Interfaces:**
+- Consumes: `Design.etsy`, `UserSettings.etsyDescriptionTemplate`/`etsyTaxonomyMap` (Task 1), the two new endpoints (Task 7).
+- Produces: `makePushDesignToEtsyRequest(designId, overrides, ...)`, `makeGetEtsyTaxonomyRequest(...)`, `flattenTaxonomyNodes(nodes: EtsyTaxonomyNode[]): Array<{ id: number; label: string }>`, `useEtsyPush()`, `useEtsyTaxonomy()`, `useUserSettings()` now also returns/accepts `etsyDescriptionTemplate`/`etsyTaxonomyMap` — consumed by Tasks 9, 10, 11.
+
+- [ ] **Step 1: Add endpoint constants**
+
+In `packages/web/src/api/endpoints.ts`, add (alongside the existing `ETSY_*` constants):
+
+```typescript
+export const ETSY_TAXONOMY_ENDPOINT = '/api/etsy/taxonomy';
+```
+
+(The push endpoint needs a per-design id, so it's built inline as `${DESIGNS_ENDPOINT}/${designId}/etsy-push` in `etsyPush/index.ts`, following the exact pattern already used by `editDesign/index.ts` for `${DESIGNS_ENDPOINT}/${designId}`.)
+
+- [ ] **Step 2: Write `makePushDesignToEtsyRequest`**
+
+```typescript
+// packages/web/src/api/endpoints/etsyPush/index.ts
+import { type Design, MethodType } from '@jewellery-catalogue/types';
+
+import { DESIGNS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export const makePushDesignToEtsyRequest = (
+    designId: string,
+    overrides: { description?: string; price?: number },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<Design>(
+        {
+            pathname: `${DESIGNS_ENDPOINT}/${designId}/etsy-push`,
+            method: MethodType.POST,
+            headers: { 'Content-Type': 'application/json' },
+            operationString: 'push design to etsy',
+            body: overrides,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+- [ ] **Step 3: Write `makeGetEtsyTaxonomyRequest`**
+
+```typescript
+// packages/web/src/api/endpoints/etsyTaxonomy/index.ts
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { ETSY_TAXONOMY_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export interface EtsyTaxonomyNode {
+    id: number;
+    name: string;
+    children: EtsyTaxonomyNode[];
+}
+
+export const makeGetEtsyTaxonomyRequest = (
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<EtsyTaxonomyNode[]>(
+        {
+            pathname: ETSY_TAXONOMY_ENDPOINT,
+            method: MethodType.GET,
+            operationString: 'fetch etsy taxonomy',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+- [ ] **Step 4: Update `makeUpdateUserSettingsRequest`**
+
+In `packages/web/src/api/endpoints/userSettings/index.ts`, update `makeUpdateUserSettingsRequest`'s parameter type to include the two new fields:
+
+```typescript
+export const makeUpdateUserSettingsRequest = (
+    updates: {
+        hourlyWage: number;
+        profitMargin: number;
+        markupMultiplier: number;
+        hourlyRate: number;
+        etsyDescriptionTemplate: string;
+        etsyTaxonomyMap: Record<string, number>;
+    },
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<UserSettings>(
+        {
+            pathname: USER_SETTINGS_ENDPOINT,
+            method: MethodType.PUT,
+            headers: { 'Content-Type': 'application/json' },
+            operationString: 'update user settings',
+            body: updates,
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+(`makeGetUserSettingsRequest`/`makeRecalculatePricesRequest` are unchanged — leave them exactly as they are.)
+
+- [ ] **Step 5: Write the failing tests for `flattenTaxonomyNodes`**
+
+```typescript
+// packages/web/src/utils/flattenTaxonomyNodes/index.test.ts
+import { describe, expect, it } from 'bun:test';
+
+import { flattenTaxonomyNodes } from './index';
+
+describe('flattenTaxonomyNodes', () => {
+    it('flattens a nested tree into a list with breadcrumb labels', () => {
+        const result = flattenTaxonomyNodes([
+            {
+                id: 1,
+                name: 'Jewelry',
+                children: [
+                    { id: 2, name: 'Rings', children: [] },
+                    { id: 3, name: 'Necklaces', children: [{ id: 4, name: 'Chokers', children: [] }] },
+                ],
+            },
+        ]);
+
+        expect(result).toEqual([
+            { id: 1, label: 'Jewelry' },
+            { id: 2, label: 'Jewelry > Rings' },
+            { id: 3, label: 'Jewelry > Necklaces' },
+            { id: 4, label: 'Jewelry > Necklaces > Chokers' },
+        ]);
+    });
+
+    it('returns an empty array for an empty tree', () => {
+        expect(flattenTaxonomyNodes([])).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cd packages/web && bun test src/utils/flattenTaxonomyNodes/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 7: Implement `flattenTaxonomyNodes`**
+
+```typescript
+// packages/web/src/utils/flattenTaxonomyNodes/index.ts
+import type { EtsyTaxonomyNode } from '../../api/endpoints/etsyTaxonomy';
+
+export interface FlatTaxonomyOption {
+    id: number;
+    label: string;
+}
+
+export const flattenTaxonomyNodes = (nodes: EtsyTaxonomyNode[], prefix = ''): FlatTaxonomyOption[] =>
+    nodes.flatMap((node) => {
+        const label = prefix ? `${prefix} > ${node.name}` : node.name;
+        return [{ id: node.id, label }, ...flattenTaxonomyNodes(node.children, label)];
+    });
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cd packages/web && bun test src/utils/flattenTaxonomyNodes/index.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 9: Write `useEtsyPush`**
+
+```typescript
+// packages/web/src/hooks/useEtsyPush.ts
+import { useAuth } from '@imapps/web-utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { makePushDesignToEtsyRequest } from '../api/endpoints/etsyPush';
+
+export const useEtsyPush = (designId: string) => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    const pushMutation = useMutation({
+        mutationFn: (overrides: { description?: string; price?: number }) =>
+            makePushDesignToEtsyRequest(designId, overrides, () => accessToken, login, logout),
+        onSuccess: (updated) => {
+            queryClient.setQueryData(['design', designId], updated);
+        },
+    });
+
+    return {
+        push: pushMutation.mutateAsync,
+        isPushing: pushMutation.isPending,
+        pushError: pushMutation.error,
+    };
+};
+```
+
+- [ ] **Step 10: Write `useEtsyTaxonomy`**
+
+```typescript
+// packages/web/src/hooks/useEtsyTaxonomy.ts
+import { useAuth } from '@imapps/web-utils';
+import { useQuery } from '@tanstack/react-query';
+
+import { makeGetEtsyTaxonomyRequest } from '../api/endpoints/etsyTaxonomy';
+import { flattenTaxonomyNodes } from '../utils/flattenTaxonomyNodes';
+
+export const useEtsyTaxonomy = (enabled: boolean) => {
+    const { accessToken, login, logout } = useAuth();
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['etsy-taxonomy'],
+        queryFn: () => makeGetEtsyTaxonomyRequest(() => accessToken, login, logout),
+        enabled: enabled && !!accessToken,
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+
+    return {
+        options: flattenTaxonomyNodes(data ?? []),
+        isLoading,
+    };
+};
+```
+
+- [ ] **Step 11: Update `useUserSettings`**
+
+Replace `packages/web/src/hooks/useUserSettings.ts` in full:
+
+```typescript
+import { useAuth } from '@imapps/web-utils';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+    makeGetUserSettingsRequest,
+    makeRecalculatePricesRequest,
+    makeUpdateUserSettingsRequest,
+} from '../api/endpoints/userSettings';
+
+const QUERY_KEY = ['user-settings'];
+
+export const useUserSettings = () => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    const { data, isLoading } = useQuery({
+        queryKey: QUERY_KEY,
+        queryFn: () => makeGetUserSettingsRequest(() => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: (updates: {
+            hourlyWage: number;
+            profitMargin: number;
+            markupMultiplier: number;
+            hourlyRate: number;
+            etsyDescriptionTemplate: string;
+            etsyTaxonomyMap: Record<string, number>;
+        }) => makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
+        onSuccess: (updated) => {
+            queryClient.setQueryData(QUERY_KEY, updated);
+        },
+    });
+
+    const recalculateMutation = useMutation({
+        mutationFn: () => makeRecalculatePricesRequest(() => accessToken, login, logout),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['designs'] });
+        },
+    });
+
+    return {
+        hourlyWage: data?.hourlyWage ?? 10,
+        profitMargin: data?.profitMargin ?? 15,
+        markupMultiplier: data?.markupMultiplier ?? 2.5,
+        hourlyRate: data?.hourlyRate ?? 0,
+        etsyDescriptionTemplate: data?.etsyDescriptionTemplate ?? '',
+        etsyTaxonomyMap: data?.etsyTaxonomyMap ?? {},
+        isLoading,
+        updateSettings: updateMutation.mutateAsync,
+        recalculate: recalculateMutation.mutateAsync,
+        isRecalculating: recalculateMutation.isPending,
+        recalculateResult: recalculateMutation.data,
+        recalculateError: recalculateMutation.error,
+    };
+};
+```
+
+- [ ] **Step 12: Typecheck**
+
+Run: `cd packages/web && bunx tsc --build --force 2>&1 | grep -E "error TS" | sort > /tmp/task8-sp3-errors.txt` from repo root, then diff against a fresh baseline (this branch stacks on `feat/design-authoring-upgrades`, not `main` — re-derive the baseline from THIS branch's parent commit, not the sub-project-2 baseline file, since the two branches diverge; use a disposable worktree at this task's base commit the same way sub-project 2's tasks did). Expect the same class of pre-existing/known-noise errors as before, plus new errors ONLY at `Settings/index.tsx`'s `updateSettings(...)` call site (missing the two new fields) and `ViewDesign`/`DesignEditForm` if they reference `design.etsy` before Task 10 wires them up — both are EXPECTED and fixed in later tasks of this plan. Clean generated build artifacts afterward with `git clean -fd -- packages/` (no `-x`, nothing outside `packages/`).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add packages/web/src/api/endpoints.ts packages/web/src/api/endpoints/etsyPush packages/web/src/api/endpoints/etsyTaxonomy packages/web/src/api/endpoints/userSettings packages/web/src/utils/flattenTaxonomyNodes packages/web/src/hooks/useEtsyPush.ts packages/web/src/hooks/useEtsyTaxonomy.ts packages/web/src/hooks/useUserSettings.ts
+git commit -m "feat(web): add Etsy push/taxonomy API clients and hooks"
+```
+
+---
+
+### Task 9: Web — `EtsyPushDialog` component
+
+**Files:**
+- Create: `packages/web/src/components/EtsyPushDialog/index.tsx`
+
+**Interfaces:**
+- Consumes: `useEtsyPush` (Task 8), `useEtsyTaxonomy` (Task 8), `useUserSettings` (Task 8, for `etsyDescriptionTemplate`/`etsyTaxonomyMap`), existing `Dialog`/`Button`/`Textarea`/`InputGroup` UI primitives (`packages/web/src/components/ui/*`), `renderDescriptionTemplate`-equivalent client-side rendering (do NOT import the api package's mapper — reimplement the same two-placeholder substitution inline here, it's a one-line `.replace().replace()`, not worth sharing across the api/web boundary).
+- Produces: `<EtsyPushDialog design={Design} open={boolean} onOpenChange={(open: boolean) => void} />` — a modal showing the editable composed description, resolved category (from `design.designType` looked up in `etsyTaxonomyMap`, rendered as read-only text — category is a settings-time decision, not edited per-push), price (prefilled from `design.price`), the list of product photo ids that will be sent (never diagram images), and a submit button that calls `useEtsyPush().push({ description, price })` and closes the dialog on success.
+
+- [ ] **Step 1: Write `EtsyPushDialog`**
+
+```typescript
+// packages/web/src/components/EtsyPushDialog/index.tsx
+import type { Design } from '@jewellery-catalogue/types';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+import { useEtsyPush } from '../../hooks/useEtsyPush';
+import { useUserSettings } from '../../hooks/useUserSettings';
+
+interface EtsyPushDialogProps {
+    design: Design;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+const renderTemplate = (template: string, description: string, materials: Array<{ name: string }>): string =>
+    template.replace(/\{description\}/g, description).replace(/\{materials\}/g, materials.map((m) => m.name).join(', '));
+
+const EtsyPushDialog: React.FC<EtsyPushDialogProps> = ({ design, open, onOpenChange }) => {
+    const { etsyDescriptionTemplate, etsyTaxonomyMap } = useUserSettings();
+    const { push, isPushing, pushError } = useEtsyPush(design.id);
+
+    const [description, setDescription] = useState(() =>
+        renderTemplate(etsyDescriptionTemplate, design.description, design.materials)
+    );
+    const [price, setPrice] = useState(design.price);
+
+    const taxonomyId = design.designType ? etsyTaxonomyMap[design.designType] : undefined;
+
+    const handleSend = async () => {
+        await push({ description, price });
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Send to Etsy</DialogTitle>
+                    <DialogDescription>Review before creating the draft listing on Etsy.</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <div className="space-y-1.5">
+                        <Label>Description</Label>
+                        <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={6} />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Category</Label>
+                        <p className="text-sm text-muted-foreground">
+                            {taxonomyId
+                                ? `Taxonomy #${taxonomyId} (set for ${design.designType} in Settings)`
+                                : 'No category mapped for this design type — set one in Settings before sending.'}
+                        </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Price</Label>
+                        <InputGroup className="max-w-[160px]">
+                            <InputGroupAddon align="inline-start">
+                                <InputGroupText>£</InputGroupText>
+                            </InputGroupAddon>
+                            <InputGroupInput
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={price}
+                                onChange={(e) => setPrice(Number(e.target.value))}
+                            />
+                        </InputGroup>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label>Photos</Label>
+                        <p className="text-sm text-muted-foreground">
+                            {design.imageIds.length > 0
+                                ? `${design.imageIds.length} product photo(s) will be sent.`
+                                : 'No product photos — you can add them on Etsy before publishing.'}
+                        </p>
+                    </div>
+
+                    {pushError && (
+                        <p className="text-sm text-destructive">
+                            {pushError instanceof Error ? pushError.message : 'Failed to send to Etsy.'}
+                        </p>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPushing}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSend} disabled={isPushing || !taxonomyId}>
+                        {isPushing ? 'Sending…' : 'Send to Etsy'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default EtsyPushDialog;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd packages/web && bunx tsc --build --force 2>&1 | grep -E "error TS"` from repo root, filter to lines referencing `EtsyPushDialog` — expect none beyond pre-existing/known noise. Clean generated artifacts afterward with `git clean -fd -- packages/`.
+
+(If `Dialog`/`DialogContent`/`DialogFooter`/`InputGroup` import paths don't match this repo's actual `components/ui` exports, read the nearest existing dialog usage — e.g. search for `from '@/components/ui/dialog'` elsewhere in `packages/web/src` — and correct the import paths to match; keep the component's props/logic identical.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/src/components/EtsyPushDialog
+git commit -m "feat(web): add EtsyPushDialog for reviewing a design before sending to Etsy"
+```
+
+---
+
+### Task 10: Web — wire "Send to Etsy" + Etsy chip into `ViewDesign`
+
+**Files:**
+- Modify: `packages/web/src/pages/ViewDesign/index.tsx`
+
+**Interfaces:**
+- Consumes: `Design.etsy` (Task 1), `useEtsyConnection` (existing, sub-project 1), `EtsyPushDialog` (Task 9).
+- Produces: an Etsy state chip (`Draft`/`Active` + external link to `https://www.etsy.com/your/shops/me/listing-editor/edit/{listingId}` when linked) and a "Send to Etsy" button (hidden entirely when `!connected`; disabled with a reason string in a tooltip/title attribute when `design.etsy?.listingId && !design.etsy.pushIncomplete`) that opens `EtsyPushDialog`.
+
+- [ ] **Step 1: Read the current page header/action-button area**
+
+Read `packages/web/src/pages/ViewDesign/index.tsx` around its top action-button row (near where "Edit Details" or similar buttons already render) and its destructure of `design` (already extended in sub-project 2 with `diagramImageIds`/`makingNotes` — add `etsy` to the same destructure) — find the exact existing button-row markup to match its spacing/variant conventions.
+
+- [ ] **Step 2: Add imports and state**
+
+Add imports:
+
+```typescript
+import { ExternalLink } from 'lucide-react';
+
+import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import EtsyPushDialog from '../../components/EtsyPushDialog';
+```
+
+Add to the component body (alongside other `useState` hooks):
+
+```typescript
+    const { connected: etsyConnected } = useEtsyConnection();
+    const [etsyDialogOpen, setEtsyDialogOpen] = useState(false);
+```
+
+Add `etsy` to the existing `design ?? {}` destructure.
+
+- [ ] **Step 3: Add the chip + button**
+
+In the action-button row (read the file to find its exact JSX — likely a `<div className="flex ... gap-2">` alongside an existing "Edit Details" button), add, only when `etsyConnected`:
+
+```typescript
+                    {etsyConnected && (
+                        <>
+                            {etsy?.listingId && (
+                                <a
+                                    href={`https://www.etsy.com/your/shops/me/listing-editor/edit/${etsy.listingId}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="inline-flex items-center gap-1 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+                                >
+                                    {etsy.state === 'active' ? 'Active' : 'Draft'} on Etsy
+                                    <ExternalLink className="h-3 w-3" />
+                                </a>
+                            )}
+                            <Button
+                                type="button"
+                                variant="outline"
+                                disabled={!!etsy?.listingId && !etsy.pushIncomplete}
+                                title={
+                                    etsy?.listingId && !etsy.pushIncomplete
+                                        ? 'This design is already on Etsy'
+                                        : undefined
+                                }
+                                onClick={() => setEtsyDialogOpen(true)}
+                            >
+                                Send to Etsy
+                            </Button>
+                        </>
+                    )}
+```
+
+(Match the existing `Button` import already present in this file — do not add a duplicate import if one exists.)
+
+- [ ] **Step 4: Render the dialog**
+
+At the end of the component's JSX (as a sibling to the main returned markup, same level as any other existing dialogs on this page), add:
+
+```typescript
+            {design && <EtsyPushDialog design={design} open={etsyDialogOpen} onOpenChange={setEtsyDialogOpen} />}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/web && bunx tsc --build --force 2>&1 | grep -E "error TS"` from repo root, filter to lines referencing `ViewDesign` — expect none beyond pre-existing/known noise. Clean generated artifacts afterward with `git clean -fd -- packages/`.
+
+- [ ] **Step 6: Manual smoke test**
+
+Same sandbox caveats as sub-project 2's tasks (no seeded DB, mock-auth-server bug) — attempt best-effort only; confirm the page renders without crashing when `etsyConnected` is false (chip/button simply absent) is reasonable evidence given the auth/seed limitations already documented in this repo's prior task reports.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/pages/ViewDesign/index.tsx
+git commit -m "feat(web): add Send to Etsy button and Etsy state chip to ViewDesign"
+```
+
+---
+
+### Task 11: Web — Settings page: description template + taxonomy map
+
+**Files:**
+- Modify: `packages/web/src/pages/Settings/index.tsx`
+
+**Interfaces:**
+- Consumes: `useUserSettings()` (Task 8, now returning/accepting `etsyDescriptionTemplate`/`etsyTaxonomyMap`), `useEtsyTaxonomy` (Task 8), `useEtsyConnection` (existing).
+- Produces: a new "Etsy defaults" section on `/settings` (description template textarea; one `designType → taxonomy_id` dropdown per `DesignType` enum value, fed by `useEtsyTaxonomy`'s flattened options) — shown only when `useEtsyConnection().connected` is true (per spec's UI surface map). `handleSavePricing` (or a new sibling `handleSaveEtsyDefaults`, matching whichever save-button granularity this page already uses for its other sections — read the file first) sends the two new fields.
+
+- [ ] **Step 1: Read the current Settings page structure**
+
+Read `packages/web/src/pages/Settings/index.tsx` in full — note whether each `<section>` (Etsy Connection, Pricing) has its own independent save action or shares one page-level save, and match that pattern for the new section rather than inventing a third pattern.
+
+- [ ] **Step 2: Add local state**
+
+Alongside the existing `local*` `useState` declarations, add:
+
+```typescript
+    const [localEtsyDescriptionTemplate, setLocalEtsyDescriptionTemplate] = useState(etsyDescriptionTemplate);
+    const [localEtsyTaxonomyMap, setLocalEtsyTaxonomyMap] = useState<Record<string, number>>(etsyTaxonomyMap);
+```
+
+Destructure `etsyDescriptionTemplate`, `etsyTaxonomyMap` from `useUserSettings()` alongside the existing fields. Add the same fields to this page's existing sync `useEffect` (the one that resets local state when the hook's data changes), following its exact pattern.
+
+- [ ] **Step 3: Update the save call**
+
+Wherever this page currently calls `updateSettings({ hourlyWage, profitMargin, markupMultiplier, hourlyRate })` (from sub-project 2's Task 11), extend it to include the two new fields:
+
+```typescript
+            await updateSettings({
+                hourlyWage: wage,
+                profitMargin: margin,
+                markupMultiplier: Number(localMarkupMultiplier),
+                hourlyRate: Number(localHourlyRate),
+                etsyDescriptionTemplate: localEtsyDescriptionTemplate,
+                etsyTaxonomyMap: localEtsyTaxonomyMap,
+            });
+```
+
+(If this page's save actions are per-section rather than one shared call, add the two new fields to whichever single call already sends the full settings object — this page's `updateSettings` mutation always sends the complete `UserSettings` shape per Task 4's handler contract, which requires all 6 fields together; there is no partial-update endpoint.)
+
+- [ ] **Step 4: Add the Etsy defaults section markup**
+
+Add the import:
+
+```typescript
+import { useEtsyTaxonomy } from '../../hooks/useEtsyTaxonomy';
+import { DesignType } from '@jewellery-catalogue/types';
+```
+
+Call the hook near the top of the component (alongside `useEtsyConnection()`):
+
+```typescript
+    const { options: taxonomyOptions, isLoading: taxonomyLoading } = useEtsyTaxonomy(etsyConnected);
+```
+
+Add a new `<Card>` section (matching the existing `Etsy Connection`/`Pricing` cards' structure — read one for the exact wrapper markup), rendered only when `etsyConnected`:
+
+```typescript
+                {etsyConnected && (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Etsy Defaults</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-1.5">
+                                <Label>Description template</Label>
+                                <Textarea
+                                    value={localEtsyDescriptionTemplate}
+                                    onChange={(e) => setLocalEtsyDescriptionTemplate(e.target.value)}
+                                    placeholder="{description}\n\nMaterials: {materials}"
+                                    rows={4}
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Use {'{description}'} and {'{materials}'} as placeholders.
+                                </p>
+                            </div>
+
+                            <div className="space-y-3">
+                                <Label>Category by design type</Label>
+                                {Object.values(DesignType).map((designType) => (
+                                    <div key={designType} className="flex items-center gap-3">
+                                        <span className="w-28 text-sm">{designType}</span>
+                                        <select
+                                            className="flex-1 rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+                                            disabled={taxonomyLoading}
+                                            value={localEtsyTaxonomyMap[designType] ?? ''}
+                                            onChange={(e) =>
+                                                setLocalEtsyTaxonomyMap((prev) => ({
+                                                    ...prev,
+                                                    [designType]: Number(e.target.value),
+                                                }))
+                                            }
+                                        >
+                                            <option value="" disabled>
+                                                Select a category…
+                                            </option>
+                                            {taxonomyOptions.map((opt) => (
+                                                <option key={opt.id} value={opt.id}>
+                                                    {opt.label}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                )}
+```
+
+(Match this page's existing `Card`/`CardHeader`/`CardTitle`/`CardContent`/`Label`/`Textarea` import sources exactly — read the top of the file rather than guessing.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/web && bunx tsc --build --force 2>&1 | grep -E "error TS"` from repo root, filter to lines referencing `Settings/index.tsx` — expect none beyond pre-existing/known noise (this task should make the `updateSettings(...)` arity error from Task 8 disappear, mirroring how sub-project 2's Task 11 resolved its own carried-forward error). Clean generated artifacts afterward with `git clean -fd -- packages/`.
+
+- [ ] **Step 6: Manual smoke test**
+
+Best-effort only, same sandbox caveats as prior tasks — confirm `/settings` renders without crashing and the Etsy Defaults section is entirely absent when not connected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/pages/Settings/index.tsx
+git commit -m "feat(web): add Etsy description template and category mapping to Settings"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Entry button + push dialog (Task 9, 10) · Server flow's 4 sequential steps — createDraftListing, uploadListingImage, updateListingInventory, persist `etsy` block (Task 6) · >2 variation groups rejected before any Etsy call (Task 6) · Fixed fields `who_made`/`when_made`/`quantity` (Task 5 mapper) · Failure/resume model with `pushIncomplete` + `getListingImages`-checked idempotent image upload + always-safe inventory re-put (Task 6) · Description template with `{description}`/`{materials}` placeholders, editable before send (Task 5 mapper on the API side for the *initial* render only, Task 9 dialog for the editable copy) · Category via `designType → taxonomy_id` settings map fed by `getSellerTaxonomyNodes` (Task 2, 8, 11) · Diagrams never sent — verified by construction: `EtsyPushService` only ever reads `design.imageIds`, never `design.diagramImageIds` (Task 6, and asserted directly in Task 6's test `expect(mockImageService.getImage).not.toHaveBeenCalledWith('diagram-1')`) · Re-push blocked with "already on Etsy" (Task 6) · Unique sparse index on `etsy.listingId` (Task 7).
+- **Out of scope, confirmed not implemented here:** status refresh polling (sub-project 4), the one-time linking script (sub-project 5), re-push/update-after-push (spec Non-goal), orders/receipts (spec Non-goal), AI-generated descriptions (spec Non-goal — the template `{description}`/`{materials}` slot is designed so this can be added later without touching this plan's code).
+- **Placeholder scan:** no TBD/TODO markers; every step has runnable code or an exact command. Task 9/10/11's UI steps ask the implementer to read the exact existing `components/ui` import paths and section-save-granularity before inserting (rather than guessing a shape that might not match this repo's actual primitives) — same intentional pattern sub-project 2's Task 9/12 used, not a placeholder.
+- **Type consistency:** `EtsyPushService.push`'s constructor dependency order (`designRepo, imageService, etsyClient, etsyConnectionService, userSettingsService`) is used identically in Task 6's test, implementation, and Task 7's DI registration. `EtsyClient`'s new method signatures (Task 2) match exactly how `EtsyPushService` (Task 6) and `handlers/Etsy` (Task 7) call them. `flattenTaxonomyNodes`'s `{id, label}` shape (Task 8) matches exactly what `Settings`' taxonomy dropdown (Task 11) renders. `UserSettings.etsyDescriptionTemplate`/`etsyTaxonomyMap` field names are identical from the schema (Task 1) through the service (Task 4), the hook (Task 8), and every UI consumer (Task 9, 11).

--- a/docs/superpowers/plans/2026-07-19-etsy-integration-remaining-work.md
+++ b/docs/superpowers/plans/2026-07-19-etsy-integration-remaining-work.md
@@ -1,0 +1,46 @@
+# Etsy API Integration — Remaining Work
+
+**Status as of 2026-07-19.** Tracks progress against `docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md`'s 5 sub-projects (now 6, see amendment below). For "how we got here," see `.superpowers/sdd/progress.md` (current sub-project's task-by-task ledger) and `.superpowers/sdd/archive-*/` (completed sub-projects' ledgers).
+
+## Done and merged to `main`
+
+| # | Sub-project | Plan | PR | Status |
+|---|---|---|---|---|
+| 1 | Etsy connection (OAuth) | `docs/superpowers/plans/2026-07-16-etsy-oauth-connection.md` | #35 | Merged |
+| 2 | Design authoring upgrades (maker docs + price suggestion) | `docs/superpowers/plans/2026-07-18-design-authoring-upgrades.md`* | #36 | Merged |
+| 3 | Push to Etsy as draft | `docs/superpowers/plans/2026-07-18-push-to-etsy-as-draft.md`* | #37 | Merged |
+
+\* These two plan files exist locally but were never `git add`ed — they're currently untracked in the working tree. Worth committing to the repo now that their branches have merged, for permanent record (or intentionally leave as scratch — your call).
+
+Both #36 and #37 were originally opened as **stacked PRs** (each based on the previous sub-project's branch, not `main`) per an explicit instruction to merge the whole chain in sequence at the end rather than one-by-one. #36 and #37 ended up merged individually before the rest of the stack was ready — when #36 was squash-merged, `feat/etsy-push-to-draft` had to be rebased (`git rebase --onto origin/main d48b513 feat/etsy-push-to-draft`) and force-pushed to stay mergeable. **Squash-merging a base PR while a stacked branch is still open always requires this rebase** — keep that in mind for sub-project 4/5's branches once they exist.
+
+## Not started
+
+### Sub-project 4: Status refresh + Listings page (amended scope)
+
+**Plan written:** `docs/superpowers/plans/2026-07-19-etsy-status-and-listings.md` (8 tasks, verified against the live Etsy API via the Etsy MCP tool — not guessed). Ready to execute with `superpowers:subagent-driven-development`. Original spec text: "Viewing a linked design triggers a lightweight `GET /listings/{id}` ... updates the stored `state`. No background polling in v1." — this part is unchanged.
+
+**Scope amendment (decided mid-session, 2026-07-18, via AskUserQuestion):** the user asked for a new page listing **all current Etsy listings** (live from Etsy, not just catalogue-linked designs), and chose to fold it into sub-project 4 rather than create a separate sub-project 6. This **supersedes** the spec's original decision-log line "No listings screen (one-time script covers linking); orders page is future work." The spec file itself has not been edited to reflect this yet — do that when sub-project 4's plan is written, or at least note the amendment at the top of that plan (mirroring how sub-project 2's/3's plans state their own scope precisely).
+
+**Design sketched but not yet written into a plan** (from mid-session exploration — verify against current code before trusting, since no code was written):
+- `EtsyClient.getListing(accessToken, listingId): Promise<{listingId, state}>` — always pass the OAuth token (simpler than branching on public-vs-private per the spec's "public for active, OAuth for draft" note, since the caller is always an already-connected user).
+- `EtsyClient.getShopListingsActive(shopId): Promise<EtsyListingSummary[]>` — public endpoint (`GET /shops/{shop_id}/listings/active`, verified in spec's "Verified API facts"), no token needed; paginate internally (Etsy caps `limit` at 100, ~102 listings means 2 pages) and return the full list in one response. Note this only surfaces **active** listings, not drafts sitting on Etsy outside this app — call that out in the plan/UI copy.
+- `EtsyConnectionService.getShopId(userId): Promise<number>` — new trivial method (read `shopId` off the stored connection without touching access-token refresh logic at all, since browsing listings doesn't need a live token).
+- New `EtsyStatusService` (separate from `EtsyPushService`, single-responsibility): `refreshStatus(designId, userId)` (fetch + persist updated `etsy.state`) and `listShopListings(userId)` (fetch all active listings, cross-reference against this user's designs by `etsy.listingId` to flag which are already linked).
+- New routes: `GET /api/designs/:id/etsy-status`, `GET /api/etsy/listings`.
+- Web: a new `/listings` page + `LISTINGS_PAGE` route constant + sidebar nav entry (`AppSidebar` maps the `ROUTES` array in `packages/web/src/constants/routes.ts` to icons in a `routeIcons` object in `packages/web/src/components/AppSidebar/index.tsx` — follow that exact pattern, pick a `lucide-react` icon). Status-refresh call fires once on `ViewDesign` mount when the design is already linked (no polling).
+- Rough task count estimate: ~7 tasks (EtsyClient methods, EtsyConnectionService.getShopId, EtsyStatusService, handlers/routes/DI, web API client+hooks, ViewDesign wiring, new Listings page).
+
+**Next action:** write the plan (`superpowers:writing-plans`), following the same TDD/bite-sized-task discipline as sub-projects 2 and 3's plans — read those two as the style reference. Then execute with `superpowers:subagent-driven-development` (fresh implementer + reviewer per task), same as sub-projects 2/3. Branch stacks on current `main` tip (sub-projects 1–3 already merged, so no need to stack on a branch — just branch from `main`).
+
+### Sub-project 5: One-time linking script
+
+**No plan file exists yet.** Spec: `scripts/link-etsy-listings.ts` — fetches all active listings + all designs, prints title-similarity suggestions as a proposed `designId → listingId` map, operator confirms/edits inline, writes `etsy: {listingId, state, lastPushedAt: null}` to each design. Guards: refuses to link a listing already linked elsewhere (the unique sparse index on `etsy.listingId`, added in sub-project 3, already backs this at the DB level). Run once against prod for the 5 existing designs; safely rerunnable.
+
+This sub-project benefits from sub-project 4's `getShopListingsActive` already existing (don't duplicate that Etsy call) — do it after 4, not before or in parallel.
+
+## Process notes worth carrying into the next sub-project's dispatches
+
+- **`bunx tsc --noEmit` inside `packages/web` is a silent no-op** (solution-style tsconfig). Use `bunx tsc --build --force` from repo root + diff against a baseline captured via a disposable worktree at the branch's base commit, then `git clean -fd -- packages/` to remove generated artifacts. `packages/api`/`packages/types` don't have this problem.
+- **`fallow-audit` (the pre-push hook) hard-fails on dead-code findings**, not just duplication (duplication is warn-only). A method only called via DI-container resolution from a different file (e.g. `dependencyContainer.resolve(...).someMethod()`) reads as unreachable to the static analyzer — suppress with `// fallow-ignore-next-line unused-class-member` directly above the method (see `EtsyClient.getSellerTaxonomyNodes` or `EtsyConnectionService.getValidAccessToken` for the existing convention). Check `bunx fallow-audit --format json` for structured findings if a push is blocked and the reason isn't obvious from the summary.
+- **Squash-merging a base branch while a stacked branch is open breaks the stack** — rebase `--onto` the new tip and force-push before continuing work on the child branch.

--- a/docs/superpowers/plans/2026-07-19-etsy-status-and-listings.md
+++ b/docs/superpowers/plans/2026-07-19-etsy-status-and-listings.md
@@ -1,0 +1,1170 @@
+# Etsy Status Refresh + Listings Page (Sub-project 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Scope amendment (carried from `docs/superpowers/plans/2026-07-19-etsy-integration-remaining-work.md`, decided 2026-07-18 via AskUserQuestion):** this plan covers both halves of the amended sub-project 4 — (a) the original spec's lightweight per-design status refresh, and (b) a new `/listings` page showing **all current active Etsy listings** (live from Etsy, not just catalogue-linked designs). This **supersedes** the design spec's (`docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md`) decision-log line "No listings screen (one-time script covers linking); orders page is future work."
+
+**Goal:** Let Mari see a design's live Etsy status (Draft/Active/Inactive) refreshed on page view, and browse all of her shop's active Etsy listings with which ones are already linked to a catalogue design.
+
+**Architecture:** Same layered pattern as sub-projects 1–3: `types` (no changes needed — `Design.etsy` already covers the states this plan reads/writes) → `domain` (`EtsyClient` gains two thin, tested HTTP methods; `EtsyConnectionService` gains a trivial `getShopId`; a new `EtsyStatusService`, separate from `EtsyPushService`, orchestrates both status-refresh and shop-listing-browse) → `handlers`/`routes` → web (`api/endpoints` + `useEtsyStatus`/`useEtsyListings` hooks + `ViewDesign` wiring + a new `Listings` page reachable from the sidebar).
+
+**Tech Stack:** Bun + TypeScript + Hono (api), React + react-query + react-router-dom (web), MongoDB, Zod, bun:test, lucide-react icons.
+
+## Global Constraints
+
+- **Verified against the live Etsy API** (via the Etsy MCP tool, this session) rather than guessed:
+  - `getListing` — `GET /v3/application/listings/{listing_id}`. Requires only `x-api-key` per Etsy's docs (no OAuth scope listed), but per this app's existing design decision (`docs/superpowers/plans/2026-07-19-etsy-integration-remaining-work.md`: "always pass the OAuth token — simpler than branching on public-vs-private per the spec's note, since the caller is always an already-connected user") this app always sends the bearer token too, matching the pattern already used by `EtsyClient.getListingImages`. Response `state` is one of `active, inactive, sold_out, draft, expired` — this app's `Design.etsy.state` only models `draft | active | inactive` (`packages/types/src/design/index.ts`), so `sold_out`/`expired` map down to `inactive`.
+  - `findAllActiveListingsByShop` — `GET /v3/application/shops/{shop_id}/listings/active`. Public (`x-api-key` only, no token). Response is `{ count: number, results: ShopListing[] }`; supports `limit`/`offset` query params. `limit` caps at 100 server-side, so ~102 listings (per the spec's verified shop facts) needs 2 pages — paginate internally by looping on `offset += 100` until `offset >= count`.
+  - `ShopListing.price` is a `Money` object `{ amount, divisor, currency_code }`, not a plain number — render as `amount / divisor`.
+- This plan only surfaces **active** Etsy listings (`findAllActiveListingsByShop`) — drafts sitting on Etsy outside this app are not visible here. State this plainly in the `/listings` page copy so Mari isn't confused about why a known draft is missing.
+- No background polling anywhere in this plan (spec, sub-project 4: "No background polling in v1") — status refresh fires once when `ViewDesign` mounts for an already-linked design; the listings page fetches once on mount, refresh only via manual navigation/refetch.
+- `EtsyStatusService` is a new, separate domain service (single-responsibility, mirrors why `EtsyPushService` is separate from `DesignService`) — do not bolt these methods onto `EtsyPushService` or `DesignService`.
+- All new `EtsyClient` HTTP methods take `accessToken`/`shopId`/`listingId` as explicit parameters (the client stays stateless per-call, matching every existing method) — do not give `EtsyClient` its own notion of "the current user."
+- `EtsyConnectionService.getShopId` reads the stored `shopId` only — it must NOT call `getValidAccessToken` or touch refresh logic at all (browsing listings needs no live token; the spec's `getShopListingsActive` call is a public endpoint).
+- Follow the existing repo's layered pattern exactly (`EtsyPushService`/`EtsyConnectionService` are the reference shape) — constructed from injected dependencies, no service reaching into another service's internals.
+- Tests: `bun:test`, mocks via `mock()`, following `EtsyClient/index.test.ts`/`EtsyConnectionService/index.test.ts`/`EtsyPushService/index.test.ts` conventions exactly (this plan adds sibling `describe` blocks to two of those three existing files, and one brand new test file for `EtsyStatusService`).
+- Lint/format: `bun run lint` (Biome) must pass on touched files before each commit.
+- **Typecheck caveat (carried over from sub-projects 2/3):** `bunx tsc --noEmit` inside `packages/web` (and the repo's CI `bun run tsc --noEmit`) is a silent no-op — the tsconfig is solution-style (`files: []`, no `include`), so it always exits 0 having checked nothing. Use `bunx tsc --build --force` from the repo root for a real check, then `git clean -fd -- packages/` to remove the generated `.d.ts`/`.tsbuildinfo`/`.js` artifacts it leaves behind (do NOT use `-x`, do NOT run `git clean` outside `packages/`). A pre-existing baseline of unrelated errors exists on `main` — diff against that baseline rather than expecting a clean run. `packages/api` and `packages/types` do NOT have this problem; `bunx tsc --noEmit` works normally there.
+- **`fallow-audit` (the pre-push hook) hard-fails on dead-code findings.** A method only called via DI-container resolution from a different file (e.g. `dependencyContainer.resolve(...).someMethod()`) reads as unreachable to the static analyzer — suppress with `// fallow-ignore-next-line unused-class-member` directly above the method if that happens (see `EtsyClient.getSellerTaxonomyNodes` for the existing convention). Methods called as plain typed method calls on an injected constructor field (e.g. `this.etsyConnectionService.getShopId(userId)` from inside `EtsyStatusService`) are traceable normally and do NOT need this suppression — only the handler-layer entry points that go through `dependencyContainer.resolve(...)` directly are at risk. Check `bunx fallow-audit --format json` for structured findings if a push is blocked and the reason isn't obvious from the summary.
+- This plan does not implement the one-time linking script (sub-project 5, spec) — that is a separate, later plan that depends on this one's `EtsyClient.getShopListingsActive` already existing (don't duplicate that Etsy call there).
+- Branch stacks on current `main` tip — sub-projects 1–3 are already merged, so branch directly from `main`, no rebase-onto-a-stack dance needed for this plan.
+
+---
+
+## File Structure
+
+```
+packages/api/src/domain/EtsyClient/index.ts                    # + getListing, getShopListingsActive
+packages/api/src/domain/EtsyClient/index.test.ts
+packages/api/src/domain/EtsyConnectionService/index.ts         # + getShopId
+packages/api/src/domain/EtsyConnectionService/index.test.ts
+packages/api/src/domain/EtsyStatusService/index.ts              # new: refreshStatus + listShopListings
+packages/api/src/domain/EtsyStatusService/index.test.ts         # new
+packages/api/src/handlers/Etsy/index.ts                         # + refreshDesignEtsyStatus, getEtsyShopListings
+packages/api/src/dependencies/types.ts                          # + EtsyStatusService token
+packages/api/src/dependencies/index.ts                          # + registration
+packages/api/src/routes/index.ts                                # + GET /api/designs/:id/etsy-status, GET /api/etsy/listings
+
+packages/web/src/api/endpoints.ts                                # + getEtsyStatusEndpoint, ETSY_LISTINGS_ENDPOINT
+packages/web/src/api/endpoints/etsyStatus/index.ts                # new
+packages/web/src/api/endpoints/etsyListings/index.ts               # new
+packages/web/src/hooks/useEtsyStatus.ts                            # new
+packages/web/src/hooks/useEtsyListings.ts                          # new
+packages/web/src/pages/ViewDesign/index.tsx                        # + fire useEtsyStatus on mount when linked
+packages/web/src/pages/Listings/index.tsx                          # new
+packages/web/src/constants/routes.ts                               # + LISTINGS_PAGE, added to ROUTES
+packages/web/src/components/AppSidebar/index.tsx                    # + '/listings' icon mapping
+packages/web/src/index.tsx                                          # + <Route> for LISTINGS_PAGE
+```
+
+---
+
+### Task 1: API — `EtsyClient.getListing`
+
+**Files:**
+- Modify: `packages/api/src/domain/EtsyClient/index.ts`
+- Modify: `packages/api/src/domain/EtsyClient/index.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (same file/class sub-projects 1/3 created; purely additive).
+- Produces: `interface EtsyListingStatus { listingId: number; state: EtsyListingState }` (imports `EtsyListingState` from `@jewellery-catalogue/types`), `getListing(accessToken: string, listingId: number): Promise<EtsyListingStatus>` — consumed by `EtsyStatusService` (Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/api/src/domain/EtsyClient/index.test.ts`, inside the existing `describe('EtsyClient', ...)` block, as a sibling to `getSellerTaxonomyNodes`:
+
+```typescript
+    describe('getListing', () => {
+        it('fetches the listing and maps a draft state through unchanged', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_id: 999, state: 'draft' }), { status: 200 }));
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'draft' });
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+        });
+
+        it('maps an active state through unchanged', async () => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_id: 999, state: 'active' }), { status: 200 }));
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'active' });
+        });
+
+        it.each(['inactive', 'sold_out', 'expired'])('maps Etsy state "%s" down to "inactive"', async (etsyState) => {
+            fetchMock.mockResolvedValue(new Response(JSON.stringify({ listing_id: 999, state: etsyState }), { status: 200 }));
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'inactive' });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 404 }));
+
+            await expect(client.getListing('at', 1)).rejects.toThrow();
+        });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: FAIL — `client.getListing is not a function`
+
+- [ ] **Step 3: Implement**
+
+In `packages/api/src/domain/EtsyClient/index.ts`, add the import at the top of the file (after the `node:crypto` import):
+
+```typescript
+import type { EtsyListingState } from '@jewellery-catalogue/types';
+```
+
+Add the interface and mapping helper above the `EtsyClient` class, alongside the other exported interfaces:
+
+```typescript
+export interface EtsyListingStatus {
+    listingId: number;
+    state: EtsyListingState;
+}
+
+const mapListingState = (state: string): EtsyListingState => (state === 'draft' || state === 'active' ? state : 'inactive');
+```
+
+Add the method inside the `EtsyClient` class, after `getShop` (before `createDraftListing`):
+
+```typescript
+    async getListing(accessToken: string, listingId: number): Promise<EtsyListingStatus> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getListing failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { listing_id: number; state: string };
+        return { listingId: body.listing_id, state: mapListingState(body.state) };
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: PASS (including all pre-existing `EtsyClient` tests — unaffected, purely additive)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyClient/index.ts packages/api/src/domain/EtsyClient/index.test.ts
+git commit -m "feat(api): add EtsyClient.getListing for status refresh"
+```
+
+---
+
+### Task 2: API — `EtsyClient.getShopListingsActive`
+
+**Files:**
+- Modify: `packages/api/src/domain/EtsyClient/index.ts`
+- Modify: `packages/api/src/domain/EtsyClient/index.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (additive to the same class).
+- Produces: `interface EtsyListingSummary { listingId: number; title: string; price: number; url: string }`, `getShopListingsActive(shopId: number): Promise<EtsyListingSummary[]>` — consumed by `EtsyStatusService` (Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/api/src/domain/EtsyClient/index.test.ts`, as a sibling to the `getListing` block just added:
+
+```typescript
+    describe('getShopListingsActive', () => {
+        it('fetches a single page when count fits within the page limit', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        count: 2,
+                        results: [
+                            { listing_id: 1, title: 'Silver Ring', price: { amount: 2550, divisor: 100, currency_code: 'GBP' }, url: 'https://etsy.com/listing/1' },
+                            { listing_id: 2, title: 'Gold Ring', price: { amount: 4000, divisor: 100, currency_code: 'GBP' }, url: 'https://etsy.com/listing/2' },
+                        ],
+                    }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getShopListingsActive(47408839);
+
+            expect(result).toEqual([
+                { listingId: 1, title: 'Silver Ring', price: 25.5, url: 'https://etsy.com/listing/1' },
+                { listingId: 2, title: 'Gold Ring', price: 40, url: 'https://etsy.com/listing/2' },
+            ]);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+        });
+
+        it('paginates when count exceeds the 100-item page limit', async () => {
+            const page = (start: number, count: number, total: number) => ({
+                count: total,
+                results: Array.from({ length: count }, (_, i) => ({
+                    listing_id: start + i,
+                    title: `Listing ${start + i}`,
+                    price: { amount: 1000, divisor: 100, currency_code: 'GBP' },
+                    url: `https://etsy.com/listing/${start + i}`,
+                })),
+            });
+
+            fetchMock
+                .mockResolvedValueOnce(new Response(JSON.stringify(page(1, 100, 102)), { status: 200 }))
+                .mockResolvedValueOnce(new Response(JSON.stringify(page(101, 2, 102)), { status: 200 }));
+
+            const result = await client.getShopListingsActive(47408839);
+
+            expect(result).toHaveLength(102);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            const [firstUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [secondUrl] = fetchMock.mock.calls[1] as [string, RequestInit];
+            expect(firstUrl).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0');
+            expect(secondUrl).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=100');
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
+
+            await expect(client.getShopListingsActive(1)).rejects.toThrow();
+        });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: FAIL — `client.getShopListingsActive is not a function`
+
+- [ ] **Step 3: Implement**
+
+In `packages/api/src/domain/EtsyClient/index.ts`, add the interface above the `EtsyClient` class, alongside `EtsyListingStatus`:
+
+```typescript
+export interface EtsyListingSummary {
+    listingId: number;
+    title: string;
+    price: number;
+    url: string;
+}
+```
+
+Add a page-size constant near the top of the file, alongside `API_BASE`:
+
+```typescript
+const SHOP_LISTINGS_PAGE_LIMIT = 100;
+```
+
+Add the method inside the `EtsyClient` class, after `getListing`:
+
+```typescript
+    async getShopListingsActive(shopId: number): Promise<EtsyListingSummary[]> {
+        const results: EtsyListingSummary[] = [];
+        let offset = 0;
+
+        for (;;) {
+            const response = await fetch(
+                `${API_BASE}/shops/${shopId}/listings/active?limit=${SHOP_LISTINGS_PAGE_LIMIT}&offset=${offset}`,
+                { headers: { 'x-api-key': this.apiKeyHeader() } }
+            );
+
+            if (!response.ok) {
+                throw new Error(`Etsy getShopListingsActive failed: ${response.status} ${await response.text()}`);
+            }
+
+            const body = (await response.json()) as {
+                count: number;
+                results: Array<{
+                    listing_id: number;
+                    title: string;
+                    price: { amount: number; divisor: number };
+                    url: string;
+                }>;
+            };
+
+            results.push(
+                ...body.results.map((r) => ({
+                    listingId: r.listing_id,
+                    title: r.title,
+                    price: r.price.amount / r.price.divisor,
+                    url: r.url,
+                }))
+            );
+
+            offset += SHOP_LISTINGS_PAGE_LIMIT;
+            if (offset >= body.count || body.results.length < SHOP_LISTINGS_PAGE_LIMIT) break;
+        }
+
+        return results;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyClient/index.test.ts`
+Expected: PASS (all tests, including the pagination case)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyClient/index.ts packages/api/src/domain/EtsyClient/index.test.ts
+git commit -m "feat(api): add EtsyClient.getShopListingsActive with pagination"
+```
+
+---
+
+### Task 3: API — `EtsyConnectionService.getShopId`
+
+**Files:**
+- Modify: `packages/api/src/domain/EtsyConnectionService/index.ts`
+- Modify: `packages/api/src/domain/EtsyConnectionService/index.test.ts`
+
+**Interfaces:**
+- Consumes: `EtsyConnectionRepository.getByUserId` (existing).
+- Produces: `getShopId(userId: string): Promise<number>` — consumed by `EtsyStatusService` (Task 4). Does NOT call `getValidAccessToken` or `EtsyClient` at all.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/api/src/domain/EtsyConnectionService/index.test.ts`, as a sibling to the `getPushCredentials` block:
+
+```typescript
+    describe('getShopId', () => {
+        it('returns the stored shopId without touching token refresh', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(makeConnection({ shopId: 47408839 }));
+
+            const result = await service.getShopId('user-1');
+
+            expect(result).toBe(47408839);
+            expect(mockEtsyClient.refreshAccessToken).not.toHaveBeenCalled();
+        });
+
+        it('throws when there is no connection', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(null);
+
+            await expect(service.getShopId('user-1')).rejects.toThrow();
+        });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyConnectionService/index.test.ts`
+Expected: FAIL — `service.getShopId is not a function`
+
+- [ ] **Step 3: Implement**
+
+In `packages/api/src/domain/EtsyConnectionService/index.ts`, add the method after `getPushCredentials` (at the end of the class, before the closing `}`):
+
+```typescript
+    async getShopId(userId: string): Promise<number> {
+        const connection = await this.connectionRepo.getByUserId(userId);
+        if (!connection) {
+            throw new APIError('Etsy is not connected', 400);
+        }
+        return connection.shopId;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyConnectionService/index.test.ts`
+Expected: PASS (all pre-existing tests plus the two new ones)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyConnectionService/index.ts packages/api/src/domain/EtsyConnectionService/index.test.ts
+git commit -m "feat(api): add getShopId to EtsyConnectionService"
+```
+
+---
+
+### Task 4: API — `EtsyStatusService`
+
+**Files:**
+- Create: `packages/api/src/domain/EtsyStatusService/index.ts`
+- Create: `packages/api/src/domain/EtsyStatusService/index.test.ts`
+
+**Interfaces:**
+- Consumes: `DesignRepository.getByIdAndUserId`/`.getByUserId`/`.update` (existing), `EtsyClient.getListing`/`.getShopListingsActive` (Tasks 1/2), `EtsyConnectionService.getValidAccessToken` (existing)/`.getShopId` (Task 3).
+- Produces:
+  - `interface EtsyListingWithLinkStatus extends EtsyListingSummary { linkedDesignId: string | null }`
+  - `class EtsyStatusService { constructor(designRepo, etsyClient, etsyConnectionService); refreshStatus(designId: string, userId: string): Promise<Design>; listShopListings(userId: string): Promise<EtsyListingWithLinkStatus[]> }`
+  - consumed by `handlers/Etsy` (Task 5).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/api/src/domain/EtsyStatusService/index.test.ts
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import { EtsyStatusService } from './index';
+
+const mockDesignRepo = { getByIdAndUserId: mock(), getByUserId: mock(), update: mock() };
+const mockEtsyClient = { getListing: mock(), getShopListingsActive: mock() };
+const mockEtsyConnectionService = { getValidAccessToken: mock(), getShopId: mock() };
+
+function makeDesign(overrides: Partial<Design> = {}): Design {
+    return {
+        id: 'design-1',
+        userId: 'user-1',
+        name: 'Silver Ring',
+        description: 'A lovely ring.',
+        timeRequired: '01:00',
+        materials: [],
+        imageIds: [],
+        diagramImageIds: [],
+        makingNotes: '',
+        price: 25,
+        totalMaterialCosts: 10,
+        dateAdded: new Date(),
+        totalQuantity: 2,
+        ...overrides,
+    };
+}
+
+describe('EtsyStatusService', () => {
+    let service: EtsyStatusService;
+
+    beforeEach(() => {
+        [...Object.values(mockDesignRepo), ...Object.values(mockEtsyClient), ...Object.values(mockEtsyConnectionService)].forEach(
+            (m) => m.mockClear()
+        );
+
+        service = new EtsyStatusService(
+            mockDesignRepo as unknown as DesignRepository,
+            mockEtsyClient as unknown as EtsyClient,
+            mockEtsyConnectionService as unknown as EtsyConnectionService
+        );
+
+        mockEtsyConnectionService.getValidAccessToken.mockResolvedValue('at-token');
+        mockEtsyConnectionService.getShopId.mockResolvedValue(47408839);
+    });
+
+    describe('refreshStatus', () => {
+        it('fetches the live state and persists it onto the design, preserving other etsy fields', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({ etsy: { listingId: 999, state: 'draft', lastPushedAt: 123, pushIncomplete: false } })
+            );
+            mockEtsyClient.getListing.mockResolvedValue({ listingId: 999, state: 'active' });
+
+            const result = await service.refreshStatus('design-1', 'user-1');
+
+            expect(mockEtsyClient.getListing).toHaveBeenCalledWith('at-token', 999);
+            expect(result.etsy).toEqual({ listingId: 999, state: 'active', lastPushedAt: 123, pushIncomplete: false });
+            expect(mockDesignRepo.update).toHaveBeenCalledWith('design-1', result);
+        });
+
+        it('throws when the design does not exist', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(null);
+
+            await expect(service.refreshStatus('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.getListing).not.toHaveBeenCalled();
+        });
+
+        it('throws when the design is not linked to an Etsy listing', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+
+            await expect(service.refreshStatus('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.getListing).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listShopListings', () => {
+        it('flags listings already linked to one of this user\'s designs', async () => {
+            mockDesignRepo.getByUserId.mockResolvedValue([
+                makeDesign({ id: 'design-1', etsy: { listingId: 1, state: 'active', lastPushedAt: 1 } }),
+                makeDesign({ id: 'design-2' }),
+            ]);
+            mockEtsyClient.getShopListingsActive.mockResolvedValue([
+                { listingId: 1, title: 'Linked Listing', price: 25, url: 'https://etsy.com/listing/1' },
+                { listingId: 2, title: 'Unlinked Listing', price: 30, url: 'https://etsy.com/listing/2' },
+            ]);
+
+            const result = await service.listShopListings('user-1');
+
+            expect(mockEtsyConnectionService.getShopId).toHaveBeenCalledWith('user-1');
+            expect(mockEtsyClient.getShopListingsActive).toHaveBeenCalledWith(47408839);
+            expect(result).toEqual([
+                { listingId: 1, title: 'Linked Listing', price: 25, url: 'https://etsy.com/listing/1', linkedDesignId: 'design-1' },
+                { listingId: 2, title: 'Unlinked Listing', price: 30, url: 'https://etsy.com/listing/2', linkedDesignId: null },
+            ]);
+        });
+
+        it('returns every listing unlinked when the user has no linked designs', async () => {
+            mockDesignRepo.getByUserId.mockResolvedValue([makeDesign()]);
+            mockEtsyClient.getShopListingsActive.mockResolvedValue([
+                { listingId: 5, title: 'Some Listing', price: 10, url: 'https://etsy.com/listing/5' },
+            ]);
+
+            const result = await service.listShopListings('user-1');
+
+            expect(result).toEqual([{ listingId: 5, title: 'Some Listing', price: 10, url: 'https://etsy.com/listing/5', linkedDesignId: null }]);
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bun test src/domain/EtsyStatusService/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/api/src/domain/EtsyStatusService/index.ts
+import { APIError } from '@imapps/api-utils/hono';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient, EtsyListingSummary } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+
+export interface EtsyListingWithLinkStatus extends EtsyListingSummary {
+    linkedDesignId: string | null;
+}
+
+export class EtsyStatusService {
+    constructor(
+        private readonly designRepo: DesignRepository,
+        private readonly etsyClient: EtsyClient,
+        private readonly etsyConnectionService: EtsyConnectionService
+    ) {}
+
+    async refreshStatus(designId: string, userId: string): Promise<Design> {
+        const design = await this.designRepo.getByIdAndUserId(designId, userId);
+        if (!design) {
+            throw new APIError('Design not found', 404);
+        }
+        if (!design.etsy?.listingId) {
+            throw new APIError('Design is not linked to an Etsy listing', 400);
+        }
+
+        const accessToken = await this.etsyConnectionService.getValidAccessToken(userId);
+        const status = await this.etsyClient.getListing(accessToken, design.etsy.listingId);
+
+        const updated: Design = { ...design, etsy: { ...design.etsy, state: status.state } };
+        await this.designRepo.update(designId, updated);
+
+        return updated;
+    }
+
+    async listShopListings(userId: string): Promise<EtsyListingWithLinkStatus[]> {
+        const shopId = await this.etsyConnectionService.getShopId(userId);
+        const [listings, designs] = await Promise.all([
+            this.etsyClient.getShopListingsActive(shopId),
+            this.designRepo.getByUserId(userId),
+        ]);
+
+        const designIdByListingId = new Map(
+            designs.filter((d): d is Design & { etsy: NonNullable<Design['etsy']> } => !!d.etsy?.listingId).map((d) => [d.etsy.listingId, d.id])
+        );
+
+        return listings.map((listing) => ({
+            ...listing,
+            linkedDesignId: designIdByListingId.get(listing.listingId) ?? null,
+        }));
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bun test src/domain/EtsyStatusService/index.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Run the full api test suite**
+
+Run: `cd packages/api && bun test`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/domain/EtsyStatusService/index.ts packages/api/src/domain/EtsyStatusService/index.test.ts
+git commit -m "feat(api): add EtsyStatusService for status refresh and shop listing browse"
+```
+
+---
+
+### Task 5: API — handlers, routes, DI wiring
+
+**Files:**
+- Modify: `packages/api/src/handlers/Etsy/index.ts`
+- Modify: `packages/api/src/dependencies/types.ts`
+- Modify: `packages/api/src/dependencies/index.ts`
+- Modify: `packages/api/src/routes/index.ts`
+
+**Interfaces:**
+- Consumes: `EtsyStatusService.refreshStatus`/`.listShopListings` (Task 4).
+- Produces: `GET /api/designs/:id/etsy-status` (returns the updated `Design`), `GET /api/etsy/listings` (returns `EtsyListingWithLinkStatus[]`) — consumed by web (Task 6). No new tests — this repo's existing `handlers/Etsy/index.ts` has no dedicated test file (matches `handlers/EtsyConnection`/`handlers/EtsyPush` — thin wrappers, exercised via the domain-service tests already written and, eventually, E2E); this task is verified by typecheck + the full test suite staying green.
+
+- [ ] **Step 1: Add handlers**
+
+In `packages/api/src/handlers/Etsy/index.ts`, add the import:
+
+```typescript
+import type { EtsyStatusService } from '../../domain/EtsyStatusService';
+```
+
+Add at the end of the file, after `getEtsyTaxonomy`:
+
+```typescript
+const getStatusService = (): EtsyStatusService => dependencyContainer.resolve(DependencyToken.EtsyStatusService);
+
+export const refreshDesignEtsyStatus = async (c: AuthedCtx) => {
+    const design = await getStatusService().refreshStatus(c.req.param('id'), c.get('userId'));
+    return c.json(design, 200);
+};
+
+export const getEtsyShopListings = async (c: AuthedCtx) => {
+    const listings = await getStatusService().listShopListings(c.get('userId'));
+    return c.json(listings, 200);
+};
+```
+
+- [ ] **Step 2: Add the DI token**
+
+In `packages/api/src/dependencies/types.ts`, add the import:
+
+```typescript
+import type { EtsyStatusService } from '../domain/EtsyStatusService';
+```
+
+Add the token to the `DependencyToken` enum, in the `// Services` group, after `EtsyPushService = 'EtsyPushService',`:
+
+```typescript
+    EtsyStatusService = 'EtsyStatusService',
+```
+
+Add the type to the `Dependencies` type, in the same group, after `[DependencyToken.EtsyPushService]: EtsyPushService;`:
+
+```typescript
+    [DependencyToken.EtsyStatusService]: EtsyStatusService;
+```
+
+- [ ] **Step 3: Register the dependency**
+
+In `packages/api/src/dependencies/index.ts`, add the import:
+
+```typescript
+import { EtsyStatusService } from '../domain/EtsyStatusService';
+```
+
+Add the registration after the `EtsyPushService` registration block:
+
+```typescript
+    dependencyContainer.registerSingleton(
+        DependencyToken.EtsyStatusService,
+        class {
+            constructor() {
+                return new EtsyStatusService(
+                    dependencyContainer.resolve(DependencyToken.DesignRepository),
+                    dependencyContainer.resolve(DependencyToken.EtsyClient),
+                    dependencyContainer.resolve(DependencyToken.EtsyConnectionService)
+                );
+            }
+        } as any
+    );
+```
+
+- [ ] **Step 4: Add the routes**
+
+In `packages/api/src/routes/index.ts`, update the `handlers/Etsy` import to include the two new handlers:
+
+```typescript
+import {
+    disconnectEtsyConnection,
+    etsyOAuthCallback,
+    getEtsyConnectionStatus,
+    getEtsyShopListings,
+    getEtsyTaxonomy,
+    pushDesignToEtsy,
+    refreshDesignEtsyStatus,
+    startEtsyOAuth,
+} from '../handlers/Etsy';
+```
+
+Add the two routes after the existing `/api/etsy/taxonomy` route:
+
+```typescript
+    app.get('/api/etsy/taxonomy', authenticate, getEtsyTaxonomy);
+    app.get('/api/etsy/listings', authenticate, getEtsyShopListings);
+    app.get('/api/designs/:id/etsy-status', authenticate, refreshDesignEtsyStatus);
+```
+
+- [ ] **Step 5: Typecheck and run the full api test suite**
+
+Run: `cd packages/api && bunx tsc --noEmit`
+Expected: no errors
+
+Run: `cd packages/api && bun test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/handlers/Etsy/index.ts packages/api/src/dependencies/types.ts packages/api/src/dependencies/index.ts packages/api/src/routes/index.ts
+git commit -m "feat(api): wire etsy-status and etsy-listings routes"
+```
+
+---
+
+### Task 6: Web — API client endpoints + hooks
+
+**Files:**
+- Modify: `packages/web/src/api/endpoints.ts`
+- Create: `packages/web/src/api/endpoints/etsyStatus/index.ts`
+- Create: `packages/web/src/api/endpoints/etsyListings/index.ts`
+- Create: `packages/web/src/hooks/useEtsyStatus.ts`
+- Create: `packages/web/src/hooks/useEtsyListings.ts`
+
+**Interfaces:**
+- Consumes: `GET /api/designs/:id/etsy-status`, `GET /api/etsy/listings` (Task 5).
+- Produces: `useEtsyStatus(designId: string, enabled: boolean): void` (fires once, writes the refreshed `Design` into the `['design', designId]` query cache), `useEtsyListings(): { listings: EtsyListingWithLinkStatus[]; isLoading: boolean; isError: boolean }` — consumed by `ViewDesign` (Task 7) and `Listings` (Task 8).
+
+- [ ] **Step 1: Add endpoint constants**
+
+In `packages/web/src/api/endpoints.ts`, add after `ETSY_TAXONOMY_ENDPOINT`:
+
+```typescript
+export const ETSY_LISTINGS_ENDPOINT = '/api/etsy/listings';
+
+export const getEtsyStatusEndpoint = (designId: string) => `${DESIGNS_ENDPOINT}/${designId}/etsy-status`;
+```
+
+- [ ] **Step 2: Add the status-refresh endpoint client**
+
+```typescript
+// packages/web/src/api/endpoints/etsyStatus/index.ts
+import { type Design, MethodType } from '@jewellery-catalogue/types';
+
+import { getEtsyStatusEndpoint } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export const makeRefreshEtsyStatusRequest = (
+    designId: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<Design>(
+        {
+            pathname: getEtsyStatusEndpoint(designId),
+            method: MethodType.GET,
+            operationString: 'refresh etsy status',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+- [ ] **Step 3: Add the shop-listings endpoint client**
+
+```typescript
+// packages/web/src/api/endpoints/etsyListings/index.ts
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { ETSY_LISTINGS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export interface EtsyListingWithLinkStatus {
+    listingId: number;
+    title: string;
+    price: number;
+    url: string;
+    linkedDesignId: string | null;
+}
+
+export const makeGetEtsyListingsRequest = (
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<EtsyListingWithLinkStatus[]>(
+        {
+            pathname: ETSY_LISTINGS_ENDPOINT,
+            method: MethodType.GET,
+            operationString: 'fetch etsy shop listings',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );
+```
+
+- [ ] **Step 4: Add `useEtsyStatus`**
+
+```typescript
+// packages/web/src/hooks/useEtsyStatus.ts
+import { useAuth } from '@imapps/web-utils';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { makeRefreshEtsyStatusRequest } from '../api/endpoints/etsyStatus';
+
+export const useEtsyStatus = (designId: string, enabled: boolean) => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    useQuery({
+        queryKey: ['etsy-status', designId],
+        queryFn: async () => {
+            const design = await makeRefreshEtsyStatusRequest(designId, () => accessToken, login, logout);
+            queryClient.setQueryData(['design', designId], design);
+            return design;
+        },
+        enabled: enabled && !!accessToken && !!designId,
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+};
+```
+
+- [ ] **Step 5: Add `useEtsyListings`**
+
+```typescript
+// packages/web/src/hooks/useEtsyListings.ts
+import { useAuth } from '@imapps/web-utils';
+import { useQuery } from '@tanstack/react-query';
+
+import { makeGetEtsyListingsRequest } from '../api/endpoints/etsyListings';
+
+export const useEtsyListings = () => {
+    const { accessToken, login, logout } = useAuth();
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['etsy-listings'],
+        queryFn: () => makeGetEtsyListingsRequest(() => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    return {
+        listings: data ?? [],
+        isLoading,
+        isError,
+    };
+};
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bunx tsc --build --force` (from repo root)
+Expected: no NEW errors versus the pre-existing baseline (see Global Constraints)
+
+Run: `git clean -fd -- packages/` (from repo root, to remove generated build artifacts)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/api/endpoints.ts packages/web/src/api/endpoints/etsyStatus packages/web/src/api/endpoints/etsyListings packages/web/src/hooks/useEtsyStatus.ts packages/web/src/hooks/useEtsyListings.ts
+git commit -m "feat(web): add etsy status/listings API clients and hooks"
+```
+
+---
+
+### Task 7: Web — `ViewDesign` status-refresh wiring
+
+**Files:**
+- Modify: `packages/web/src/pages/ViewDesign/index.tsx`
+
+**Interfaces:**
+- Consumes: `useEtsyStatus` (Task 6).
+- Produces: nothing new (behavioral change only) — this is the last task that touches `ViewDesign`.
+
+- [ ] **Step 1: Wire the hook**
+
+In `packages/web/src/pages/ViewDesign/index.tsx`, add the import after the existing `useEtsyConnection` import:
+
+```typescript
+import { useEtsyStatus } from '../../hooks/useEtsyStatus';
+```
+
+In the component body, after the existing `useQuery` call for `design` (right after the `const { ... } = design ?? {};` destructure), add:
+
+```typescript
+    useEtsyStatus(id ?? '', !!id && !!etsy?.listingId);
+```
+
+This fires the `GET /api/designs/:id/etsy-status` call once, only when the design is already linked to Etsy (`etsy?.listingId` present) — matching the spec's "Viewing a linked design triggers a lightweight `GET /listings/{id}`... No background polling in v1." The hook writes the refreshed design straight into the `['design', id]` query cache (Task 6), so the existing Etsy chip (`{etsy.state === 'active' ? 'Active' : 'Draft'} on Etsy`, already rendered lower in this file) picks up the new state on the next render with no other change needed.
+
+- [ ] **Step 2: Manual verification**
+
+Run: `bun run dev` (or the project's existing dev-server command) and open a design that already has `etsy.listingId` set (or push a design to Etsy first via sub-project 3's flow, then revisit its page).
+Expected: a network request to `GET /api/designs/:id/etsy-status` fires once on page load in the browser devtools Network tab, and does not repeat while the page stays open (no polling).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bunx tsc --build --force` (from repo root)
+Expected: no NEW errors versus baseline
+
+Run: `git clean -fd -- packages/` (from repo root)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/pages/ViewDesign/index.tsx
+git commit -m "feat(web): refresh etsy status once when viewing a linked design"
+```
+
+---
+
+### Task 8: Web — `Listings` page + route + sidebar nav
+
+**Files:**
+- Modify: `packages/web/src/constants/routes.ts`
+- Modify: `packages/web/src/components/AppSidebar/index.tsx`
+- Modify: `packages/web/src/index.tsx`
+- Create: `packages/web/src/pages/Listings/index.tsx`
+
+**Interfaces:**
+- Consumes: `useEtsyListings` (Task 6), `useEtsyConnection` (existing).
+- Produces: the `/listings` page, reachable from the sidebar — final task in this plan.
+
+- [ ] **Step 1: Add the route constant**
+
+In `packages/web/src/constants/routes.ts`, add after `SETTINGS_PAGE`:
+
+```typescript
+export const LISTINGS_PAGE: NavRoute = {
+    name: 'Listings',
+    route: '/listings',
+};
+```
+
+Update the `ROUTES` array (used by the sidebar) to include it:
+
+```typescript
+export const ROUTES = [HOME_PAGE, DESIGNS_PAGE, LISTINGS_PAGE, ADD_DESIGN_PAGE, MATERIALS_PAGE, ADD_MATERIAL_PAGE];
+```
+
+- [ ] **Step 2: Add the sidebar icon**
+
+In `packages/web/src/components/AppSidebar/index.tsx`, add `ShoppingBag` to the `lucide-react` import:
+
+```typescript
+import { Gem, Home, Palette, Plus, PlusCircle, ShoppingBag } from 'lucide-react';
+```
+
+Add the mapping entry to `routeIcons`:
+
+```typescript
+const routeIcons = {
+    '/home': Home,
+    '/designs': Palette,
+    '/listings': ShoppingBag,
+    '/addDesign': Plus,
+    '/materials': Gem,
+    '/addMaterial': PlusCircle,
+};
+```
+
+- [ ] **Step 3: Build the `Listings` page**
+
+```tsx
+// packages/web/src/pages/Listings/index.tsx
+import { ExternalLink, ShoppingBag } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import LoadingScreen from '../../components/Loading';
+import { Badge } from '../../components/ui/badge';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
+import { SETTINGS_PAGE, VIEW_DESIGN_PAGE } from '../../constants/routes';
+import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import { useEtsyListings } from '../../hooks/useEtsyListings';
+
+const Listings = () => {
+    const { connected: etsyConnected, isLoading: isConnectionLoading } = useEtsyConnection();
+    const { listings, isLoading, isError } = useEtsyListings();
+
+    if (isConnectionLoading) {
+        return <LoadingScreen />;
+    }
+
+    if (!etsyConnected) {
+        return (
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                        <ShoppingBag />
+                    </EmptyMedia>
+                    <EmptyTitle>Etsy Not Connected</EmptyTitle>
+                    <EmptyDescription>
+                        <Link to={SETTINGS_PAGE.route} className="text-primary hover:underline">
+                            Connect your Etsy shop
+                        </Link>{' '}
+                        to see your active listings here.
+                    </EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+        );
+    }
+
+    if (isLoading) {
+        return <LoadingScreen />;
+    }
+
+    if (isError) {
+        return <span>Something went wrong! :(</span>;
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <h1 className="text-2xl font-semibold">Etsy Listings</h1>
+                <p className="text-sm text-muted-foreground">
+                    {listings.length} active listing{listings.length === 1 ? '' : 's'} on Etsy. Only active listings are
+                    shown here — drafts sitting on Etsy outside this app aren't included.
+                </p>
+            </div>
+
+            {listings.length === 0 ? (
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <ShoppingBag />
+                        </EmptyMedia>
+                        <EmptyTitle>No Active Listings</EmptyTitle>
+                        <EmptyDescription>Your shop has no active Etsy listings right now.</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            ) : (
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Title</TableHead>
+                            <TableHead>Price</TableHead>
+                            <TableHead>Linked Design</TableHead>
+                            <TableHead>Etsy</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {listings.map((listing) => (
+                            <TableRow key={listing.listingId}>
+                                <TableCell className="font-medium">{listing.title}</TableCell>
+                                <TableCell>£{listing.price.toFixed(2)}</TableCell>
+                                <TableCell>
+                                    {listing.linkedDesignId ? (
+                                        <Link
+                                            to={VIEW_DESIGN_PAGE.getRoute(listing.linkedDesignId)}
+                                            className="text-primary hover:underline"
+                                        >
+                                            View design
+                                        </Link>
+                                    ) : (
+                                        <Badge variant="secondary">Not linked</Badge>
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    <a
+                                        href={listing.url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                                    >
+                                        View <ExternalLink className="h-3 w-3" />
+                                    </a>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
+        </div>
+    );
+};
+
+export default Listings;
+```
+
+- [ ] **Step 4: Wire the route**
+
+In `packages/web/src/index.tsx`, add `LISTINGS_PAGE` to the routes import:
+
+```typescript
+import {
+    ADD_DESIGN_PAGE,
+    ADD_MATERIAL_PAGE,
+    DESIGNS_PAGE,
+    HOME_PAGE,
+    LISTINGS_PAGE,
+    MATERIALS_PAGE,
+    REGISTER_PAGE,
+    SETTINGS_PAGE,
+    START_PAGE,
+    VIEW_DESIGN_PAGE,
+} from './constants/routes';
+```
+
+Add the `Listings` page import after `Home`:
+
+```typescript
+import Listings from './pages/Listings';
+```
+
+Add the route inside `<Routes>`, after the `DESIGNS_PAGE` route:
+
+```tsx
+            <Route
+                path={LISTINGS_PAGE.route}
+                element={
+                    <ProtectedRoute fallbackPath={START_PAGE.route}>
+                        <MainLayout>
+                            <Listings />
+                        </MainLayout>
+                    </ProtectedRoute>
+                }
+            />
+```
+
+- [ ] **Step 5: Manual verification**
+
+Run: `bun run dev` (or the project's existing dev-server command), sign in, and navigate to the new "Listings" sidebar entry.
+Expected: with Etsy not connected, an empty state pointing to Settings; with Etsy connected, a table of active shop listings, correctly flagging which ones link to catalogue designs via "View design", and an "Etsy" column linking out to the live listing.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bunx tsc --build --force` (from repo root)
+Expected: no NEW errors versus baseline
+
+Run: `git clean -fd -- packages/` (from repo root)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/src/constants/routes.ts packages/web/src/components/AppSidebar/index.tsx packages/web/src/index.tsx packages/web/src/pages/Listings
+git commit -m "feat(web): add Etsy Listings page"
+```

--- a/docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md
+++ b/docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md
@@ -108,7 +108,7 @@ Existing pages: Home, Designs, AddDesign, ViewDesign, Materials, AddMaterial, St
 | Designs list | Etsy indicator per row when linked |
 | Nav | No new items. Settings gear routes to the page instead of opening the dialog |
 
-No listings screen (one-time script covers linking); orders page is future work.
+~~No listings screen (one-time script covers linking); orders page is future work.~~ **Superseded 2026-07-18:** a `/listings` page was added to sub-project 4 (see decision log). Orders page is still future work.
 
 ## Error handling
 
@@ -138,6 +138,7 @@ No listings screen (one-time script covers linking); orders page is future work.
 | Link-back | Store listingId + state on design | Enables status chip, future sync |
 | Existing 102 listings | Link-only one-time script (5 designs) | Manual linking simpler at this scale; rest stay Etsy-only |
 | Publish step | Always in Etsy Shop Manager | The human double-check Mari wants |
+| Listings screen (amended 2026-07-18) | Added to sub-project 4 | Supersedes the original "no listings screen" call below — Mari wants to browse all active Etsy listings from the app, not just catalogue-linked ones. See `docs/superpowers/plans/2026-07-19-etsy-status-and-listings.md` |
 
 ## Open items
 

--- a/packages/api/src/dependencies/index.test.ts
+++ b/packages/api/src/dependencies/index.test.ts
@@ -72,11 +72,11 @@ describe('Dependencies', () => {
             expect(container.constructors?.[DependencyToken.DesignService]).toBeDefined();
         });
 
-        it('should register exactly 19 dependencies', () => {
+        it('should register exactly 20 dependencies', () => {
             registerDepdendencies();
             const container = dependencyContainer as any;
             const registeredCount = Object.keys(container.constructors || {}).length;
-            expect(registeredCount).toBe(19);
+            expect(registeredCount).toBe(20);
         });
 
         it('should register all expected tokens', () => {

--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -8,6 +8,7 @@ import { EtsyClient } from '../domain/EtsyClient';
 import { EtsyConnectionService } from '../domain/EtsyConnectionService';
 import { EtsyOAuthStateStore } from '../domain/EtsyOAuthStateStore';
 import { EtsyPushService } from '../domain/EtsyPushService';
+import { EtsyStatusService } from '../domain/EtsyStatusService';
 import { ImageService } from '../domain/ImageService';
 import { MaterialService } from '../domain/MaterialService';
 import { UserSettingsService } from '../domain/UserSettingsService';
@@ -194,6 +195,19 @@ export const registerDepdendencies = () => {
                     dependencyContainer.resolve(DependencyToken.EtsyClient),
                     dependencyContainer.resolve(DependencyToken.EtsyConnectionService),
                     dependencyContainer.resolve(DependencyToken.UserSettingsService)
+                );
+            }
+        } as any
+    );
+
+    dependencyContainer.registerSingleton(
+        DependencyToken.EtsyStatusService,
+        class {
+            constructor() {
+                return new EtsyStatusService(
+                    dependencyContainer.resolve(DependencyToken.DesignRepository),
+                    dependencyContainer.resolve(DependencyToken.EtsyClient),
+                    dependencyContainer.resolve(DependencyToken.EtsyConnectionService)
                 );
             }
         } as any

--- a/packages/api/src/dependencies/types.ts
+++ b/packages/api/src/dependencies/types.ts
@@ -10,6 +10,7 @@ import type { EtsyConnectionRepository } from '../domain/EtsyConnectionRepositor
 import type { EtsyConnectionService } from '../domain/EtsyConnectionService';
 import type { EtsyOAuthStateStore } from '../domain/EtsyOAuthStateStore';
 import type { EtsyPushService } from '../domain/EtsyPushService';
+import type { EtsyStatusService } from '../domain/EtsyStatusService';
 import type { IdGenerator } from '../domain/IdGenerator';
 import type { ImageService } from '../domain/ImageService';
 import type { ImageStore } from '../domain/ImageService/types';
@@ -45,6 +46,7 @@ export enum DependencyToken {
     UserSettingsService = 'UserSettingsService',
     EtsyConnectionService = 'EtsyConnectionService',
     EtsyPushService = 'EtsyPushService',
+    EtsyStatusService = 'EtsyStatusService',
     // Infrastructure
     IdGenerator = 'IdGenerator',
     ImageStore = 'ImageStore',
@@ -71,6 +73,7 @@ export type Dependencies = {
     [DependencyToken.UserSettingsService]: UserSettingsService;
     [DependencyToken.EtsyConnectionService]: EtsyConnectionService;
     [DependencyToken.EtsyPushService]: EtsyPushService;
+    [DependencyToken.EtsyStatusService]: EtsyStatusService;
     // Infrastructure
     [DependencyToken.IdGenerator]: IdGenerator;
     [DependencyToken.ImageStore]: ImageStore;

--- a/packages/api/src/domain/EtsyClient/index.test.ts
+++ b/packages/api/src/domain/EtsyClient/index.test.ts
@@ -307,4 +307,46 @@ describe('EtsyClient', () => {
             expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
         });
     });
+
+    describe('getListing', () => {
+        it('fetches the listing and maps a draft state through unchanged', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(JSON.stringify({ listing_id: 999, state: 'draft' }), { status: 200 })
+            );
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'draft' });
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/listings/999');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+        });
+
+        it('maps an active state through unchanged', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(JSON.stringify({ listing_id: 999, state: 'active' }), { status: 200 })
+            );
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'active' });
+        });
+
+        it.each(['inactive', 'sold_out', 'expired'])('maps Etsy state "%s" down to "inactive"', async (etsyState) => {
+            fetchMock.mockResolvedValue(
+                new Response(JSON.stringify({ listing_id: 999, state: etsyState }), { status: 200 })
+            );
+
+            const result = await client.getListing('at-token', 999);
+
+            expect(result).toEqual({ listingId: 999, state: 'inactive' });
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 404 }));
+
+            await expect(client.getListing('at', 1)).rejects.toThrow();
+        });
+    });
 });

--- a/packages/api/src/domain/EtsyClient/index.test.ts
+++ b/packages/api/src/domain/EtsyClient/index.test.ts
@@ -349,4 +349,78 @@ describe('EtsyClient', () => {
             await expect(client.getListing('at', 1)).rejects.toThrow();
         });
     });
+
+    describe('getShopListingsActive', () => {
+        it('fetches a single page when count fits within the page limit', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        count: 2,
+                        results: [
+                            {
+                                listing_id: 1,
+                                title: 'Silver Ring',
+                                price: { amount: 2550, divisor: 100, currency_code: 'GBP' },
+                                url: 'https://etsy.com/listing/1',
+                            },
+                            {
+                                listing_id: 2,
+                                title: 'Gold Ring',
+                                price: { amount: 4000, divisor: 100, currency_code: 'GBP' },
+                                url: 'https://etsy.com/listing/2',
+                            },
+                        ],
+                    }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getShopListingsActive(47408839);
+
+            expect(result).toEqual([
+                { listingId: 1, title: 'Silver Ring', price: 25.5, url: 'https://etsy.com/listing/1' },
+                { listingId: 2, title: 'Gold Ring', price: 40, url: 'https://etsy.com/listing/2' },
+            ]);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+        });
+
+        it('paginates when count exceeds the 100-item page limit', async () => {
+            const page = (start: number, count: number, total: number) => ({
+                count: total,
+                results: Array.from({ length: count }, (_, i) => ({
+                    listing_id: start + i,
+                    title: `Listing ${start + i}`,
+                    price: { amount: 1000, divisor: 100, currency_code: 'GBP' },
+                    url: `https://etsy.com/listing/${start + i}`,
+                })),
+            });
+
+            fetchMock
+                .mockResolvedValueOnce(new Response(JSON.stringify(page(1, 100, 102)), { status: 200 }))
+                .mockResolvedValueOnce(new Response(JSON.stringify(page(101, 2, 102)), { status: 200 }));
+
+            const result = await client.getShopListingsActive(47408839);
+
+            expect(result).toHaveLength(102);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            const [firstUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [secondUrl] = fetchMock.mock.calls[1] as [string, RequestInit];
+            expect(firstUrl).toBe(
+                'https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0'
+            );
+            expect(secondUrl).toBe(
+                'https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=100'
+            );
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
+
+            await expect(client.getShopListingsActive(1)).rejects.toThrow();
+        });
+    });
 });

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
+import type { EtsyListingState } from '@jewellery-catalogue/types';
 
 const AUTHORIZE_URL = 'https://www.etsy.com/oauth/connect';
 const TOKEN_URL = 'https://api.etsy.com/v3/public/oauth/token';
@@ -34,6 +35,14 @@ export interface EtsyTaxonomyNode {
     name: string;
     children: EtsyTaxonomyNode[];
 }
+
+export interface EtsyListingStatus {
+    listingId: number;
+    state: EtsyListingState;
+}
+
+const mapListingState = (state: string): EtsyListingState =>
+    state === 'draft' || state === 'active' ? state : 'inactive';
 
 const base64UrlEncode = (input: Buffer): string =>
     input.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
@@ -139,6 +148,19 @@ export class EtsyClient {
 
         const body = (await response.json()) as { shop_id: number; shop_name: string };
         return { shopId: body.shop_id, shopName: body.shop_name };
+    }
+
+    async getListing(accessToken: string, listingId: number): Promise<EtsyListingStatus> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Etsy getListing failed: ${response.status} ${await response.text()}`);
+        }
+
+        const body = (await response.json()) as { listing_id: number; state: string };
+        return { listingId: body.listing_id, state: mapListingState(body.state) };
     }
 
     async createDraftListing(

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -4,6 +4,7 @@ import type { EtsyListingState } from '@jewellery-catalogue/types';
 const AUTHORIZE_URL = 'https://www.etsy.com/oauth/connect';
 const TOKEN_URL = 'https://api.etsy.com/v3/public/oauth/token';
 const API_BASE = 'https://api.etsy.com/v3/application';
+const SHOP_LISTINGS_PAGE_LIMIT = 100;
 
 export interface EtsyTokenResponse {
     accessToken: string;
@@ -39,6 +40,13 @@ export interface EtsyTaxonomyNode {
 export interface EtsyListingStatus {
     listingId: number;
     state: EtsyListingState;
+}
+
+export interface EtsyListingSummary {
+    listingId: number;
+    title: string;
+    price: number;
+    url: string;
 }
 
 const mapListingState = (state: string): EtsyListingState =>
@@ -161,6 +169,46 @@ export class EtsyClient {
 
         const body = (await response.json()) as { listing_id: number; state: string };
         return { listingId: body.listing_id, state: mapListingState(body.state) };
+    }
+
+    async getShopListingsActive(shopId: number): Promise<EtsyListingSummary[]> {
+        const results: EtsyListingSummary[] = [];
+        let offset = 0;
+
+        for (;;) {
+            const response = await fetch(
+                `${API_BASE}/shops/${shopId}/listings/active?limit=${SHOP_LISTINGS_PAGE_LIMIT}&offset=${offset}`,
+                { headers: { 'x-api-key': this.apiKeyHeader() } }
+            );
+
+            if (!response.ok) {
+                throw new Error(`Etsy getShopListingsActive failed: ${response.status} ${await response.text()}`);
+            }
+
+            const body = (await response.json()) as {
+                count: number;
+                results: Array<{
+                    listing_id: number;
+                    title: string;
+                    price: { amount: number; divisor: number };
+                    url: string;
+                }>;
+            };
+
+            results.push(
+                ...body.results.map((r) => ({
+                    listingId: r.listing_id,
+                    title: r.title,
+                    price: r.price.amount / r.price.divisor,
+                    url: r.url,
+                }))
+            );
+
+            offset += SHOP_LISTINGS_PAGE_LIMIT;
+            if (offset >= body.count || body.results.length < SHOP_LISTINGS_PAGE_LIMIT) break;
+        }
+
+        return results;
     }
 
     async createDraftListing(

--- a/packages/api/src/domain/EtsyConnectionService/index.test.ts
+++ b/packages/api/src/domain/EtsyConnectionService/index.test.ts
@@ -224,4 +224,21 @@ describe('EtsyConnectionService', () => {
             await expect(service.getPushCredentials('user-1')).rejects.toThrow();
         });
     });
+
+    describe('getShopId', () => {
+        it('returns the stored shopId without touching token refresh', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(makeConnection({ shopId: 47408839 }));
+
+            const result = await service.getShopId('user-1');
+
+            expect(result).toBe(47408839);
+            expect(mockEtsyClient.refreshAccessToken).not.toHaveBeenCalled();
+        });
+
+        it('throws when there is no connection', async () => {
+            mockConnectionRepo.getByUserId.mockResolvedValue(null);
+
+            await expect(service.getShopId('user-1')).rejects.toThrow();
+        });
+    });
 });

--- a/packages/api/src/domain/EtsyConnectionService/index.ts
+++ b/packages/api/src/domain/EtsyConnectionService/index.ts
@@ -109,4 +109,12 @@ export class EtsyConnectionService {
         }
         return { accessToken, shopId: connection.shopId };
     }
+
+    async getShopId(userId: string): Promise<number> {
+        const connection = await this.connectionRepo.getByUserId(userId);
+        if (!connection) {
+            throw new APIError('Etsy is not connected', 400);
+        }
+        return connection.shopId;
+    }
 }

--- a/packages/api/src/domain/EtsyStatusService/index.test.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.test.ts
@@ -65,6 +65,19 @@ describe('EtsyStatusService', () => {
             expect(mockDesignRepo.update).toHaveBeenCalledWith('design-1', result);
         });
 
+        it('does not persist and returns the original design when the fetched state is unchanged', async () => {
+            const design = makeDesign({
+                etsy: { listingId: 999, state: 'active', lastPushedAt: 123, pushIncomplete: false },
+            });
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(design);
+            mockEtsyClient.getListing.mockResolvedValue({ listingId: 999, state: 'active' });
+
+            const result = await service.refreshStatus('design-1', 'user-1');
+
+            expect(mockDesignRepo.update).not.toHaveBeenCalled();
+            expect(result).toEqual(design);
+        });
+
         it('throws when the design does not exist', async () => {
             mockDesignRepo.getByIdAndUserId.mockResolvedValue(null);
 

--- a/packages/api/src/domain/EtsyStatusService/index.test.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+import { EtsyStatusService } from './index';
+
+const mockDesignRepo = { getByIdAndUserId: mock(), getByUserId: mock(), update: mock() };
+const mockEtsyClient = { getListing: mock(), getShopListingsActive: mock() };
+const mockEtsyConnectionService = { getValidAccessToken: mock(), getShopId: mock() };
+
+function makeDesign(overrides: Partial<Design> = {}): Design {
+    return {
+        id: 'design-1',
+        userId: 'user-1',
+        name: 'Silver Ring',
+        description: 'A lovely ring.',
+        timeRequired: '01:00',
+        materials: [],
+        imageIds: [],
+        diagramImageIds: [],
+        makingNotes: '',
+        price: 25,
+        totalMaterialCosts: 10,
+        dateAdded: new Date(),
+        totalQuantity: 2,
+        ...overrides,
+    };
+}
+
+describe('EtsyStatusService', () => {
+    let service: EtsyStatusService;
+
+    beforeEach(() => {
+        for (const m of [
+            ...Object.values(mockDesignRepo),
+            ...Object.values(mockEtsyClient),
+            ...Object.values(mockEtsyConnectionService),
+        ]) {
+            m.mockClear();
+        }
+
+        service = new EtsyStatusService(
+            mockDesignRepo as unknown as DesignRepository,
+            mockEtsyClient as unknown as EtsyClient,
+            mockEtsyConnectionService as unknown as EtsyConnectionService
+        );
+
+        mockEtsyConnectionService.getValidAccessToken.mockResolvedValue('at-token');
+        mockEtsyConnectionService.getShopId.mockResolvedValue(47408839);
+    });
+
+    describe('refreshStatus', () => {
+        it('fetches the live state and persists it onto the design, preserving other etsy fields', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(
+                makeDesign({ etsy: { listingId: 999, state: 'draft', lastPushedAt: 123, pushIncomplete: false } })
+            );
+            mockEtsyClient.getListing.mockResolvedValue({ listingId: 999, state: 'active' });
+
+            const result = await service.refreshStatus('design-1', 'user-1');
+
+            expect(mockEtsyClient.getListing).toHaveBeenCalledWith('at-token', 999);
+            expect(result.etsy).toEqual({ listingId: 999, state: 'active', lastPushedAt: 123, pushIncomplete: false });
+            expect(mockDesignRepo.update).toHaveBeenCalledWith('design-1', result);
+        });
+
+        it('throws when the design does not exist', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(null);
+
+            await expect(service.refreshStatus('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.getListing).not.toHaveBeenCalled();
+        });
+
+        it('throws when the design is not linked to an Etsy listing', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+
+            await expect(service.refreshStatus('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.getListing).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listShopListings', () => {
+        it("flags listings already linked to one of this user's designs", async () => {
+            mockDesignRepo.getByUserId.mockResolvedValue([
+                makeDesign({ id: 'design-1', etsy: { listingId: 1, state: 'active', lastPushedAt: 1 } }),
+                makeDesign({ id: 'design-2' }),
+            ]);
+            mockEtsyClient.getShopListingsActive.mockResolvedValue([
+                { listingId: 1, title: 'Linked Listing', price: 25, url: 'https://etsy.com/listing/1' },
+                { listingId: 2, title: 'Unlinked Listing', price: 30, url: 'https://etsy.com/listing/2' },
+            ]);
+
+            const result = await service.listShopListings('user-1');
+
+            expect(mockEtsyConnectionService.getShopId).toHaveBeenCalledWith('user-1');
+            expect(mockEtsyClient.getShopListingsActive).toHaveBeenCalledWith(47408839);
+            expect(result).toEqual([
+                {
+                    listingId: 1,
+                    title: 'Linked Listing',
+                    price: 25,
+                    url: 'https://etsy.com/listing/1',
+                    linkedDesignId: 'design-1',
+                },
+                {
+                    listingId: 2,
+                    title: 'Unlinked Listing',
+                    price: 30,
+                    url: 'https://etsy.com/listing/2',
+                    linkedDesignId: null,
+                },
+            ]);
+        });
+
+        it('returns every listing unlinked when the user has no linked designs', async () => {
+            mockDesignRepo.getByUserId.mockResolvedValue([makeDesign()]);
+            mockEtsyClient.getShopListingsActive.mockResolvedValue([
+                { listingId: 5, title: 'Some Listing', price: 10, url: 'https://etsy.com/listing/5' },
+            ]);
+
+            const result = await service.listShopListings('user-1');
+
+            expect(result).toEqual([
+                {
+                    listingId: 5,
+                    title: 'Some Listing',
+                    price: 10,
+                    url: 'https://etsy.com/listing/5',
+                    linkedDesignId: null,
+                },
+            ]);
+        });
+    });
+});

--- a/packages/api/src/domain/EtsyStatusService/index.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.ts
@@ -28,6 +28,10 @@ export class EtsyStatusService {
         const accessToken = await this.etsyConnectionService.getValidAccessToken(userId);
         const status = await this.etsyClient.getListing(accessToken, design.etsy.listingId);
 
+        if (status.state === design.etsy.state) {
+            return design;
+        }
+
         const updated: Design = { ...design, etsy: { ...design.etsy, state: status.state } };
         await this.designRepo.update(designId, updated);
 

--- a/packages/api/src/domain/EtsyStatusService/index.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.ts
@@ -1,0 +1,55 @@
+import { APIError } from '@imapps/api-utils/hono';
+import type { Design } from '@jewellery-catalogue/types';
+
+import type { DesignRepository } from '../DesignRepository';
+import type { EtsyClient, EtsyListingSummary } from '../EtsyClient';
+import type { EtsyConnectionService } from '../EtsyConnectionService';
+
+export interface EtsyListingWithLinkStatus extends EtsyListingSummary {
+    linkedDesignId: string | null;
+}
+
+export class EtsyStatusService {
+    constructor(
+        private readonly designRepo: DesignRepository,
+        private readonly etsyClient: EtsyClient,
+        private readonly etsyConnectionService: EtsyConnectionService
+    ) {}
+
+    async refreshStatus(designId: string, userId: string): Promise<Design> {
+        const design = await this.designRepo.getByIdAndUserId(designId, userId);
+        if (!design) {
+            throw new APIError('Design not found', 404);
+        }
+        if (!design.etsy?.listingId) {
+            throw new APIError('Design is not linked to an Etsy listing', 400);
+        }
+
+        const accessToken = await this.etsyConnectionService.getValidAccessToken(userId);
+        const status = await this.etsyClient.getListing(accessToken, design.etsy.listingId);
+
+        const updated: Design = { ...design, etsy: { ...design.etsy, state: status.state } };
+        await this.designRepo.update(designId, updated);
+
+        return updated;
+    }
+
+    async listShopListings(userId: string): Promise<EtsyListingWithLinkStatus[]> {
+        const shopId = await this.etsyConnectionService.getShopId(userId);
+        const [listings, designs] = await Promise.all([
+            this.etsyClient.getShopListingsActive(shopId),
+            this.designRepo.getByUserId(userId),
+        ]);
+
+        const designIdByListingId = new Map(
+            designs
+                .filter((d): d is Design & { etsy: NonNullable<Design['etsy']> } => !!d.etsy?.listingId)
+                .map((d) => [d.etsy.listingId, d.id])
+        );
+
+        return listings.map((listing) => ({
+            ...listing,
+            linkedDesignId: designIdByListingId.get(listing.listingId) ?? null,
+        }));
+    }
+}

--- a/packages/api/src/handlers/Etsy/index.ts
+++ b/packages/api/src/handlers/Etsy/index.ts
@@ -5,6 +5,7 @@ import { dependencyContainer } from '../../dependencies';
 import { DependencyToken } from '../../dependencies/types';
 import type { EtsyConnectionService } from '../../domain/EtsyConnectionService';
 import type { EtsyPushService } from '../../domain/EtsyPushService';
+import type { EtsyStatusService } from '../../domain/EtsyStatusService';
 
 type AuthedCtx = Context<{ Variables: { userId: string } }>;
 
@@ -72,4 +73,16 @@ export const getEtsyTaxonomy = async (c: AuthedCtx) => {
     const client = dependencyContainer.resolve(DependencyToken.EtsyClient);
     const nodes = await client.getSellerTaxonomyNodes();
     return c.json(nodes, 200);
+};
+
+const getStatusService = (): EtsyStatusService => dependencyContainer.resolve(DependencyToken.EtsyStatusService);
+
+export const refreshDesignEtsyStatus = async (c: AuthedCtx) => {
+    const design = await getStatusService().refreshStatus(c.req.param('id'), c.get('userId'));
+    return c.json(design, 200);
+};
+
+export const getEtsyShopListings = async (c: AuthedCtx) => {
+    const listings = await getStatusService().listShopListings(c.get('userId'));
+    return c.json(listings, 200);
 };

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -9,8 +9,10 @@ import {
     disconnectEtsyConnection,
     etsyOAuthCallback,
     getEtsyConnectionStatus,
+    getEtsyShopListings,
     getEtsyTaxonomy,
     pushDesignToEtsy,
+    refreshDesignEtsyStatus,
     startEtsyOAuth,
 } from '../handlers/Etsy';
 import { getImage, uploadImage } from '../handlers/Image';
@@ -47,6 +49,8 @@ export const createRoutes = (): Hono<Env> => {
     app.delete('/api/etsy/connection', authenticate, disconnectEtsyConnection);
     app.post('/api/designs/:id/etsy-push', authenticate, pushDesignToEtsy);
     app.get('/api/etsy/taxonomy', authenticate, getEtsyTaxonomy);
+    app.get('/api/etsy/listings', authenticate, getEtsyShopListings);
+    app.get('/api/designs/:id/etsy-status', authenticate, refreshDesignEtsyStatus);
 
     app.get('/api/designs', authenticate, getDesigns);
     app.post('/api/designs', authenticate, addDesign);

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -7,6 +7,9 @@ export const IMAGES_ENDPOINT = '/api/images';
 export const ETSY_OAUTH_START_ENDPOINT = '/api/etsy/oauth/start';
 export const ETSY_CONNECTION_ENDPOINT = '/api/etsy/connection';
 export const ETSY_TAXONOMY_ENDPOINT = '/api/etsy/taxonomy';
+export const ETSY_LISTINGS_ENDPOINT = '/api/etsy/listings';
 
 export const getMaterialRecalculatePricesEndpoint = (materialId: string) =>
     `${MATERIALS_ENDPOINT}/${materialId}/recalculate-prices`;
+
+export const getEtsyStatusEndpoint = (designId: string) => `${DESIGNS_ENDPOINT}/${designId}/etsy-status`;

--- a/packages/web/src/api/endpoints/etsyListings/index.ts
+++ b/packages/web/src/api/endpoints/etsyListings/index.ts
@@ -1,0 +1,29 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { ETSY_LISTINGS_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export interface EtsyListingWithLinkStatus {
+    listingId: number;
+    title: string;
+    price: number;
+    url: string;
+    linkedDesignId: string | null;
+}
+
+export const makeGetEtsyListingsRequest = (
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<EtsyListingWithLinkStatus[]>(
+        {
+            pathname: ETSY_LISTINGS_ENDPOINT,
+            method: MethodType.GET,
+            operationString: 'fetch etsy shop listings',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );

--- a/packages/web/src/api/endpoints/etsyStatus/index.ts
+++ b/packages/web/src/api/endpoints/etsyStatus/index.ts
@@ -1,0 +1,22 @@
+import { type Design, MethodType } from '@jewellery-catalogue/types';
+
+import { getEtsyStatusEndpoint } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export const makeRefreshEtsyStatusRequest = (
+    designId: string,
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<Design>(
+        {
+            pathname: getEtsyStatusEndpoint(designId),
+            method: MethodType.GET,
+            operationString: 'refresh etsy status',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );

--- a/packages/web/src/components/AppSidebar/index.tsx
+++ b/packages/web/src/components/AppSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { Gem, Home, Palette, Plus, PlusCircle } from 'lucide-react';
+import { Gem, Home, Palette, Plus, PlusCircle, ShoppingBag } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
@@ -21,6 +21,7 @@ import { Header } from './Header';
 const routeIcons = {
     '/home': Home,
     '/designs': Palette,
+    '/listings': ShoppingBag,
     '/addDesign': Plus,
     '/materials': Gem,
     '/addMaterial': PlusCircle,

--- a/packages/web/src/constants/routes.ts
+++ b/packages/web/src/constants/routes.ts
@@ -46,4 +46,9 @@ export const SETTINGS_PAGE: NavRoute = {
     route: '/settings',
 };
 
-export const ROUTES = [HOME_PAGE, DESIGNS_PAGE, ADD_DESIGN_PAGE, MATERIALS_PAGE, ADD_MATERIAL_PAGE];
+export const LISTINGS_PAGE: NavRoute = {
+    name: 'Listings',
+    route: '/listings',
+};
+
+export const ROUTES = [HOME_PAGE, DESIGNS_PAGE, LISTINGS_PAGE, ADD_DESIGN_PAGE, MATERIALS_PAGE, ADD_MATERIAL_PAGE];

--- a/packages/web/src/hooks/useEtsyListings.ts
+++ b/packages/web/src/hooks/useEtsyListings.ts
@@ -1,9 +1,11 @@
 import { useAuth } from '@imapps/web-utils';
 import { useQuery } from '@tanstack/react-query';
 
-import { makeGetEtsyListingsRequest } from '../api/endpoints/etsyListings';
+import { type EtsyListingWithLinkStatus, makeGetEtsyListingsRequest } from '../api/endpoints/etsyListings';
 
-export const useEtsyListings = (enabled: boolean) => {
+export const useEtsyListings = (
+    enabled: boolean
+): { listings: EtsyListingWithLinkStatus[]; isLoading: boolean; isError: boolean } => {
     const { accessToken, login, logout } = useAuth();
 
     const { data, isLoading, isError } = useQuery({

--- a/packages/web/src/hooks/useEtsyListings.ts
+++ b/packages/web/src/hooks/useEtsyListings.ts
@@ -3,13 +3,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { makeGetEtsyListingsRequest } from '../api/endpoints/etsyListings';
 
-export const useEtsyListings = () => {
+export const useEtsyListings = (enabled: boolean) => {
     const { accessToken, login, logout } = useAuth();
 
     const { data, isLoading, isError } = useQuery({
         queryKey: ['etsy-listings'],
         queryFn: () => makeGetEtsyListingsRequest(() => accessToken, login, logout),
-        enabled: !!accessToken,
+        enabled: enabled && !!accessToken,
     });
 
     return {

--- a/packages/web/src/hooks/useEtsyListings.ts
+++ b/packages/web/src/hooks/useEtsyListings.ts
@@ -1,0 +1,20 @@
+import { useAuth } from '@imapps/web-utils';
+import { useQuery } from '@tanstack/react-query';
+
+import { makeGetEtsyListingsRequest } from '../api/endpoints/etsyListings';
+
+export const useEtsyListings = () => {
+    const { accessToken, login, logout } = useAuth();
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['etsy-listings'],
+        queryFn: () => makeGetEtsyListingsRequest(() => accessToken, login, logout),
+        enabled: !!accessToken,
+    });
+
+    return {
+        listings: data ?? [],
+        isLoading,
+        isError,
+    };
+};

--- a/packages/web/src/hooks/useEtsyStatus.ts
+++ b/packages/web/src/hooks/useEtsyStatus.ts
@@ -1,0 +1,20 @@
+import { useAuth } from '@imapps/web-utils';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { makeRefreshEtsyStatusRequest } from '../api/endpoints/etsyStatus';
+
+export const useEtsyStatus = (designId: string, enabled: boolean) => {
+    const { accessToken, login, logout } = useAuth();
+    const queryClient = useQueryClient();
+
+    useQuery({
+        queryKey: ['etsy-status', designId],
+        queryFn: async () => {
+            const design = await makeRefreshEtsyStatusRequest(designId, () => accessToken, login, logout);
+            queryClient.setQueryData(['design', designId], design);
+            return design;
+        },
+        enabled: enabled && !!accessToken && !!designId,
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+};

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -13,6 +13,7 @@ import {
     ADD_MATERIAL_PAGE,
     DESIGNS_PAGE,
     HOME_PAGE,
+    LISTINGS_PAGE,
     MATERIALS_PAGE,
     REGISTER_PAGE,
     SETTINGS_PAGE,
@@ -25,6 +26,7 @@ import AddDesign from './pages/AddDesign';
 import AddMaterial from './pages/AddMaterial';
 import Designs from './pages/Designs';
 import Home from './pages/Home';
+import Listings from './pages/Listings';
 import Materials from './pages/Materials';
 import Register from './pages/Register';
 import Settings from './pages/Settings';
@@ -67,6 +69,17 @@ function App() {
                     <ProtectedRoute fallbackPath={START_PAGE.route}>
                         <MainLayout>
                             <Designs />
+                        </MainLayout>
+                    </ProtectedRoute>
+                }
+            />
+
+            <Route
+                path={LISTINGS_PAGE.route}
+                element={
+                    <ProtectedRoute fallbackPath={START_PAGE.route}>
+                        <MainLayout>
+                            <Listings />
                         </MainLayout>
                     </ProtectedRoute>
                 }

--- a/packages/web/src/pages/Listings/index.tsx
+++ b/packages/web/src/pages/Listings/index.tsx
@@ -11,7 +11,7 @@ import { useEtsyListings } from '../../hooks/useEtsyListings';
 
 const Listings = () => {
     const { connected: etsyConnected, isLoading: isConnectionLoading } = useEtsyConnection();
-    const { listings, isLoading, isError } = useEtsyListings();
+    const { listings, isLoading, isError } = useEtsyListings(etsyConnected);
 
     if (isConnectionLoading) {
         return <LoadingScreen />;

--- a/packages/web/src/pages/Listings/index.tsx
+++ b/packages/web/src/pages/Listings/index.tsx
@@ -1,0 +1,113 @@
+import { ExternalLink, ShoppingBag } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import LoadingScreen from '../../components/Loading';
+import { Badge } from '../../components/ui/badge';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
+import { SETTINGS_PAGE, VIEW_DESIGN_PAGE } from '../../constants/routes';
+import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import { useEtsyListings } from '../../hooks/useEtsyListings';
+
+const Listings = () => {
+    const { connected: etsyConnected, isLoading: isConnectionLoading } = useEtsyConnection();
+    const { listings, isLoading, isError } = useEtsyListings();
+
+    if (isConnectionLoading) {
+        return <LoadingScreen />;
+    }
+
+    if (!etsyConnected) {
+        return (
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                        <ShoppingBag />
+                    </EmptyMedia>
+                    <EmptyTitle>Etsy Not Connected</EmptyTitle>
+                    <EmptyDescription>
+                        <Link to={SETTINGS_PAGE.route} className="text-primary hover:underline">
+                            Connect your Etsy shop
+                        </Link>{' '}
+                        to see your active listings here.
+                    </EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+        );
+    }
+
+    if (isLoading) {
+        return <LoadingScreen />;
+    }
+
+    if (isError) {
+        return <span>Something went wrong! :(</span>;
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <h1 className="text-2xl font-semibold">Etsy Listings</h1>
+                <p className="text-sm text-muted-foreground">
+                    {listings.length} active listing{listings.length === 1 ? '' : 's'} on Etsy. Only active listings are
+                    shown here — drafts sitting on Etsy outside this app aren't included.
+                </p>
+            </div>
+
+            {listings.length === 0 ? (
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <ShoppingBag />
+                        </EmptyMedia>
+                        <EmptyTitle>No Active Listings</EmptyTitle>
+                        <EmptyDescription>Your shop has no active Etsy listings right now.</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            ) : (
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Title</TableHead>
+                            <TableHead>Price</TableHead>
+                            <TableHead>Linked Design</TableHead>
+                            <TableHead>Etsy</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {listings.map((listing) => (
+                            <TableRow key={listing.listingId}>
+                                <TableCell className="font-medium">{listing.title}</TableCell>
+                                <TableCell>£{listing.price.toFixed(2)}</TableCell>
+                                <TableCell>
+                                    {listing.linkedDesignId ? (
+                                        <Link
+                                            to={VIEW_DESIGN_PAGE.getRoute(listing.linkedDesignId)}
+                                            className="text-primary hover:underline"
+                                        >
+                                            View design
+                                        </Link>
+                                    ) : (
+                                        <Badge variant="secondary">Not linked</Badge>
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    <a
+                                        href={listing.url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                                    >
+                                        View <ExternalLink className="h-3 w-3" />
+                                    </a>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
+        </div>
+    );
+};
+
+export default Listings;

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -128,7 +128,12 @@ const ViewDesign = () => {
                                         rel="noreferrer"
                                         className="inline-flex items-center gap-1 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
                                     >
-                                        {etsy.state === 'active' ? 'Active' : 'Draft'} on Etsy
+                                        {etsy.state === 'active'
+                                            ? 'Active'
+                                            : etsy.state === 'inactive'
+                                              ? 'Inactive'
+                                              : 'Draft'}{' '}
+                                        on Etsy
                                         <ExternalLink className="h-3 w-3" />
                                     </a>
                                 )}

--- a/packages/web/src/pages/ViewDesign/index.tsx
+++ b/packages/web/src/pages/ViewDesign/index.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../componen
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
 import { MATERIALS_PAGE } from '../../constants/routes';
 import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import { useEtsyStatus } from '../../hooks/useEtsyStatus';
 import {
     DESIGN_TYPE_LABELS,
     MATERIAL_TYPE_LABELS,
@@ -62,6 +63,8 @@ const ViewDesign = () => {
         makingNotes,
         etsy,
     } = design ?? {};
+
+    useEtsyStatus(id ?? '', !!id && !!etsy?.listingId);
 
     const hasDescription = description && description !== '<p></p>';
 


### PR DESCRIPTION
## Summary
- Adds a lightweight per-design Etsy status refresh: viewing a design already linked to Etsy fires one `GET /api/designs/:id/etsy-status` on mount and updates the stored Draft/Active/Inactive state, with no background polling.
- Adds a new `/listings` page showing all of the shop's active Etsy listings (live from Etsy), flagging which ones are already linked to a catalogue design — a scope amendment over the original spec's "no listings screen" decision (see `docs/superpowers/specs/2026-07-16-etsy-api-integration-design.md` decision log).
- Implements sub-project 4 of the Etsy API integration (`docs/superpowers/plans/2026-07-19-etsy-status-and-listings.md`), built via subagent-driven development: 8 tasks, each independently spec+quality reviewed, plus a broad final whole-branch review that caught one real bug (fixed in `cce8ab7`) before merge.

## Test plan
- [x] `packages/api` full test suite passes (223 pass, 0 fail)
- [x] `bunx tsc --build --force` shows no new errors vs. the pre-existing `main` baseline
- [x] `fallow-audit` pre-push gate passes (0 dead code, duplication warn-only)
- [ ] Manual smoke test in the browser (not performed in this session — headless environment; recommend a quick pass on Etsy-connected/not-connected states before considering this fully verified in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)