### PR TITLE
fix: surface real error on Etsy push failures instead of opaque 500

### DIFF
--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -1,5 +1,12 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { APIError } from '@imapps/api-utils/hono';
 import type { EtsyListingState } from '@jewellery-catalogue/types';
+
+// Etsy failures are surfaced as 502 (not the upstream status) so they can't collide with
+// our own 401/403 semantics — the web client treats any "401" in an error message as its
+// own JWT expiring and tries to refresh/logout, which must not fire for Etsy-side auth issues.
+const etsyError = async (op: string, response: Response): Promise<APIError> =>
+    new APIError(`Etsy ${op} failed: ${response.status} ${await response.text()}`, 502);
 
 const AUTHORIZE_URL = 'https://www.etsy.com/oauth/connect';
 const TOKEN_URL = 'https://api.etsy.com/v3/public/oauth/token';
@@ -104,7 +111,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy token request failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('token request', response);
         }
 
         return mapTokenResponse((await response.json()) as EtsyTokenApiResponse);
@@ -138,7 +145,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy getMe failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('getMe', response);
         }
 
         const body = (await response.json()) as { user_id: number; shop_id: number };
@@ -151,7 +158,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy getShop failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('getShop', response);
         }
 
         const body = (await response.json()) as { shop_id: number; shop_name: string };
@@ -164,7 +171,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy getListing failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('getListing', response);
         }
 
         const body = (await response.json()) as { listing_id: number; state: string };
@@ -182,7 +189,7 @@ export class EtsyClient {
             );
 
             if (!response.ok) {
-                throw new Error(`Etsy getShopListingsActive failed: ${response.status} ${await response.text()}`);
+                throw await etsyError('getShopListingsActive', response);
             }
 
             const body = (await response.json()) as {
@@ -235,7 +242,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy createDraftListing failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('createDraftListing', response);
         }
 
         const body = (await response.json()) as { listing_id: number };
@@ -263,7 +270,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy uploadListingImage failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('uploadListingImage', response);
         }
     }
 
@@ -273,7 +280,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy getListingImages failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('getListingImages', response);
         }
 
         const body = (await response.json()) as { results: Array<{ listing_image_id: number }> };
@@ -311,7 +318,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy updateListingInventory failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('updateListingInventory', response);
         }
     }
 
@@ -322,7 +329,7 @@ export class EtsyClient {
         });
 
         if (!response.ok) {
-            throw new Error(`Etsy getSellerTaxonomyNodes failed: ${response.status} ${await response.text()}`);
+            throw await etsyError('getSellerTaxonomyNodes', response);
         }
 
         const body = (await response.json()) as {

--- a/packages/api/src/handlers/Etsy/index.ts
+++ b/packages/api/src/handlers/Etsy/index.ts
@@ -65,8 +65,18 @@ export const pushDesignToEtsy = async (c: AuthedCtx) => {
         price?: number;
     };
 
-    const design = await getPushService().push(c.req.param('id'), c.get('userId'), { description, price });
-    return c.json(design, 200);
+    try {
+        const design = await getPushService().push(c.req.param('id'), c.get('userId'), { description, price });
+        return c.json(design, 200);
+    } catch (err) {
+        dependencyContainer.resolve(DependencyToken.Logger).error('Etsy push failed', {
+            designId: c.req.param('id'),
+            userId: c.get('userId'),
+            status: err instanceof Error && 'status' in err ? (err as { status?: number }).status : undefined,
+            message: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+    }
 };
 
 export const getEtsyTaxonomy = async (c: AuthedCtx) => {


### PR DESCRIPTION
## Summary
- Debugging Mari's "500 on Etsy push" report: the failure was 100% opaque — the shared `errorHandler` never logged errors, and `EtsyClient` threw plain `Error`s that always defaulted to a 500 response regardless of what actually went wrong upstream.
- `EtsyClient` now throws a typed `APIError(message, 502)` carrying Etsy's real status + response body, instead of a bare `Error` that gets flattened to a generic 500.
- `pushDesignToEtsy` now logs the failure (design id, user id, status, message) before rethrowing, so it lands in `docker logs` instead of vanishing.
- Deliberately used `502` rather than forwarding Etsy's raw status: the web client's token-refresh interceptor matches the literal substring `"401"` in any error message, so passing through an Etsy-side 401/403 would incorrectly trigger our own JWT refresh/logout flow for an unrelated failure.

This doesn't fix Mari's original failure (that error was never persisted anywhere so it's unrecoverable) — it makes the *next* occurrence debuggable. Once this ships, ask Mari to retry the push and check `docker logs` on the API container for the `"Etsy push failed"` line.

## Test plan
- [x] `bun test src/domain/EtsyClient src/handlers` — 42 pass
- [x] `tsc --noEmit` — clean
- [ ] Deploy and have Mari retry the push; confirm the real Etsy error now appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)