### PR TITLE
fix: send required shipping_profile_id when creating Etsy draft listings

### DIFF
--- a/packages/api/src/domain/EtsyClient/index.test.ts
+++ b/packages/api/src/domain/EtsyClient/index.test.ts
@@ -156,6 +156,7 @@ describe('EtsyClient', () => {
                 whoMade: 'i_did',
                 whenMade: 'made_to_order',
                 taxonomyId: 1234,
+                shippingProfileId: 5678,
             });
 
             expect(result).toEqual({ listingId: 999 });
@@ -175,6 +176,7 @@ describe('EtsyClient', () => {
                 who_made: 'i_did',
                 when_made: 'made_to_order',
                 taxonomy_id: 1234,
+                shipping_profile_id: 5678,
             });
         });
 
@@ -190,8 +192,42 @@ describe('EtsyClient', () => {
                     whoMade: 'i_did',
                     whenMade: 'made_to_order',
                     taxonomyId: 1,
+                    shippingProfileId: 1,
                 })
             ).rejects.toThrow();
+        });
+    });
+
+    describe('getShopShippingProfiles', () => {
+        it('fetches and maps the shop shipping profiles', async () => {
+            fetchMock.mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        results: [
+                            { shipping_profile_id: 1, title: 'Standard' },
+                            { shipping_profile_id: 2, title: 'Express' },
+                        ],
+                    }),
+                    { status: 200 }
+                )
+            );
+
+            const result = await client.getShopShippingProfiles('at-token', 47408839);
+
+            expect(result).toEqual([
+                { shippingProfileId: 1, title: 'Standard' },
+                { shippingProfileId: 2, title: 'Express' },
+            ]);
+            const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/shipping-profiles');
+            expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer at-token');
+        });
+
+        it('throws when Etsy responds with an error status', async () => {
+            fetchMock.mockResolvedValue(new Response('nope', { status: 404 }));
+
+            await expect(client.getShopShippingProfiles('at', 1)).rejects.toThrow();
         });
     });
 

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -27,10 +27,16 @@ export interface EtsyDraftListingInput {
     whoMade: string;
     whenMade: string;
     taxonomyId: number;
+    shippingProfileId: number;
 }
 
 export interface EtsyListingResult {
     listingId: number;
+}
+
+export interface EtsyShippingProfile {
+    shippingProfileId: number;
+    title: string;
 }
 
 export interface EtsyInventoryProduct {
@@ -238,6 +244,7 @@ export class EtsyClient {
                 who_made: input.whoMade,
                 when_made: input.whenMade,
                 taxonomy_id: input.taxonomyId,
+                shipping_profile_id: input.shippingProfileId,
             }),
         });
 
@@ -247,6 +254,21 @@ export class EtsyClient {
 
         const body = (await response.json()) as { listing_id: number };
         return { listingId: body.listing_id };
+    }
+
+    async getShopShippingProfiles(accessToken: string, shopId: number): Promise<EtsyShippingProfile[]> {
+        const response = await fetch(`${API_BASE}/shops/${shopId}/shipping-profiles`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw await etsyError('getShopShippingProfiles', response);
+        }
+
+        const body = (await response.json()) as {
+            results: Array<{ shipping_profile_id: number; title: string }>;
+        };
+        return body.results.map((r) => ({ shippingProfileId: r.shipping_profile_id, title: r.title }));
     }
 
     async uploadListingImage(

--- a/packages/api/src/domain/EtsyPushService/index.test.ts
+++ b/packages/api/src/domain/EtsyPushService/index.test.ts
@@ -17,6 +17,7 @@ const mockEtsyClient = {
     getListingImages: mock(),
     updateListingInventory: mock(),
     getSellerTaxonomyNodes: mock(),
+    getShopShippingProfiles: mock(),
 };
 const mockEtsyConnectionService = { getPushCredentials: mock() };
 const mockUserSettingsService = { get: mock() };
@@ -82,6 +83,7 @@ describe('EtsyPushService', () => {
             cacheControl: 'public',
         });
         mockEtsyClient.getListingImages.mockResolvedValue({ imageIds: [] });
+        mockEtsyClient.getShopShippingProfiles.mockResolvedValue([{ shippingProfileId: 5678, title: 'Standard' }]);
     });
 
     describe('push — new listing (no prior etsy.listingId)', () => {
@@ -94,7 +96,12 @@ describe('EtsyPushService', () => {
             expect(mockEtsyClient.createDraftListing).toHaveBeenCalledWith(
                 'at-token',
                 47408839,
-                expect.objectContaining({ title: 'Silver Ring', taxonomyId: 1234, quantity: 2 })
+                expect.objectContaining({
+                    title: 'Silver Ring',
+                    taxonomyId: 1234,
+                    quantity: 2,
+                    shippingProfileId: 5678,
+                })
             );
 
             expect(mockImageService.getImage).toHaveBeenCalledTimes(1);
@@ -134,6 +141,25 @@ describe('EtsyPushService', () => {
             mockDesignRepo.getByIdAndUserId.mockResolvedValue(
                 makeDesign({ designType: 'NECKLACE' as Design['designType'] })
             );
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects when the shop has no Etsy shipping profile', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.getShopShippingProfiles.mockResolvedValue([]);
+
+            await expect(service.push('design-1', 'user-1')).rejects.toThrow();
+            expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();
+        });
+
+        it('rejects when the shop has more than one Etsy shipping profile', async () => {
+            mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign());
+            mockEtsyClient.getShopShippingProfiles.mockResolvedValue([
+                { shippingProfileId: 1, title: 'Standard' },
+                { shippingProfileId: 2, title: 'Express' },
+            ]);
 
             await expect(service.push('design-1', 'user-1')).rejects.toThrow();
             expect(mockEtsyClient.createDraftListing).not.toHaveBeenCalled();

--- a/packages/api/src/domain/EtsyPushService/index.ts
+++ b/packages/api/src/domain/EtsyPushService/index.ts
@@ -57,11 +57,26 @@ export class EtsyPushService {
                 throw new APIError('No Etsy category is mapped for this design type', 400);
             }
 
+            const shippingProfiles = await this.etsyClient.getShopShippingProfiles(accessToken, shopId);
+            if (shippingProfiles.length === 0) {
+                throw new APIError(
+                    'No Etsy shipping profile found — create one in your Etsy shop settings before sending designs.',
+                    400
+                );
+            }
+            if (shippingProfiles.length > 1) {
+                throw new APIError(
+                    "Multiple Etsy shipping profiles found — selecting one isn't supported yet. Your shop must have exactly one shipping profile to push designs.",
+                    400
+                );
+            }
+            const shippingProfileId = shippingProfiles[0].shippingProfileId;
+
             const description =
                 overrides.description ?? renderDescriptionTemplate(settings.etsyDescriptionTemplate, design);
             const price = overrides.price ?? design.price;
 
-            const draftInput = buildDraftListingInput({ design, description, price, taxonomyId });
+            const draftInput = buildDraftListingInput({ design, description, price, taxonomyId, shippingProfileId });
             const created = await this.etsyClient.createDraftListing(accessToken, shopId, draftInput);
             listingId = created.listingId;
 

--- a/packages/api/src/domain/EtsyPushService/mappers.test.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.test.ts
@@ -37,6 +37,7 @@ describe('buildDraftListingInput', () => {
             description: 'A lovely ring.',
             price: 25.5,
             taxonomyId: 1234,
+            shippingProfileId: 5678,
         });
 
         expect(result).toEqual({
@@ -47,6 +48,7 @@ describe('buildDraftListingInput', () => {
             whoMade: 'i_did',
             whenMade: 'made_to_order',
             taxonomyId: 1234,
+            shippingProfileId: 5678,
         });
     });
 
@@ -56,6 +58,7 @@ describe('buildDraftListingInput', () => {
             description: 'd',
             price: 10,
             taxonomyId: 1,
+            shippingProfileId: 1,
         });
 
         expect(result.quantity).toBe(1);

--- a/packages/api/src/domain/EtsyPushService/mappers.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.ts
@@ -15,6 +15,7 @@ export const buildDraftListingInput = (args: {
     description: string;
     price: number;
     taxonomyId: number;
+    shippingProfileId: number;
 }): EtsyDraftListingInput => ({
     title: args.design.name,
     description: args.description,
@@ -23,6 +24,7 @@ export const buildDraftListingInput = (args: {
     whoMade: 'i_did',
     whenMade: 'made_to_order',
     taxonomyId: args.taxonomyId,
+    shippingProfileId: args.shippingProfileId,
 });
 
 export const buildInventoryProducts = (variants: DesignVariant[], groups: VariationGroup[]): EtsyInventoryProduct[] =>


### PR DESCRIPTION
## Summary
- Continuation of debugging Mari's "500 on Etsy push" report (#39 fixed the opaque error, this fixes the actual failure it revealed).
- Prod logs after #39 landed showed the real cause: `Etsy createDraftListing failed: 400 {"error":"A shipping_profile_id is required for physical listings."}`. Etsy requires `shipping_profile_id` for every physical listing, and this app (which only ever creates physical, made-to-order listings) never sent one — there was no shipping-profile handling anywhere in the codebase.
- `EtsyClient.getShopShippingProfiles` fetches the shop's shipping profiles (`GET /shops/{shopId}/shipping-profiles`).
- `EtsyPushService.push` calls it when creating a new listing (not on resume, since the listing already exists by then) and:
  - uses the profile automatically when the shop has exactly one (the common single-seller case, e.g. Mari's shop),
  - fails with a clear 400 `APIError` if the shop has zero profiles ("create one in your Etsy shop settings") or more than one (selection isn't supported yet — no settings UI exists for picking between profiles).
- `buildDraftListingInput` / `EtsyDraftListingInput` gained a `shippingProfileId` field, sent as `shipping_profile_id` in the Etsy request body.

Didn't verify against Mari's actual shop data before writing this (multi-profile picker UI would be the follow-up if her shop turns out to have more than one profile) — going with the general-case fix per your direction.

## Test plan
- [x] `bun test` (full api package) — 227 pass, 0 fail
- [x] `tsc --noEmit` — clean
- [ ] Deploy and have Mari retry the push

🤖 Generated with [Claude Code](https://claude.com/claude-code)