### PR TITLE
feat: let users pick an Etsy shipping profile when their shop has more than one

### DIFF
--- a/packages/api/src/domain/EtsyPushService/index.ts
+++ b/packages/api/src/domain/EtsyPushService/index.ts
@@ -57,20 +57,8 @@ export class EtsyPushService {
                 throw new APIError('No Etsy category is mapped for this design type', 400);
             }
 
-            const shippingProfiles = await this.etsyClient.getShopShippingProfiles(accessToken, shopId);
-            if (shippingProfiles.length === 0) {
-                throw new APIError(
-                    'No Etsy shipping profile found — create one in your Etsy shop settings before sending designs.',
-                    400
-                );
-            }
-            if (shippingProfiles.length > 1) {
-                throw new APIError(
-                    "Multiple Etsy shipping profiles found — selecting one isn't supported yet. Your shop must have exactly one shipping profile to push designs.",
-                    400
-                );
-            }
-            const shippingProfileId = shippingProfiles[0].shippingProfileId;
+            const shippingProfileId =
+                settings.etsyShippingProfileId ?? (await this.resolveDefaultShippingProfileId(accessToken, shopId));
 
             const description =
                 overrides.description ?? renderDescriptionTemplate(settings.etsyDescriptionTemplate, design);
@@ -113,5 +101,22 @@ export class EtsyPushService {
         await this.designRepo.update(designId, updated);
 
         return updated;
+    }
+
+    private async resolveDefaultShippingProfileId(accessToken: string, shopId: number): Promise<number> {
+        const shippingProfiles = await this.etsyClient.getShopShippingProfiles(accessToken, shopId);
+        if (shippingProfiles.length === 0) {
+            throw new APIError(
+                'No Etsy shipping profile found — create one in your Etsy shop settings before sending designs.',
+                400
+            );
+        }
+        if (shippingProfiles.length > 1) {
+            throw new APIError(
+                'Your Etsy shop has multiple shipping profiles — choose one in Settings before sending designs.',
+                400
+            );
+        }
+        return shippingProfiles[0].shippingProfileId;
     }
 }

--- a/packages/api/src/domain/UserSettingsService/index.ts
+++ b/packages/api/src/domain/UserSettingsService/index.ts
@@ -39,6 +39,7 @@ export class UserSettingsService {
             hourlyRate: DEFAULT_HOURLY_RATE,
             etsyDescriptionTemplate: DEFAULT_ETSY_DESCRIPTION_TEMPLATE,
             etsyTaxonomyMap: {},
+            etsyShippingProfileId: null,
         };
         return { ...defaults, ...stored };
     }
@@ -52,6 +53,7 @@ export class UserSettingsService {
             hourlyRate: number;
             etsyDescriptionTemplate: string;
             etsyTaxonomyMap: Record<string, number>;
+            etsyShippingProfileId: number | null;
         }
     ): Promise<UserSettings> {
         const settings: UserSettings = { userId, ...updates };

--- a/packages/api/src/handlers/Etsy/index.ts
+++ b/packages/api/src/handlers/Etsy/index.ts
@@ -85,6 +85,13 @@ export const getEtsyTaxonomy = async (c: AuthedCtx) => {
     return c.json(nodes, 200);
 };
 
+export const getEtsyShippingProfiles = async (c: AuthedCtx) => {
+    const { accessToken, shopId } = await getService().getPushCredentials(c.get('userId'));
+    const client = dependencyContainer.resolve(DependencyToken.EtsyClient);
+    const profiles = await client.getShopShippingProfiles(accessToken, shopId);
+    return c.json(profiles, 200);
+};
+
 const getStatusService = (): EtsyStatusService => dependencyContainer.resolve(DependencyToken.EtsyStatusService);
 
 export const refreshDesignEtsyStatus = async (c: AuthedCtx) => {

--- a/packages/api/src/handlers/UserSettings/index.ts
+++ b/packages/api/src/handlers/UserSettings/index.ts
@@ -12,15 +12,23 @@ const getService = (): UserSettingsService => dependencyContainer.resolve(Depend
 export const getUserSettings = async (c: Ctx) => c.json(await getService().get(c.get('userId')));
 
 export const updateUserSettings = async (c: Ctx) => {
-    const { hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate, etsyTaxonomyMap } =
-        (await c.req.json()) as {
-            hourlyWage?: number;
-            profitMargin?: number;
-            markupMultiplier?: number;
-            hourlyRate?: number;
-            etsyDescriptionTemplate?: string;
-            etsyTaxonomyMap?: Record<string, number>;
-        };
+    const {
+        hourlyWage,
+        profitMargin,
+        markupMultiplier,
+        hourlyRate,
+        etsyDescriptionTemplate,
+        etsyTaxonomyMap,
+        etsyShippingProfileId,
+    } = (await c.req.json()) as {
+        hourlyWage?: number;
+        profitMargin?: number;
+        markupMultiplier?: number;
+        hourlyRate?: number;
+        etsyDescriptionTemplate?: string;
+        etsyTaxonomyMap?: Record<string, number>;
+        etsyShippingProfileId?: number | null;
+    };
 
     if (
         hourlyWage === undefined ||
@@ -44,6 +52,7 @@ export const updateUserSettings = async (c: Ctx) => {
             hourlyRate: Number(hourlyRate),
             etsyDescriptionTemplate,
             etsyTaxonomyMap,
+            etsyShippingProfileId: etsyShippingProfileId ?? null,
         })
     );
 };

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -9,6 +9,7 @@ import {
     disconnectEtsyConnection,
     etsyOAuthCallback,
     getEtsyConnectionStatus,
+    getEtsyShippingProfiles,
     getEtsyShopListings,
     getEtsyTaxonomy,
     pushDesignToEtsy,
@@ -49,6 +50,7 @@ export const createRoutes = (): Hono<Env> => {
     app.delete('/api/etsy/connection', authenticate, disconnectEtsyConnection);
     app.post('/api/designs/:id/etsy-push', authenticate, pushDesignToEtsy);
     app.get('/api/etsy/taxonomy', authenticate, getEtsyTaxonomy);
+    app.get('/api/etsy/shipping-profiles', authenticate, getEtsyShippingProfiles);
     app.get('/api/etsy/listings', authenticate, getEtsyShopListings);
     app.get('/api/designs/:id/etsy-status', authenticate, refreshDesignEtsyStatus);
 

--- a/packages/types/src/userSettings/index.ts
+++ b/packages/types/src/userSettings/index.ts
@@ -8,6 +8,7 @@ export const userSettingsSchema = z.object({
     hourlyRate: z.number().nonnegative(),
     etsyDescriptionTemplate: z.string(),
     etsyTaxonomyMap: z.record(z.string(), z.number()),
+    etsyShippingProfileId: z.number().nullable(),
 });
 
 export type UserSettings = z.infer<typeof userSettingsSchema>;

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -7,6 +7,7 @@ export const IMAGES_ENDPOINT = '/api/images';
 export const ETSY_OAUTH_START_ENDPOINT = '/api/etsy/oauth/start';
 export const ETSY_CONNECTION_ENDPOINT = '/api/etsy/connection';
 export const ETSY_TAXONOMY_ENDPOINT = '/api/etsy/taxonomy';
+export const ETSY_SHIPPING_PROFILES_ENDPOINT = '/api/etsy/shipping-profiles';
 export const ETSY_LISTINGS_ENDPOINT = '/api/etsy/listings';
 
 export const getMaterialRecalculatePricesEndpoint = (materialId: string) =>

--- a/packages/web/src/api/endpoints/etsyShippingProfiles/index.ts
+++ b/packages/web/src/api/endpoints/etsyShippingProfiles/index.ts
@@ -3,7 +3,7 @@ import { MethodType } from '@jewellery-catalogue/types';
 import { ETSY_SHIPPING_PROFILES_ENDPOINT } from '../../endpoints';
 import { makeRequestWithAutoRefresh } from '../../makeRequest';
 
-export interface EtsyShippingProfile {
+interface EtsyShippingProfile {
     shippingProfileId: number;
     title: string;
 }

--- a/packages/web/src/api/endpoints/etsyShippingProfiles/index.ts
+++ b/packages/web/src/api/endpoints/etsyShippingProfiles/index.ts
@@ -1,0 +1,26 @@
+import { MethodType } from '@jewellery-catalogue/types';
+
+import { ETSY_SHIPPING_PROFILES_ENDPOINT } from '../../endpoints';
+import { makeRequestWithAutoRefresh } from '../../makeRequest';
+
+export interface EtsyShippingProfile {
+    shippingProfileId: number;
+    title: string;
+}
+
+export const makeGetEtsyShippingProfilesRequest = (
+    getAccessToken: () => string,
+    onTokenRefresh: (newToken: string) => void,
+    onTokenClear: () => void
+) =>
+    makeRequestWithAutoRefresh<EtsyShippingProfile[]>(
+        {
+            pathname: ETSY_SHIPPING_PROFILES_ENDPOINT,
+            method: MethodType.GET,
+            operationString: 'fetch etsy shipping profiles',
+            accessToken: '',
+        },
+        getAccessToken,
+        onTokenRefresh,
+        onTokenClear
+    );

--- a/packages/web/src/api/endpoints/userSettings/index.ts
+++ b/packages/web/src/api/endpoints/userSettings/index.ts
@@ -28,6 +28,7 @@ export const makeUpdateUserSettingsRequest = (
         hourlyRate: number;
         etsyDescriptionTemplate: string;
         etsyTaxonomyMap: Record<string, number>;
+        etsyShippingProfileId: number | null;
     },
     getAccessToken: () => string,
     onTokenRefresh: (newToken: string) => void,

--- a/packages/web/src/hooks/useEtsyShippingProfiles.ts
+++ b/packages/web/src/hooks/useEtsyShippingProfiles.ts
@@ -1,0 +1,19 @@
+import { useAuth } from '@imapps/web-utils';
+import { useQuery } from '@tanstack/react-query';
+
+import { makeGetEtsyShippingProfilesRequest } from '../api/endpoints/etsyShippingProfiles';
+
+export const useEtsyShippingProfiles = (enabled: boolean) => {
+    const { accessToken, login, logout } = useAuth();
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['etsy-shipping-profiles'],
+        queryFn: () => makeGetEtsyShippingProfilesRequest(() => accessToken, login, logout),
+        enabled: enabled && !!accessToken,
+    });
+
+    return {
+        profiles: data ?? [],
+        isLoading,
+    };
+};

--- a/packages/web/src/hooks/useUserSettings.ts
+++ b/packages/web/src/hooks/useUserSettings.ts
@@ -27,6 +27,7 @@ export const useUserSettings = () => {
             hourlyRate: number;
             etsyDescriptionTemplate: string;
             etsyTaxonomyMap: Record<string, number>;
+            etsyShippingProfileId: number | null;
         }) => makeUpdateUserSettingsRequest(updates, () => accessToken, login, logout),
         onSuccess: (updated) => {
             queryClient.setQueryData(QUERY_KEY, updated);
@@ -47,6 +48,7 @@ export const useUserSettings = () => {
         hourlyRate: data?.hourlyRate ?? 0,
         etsyDescriptionTemplate: data?.etsyDescriptionTemplate ?? '',
         etsyTaxonomyMap: data?.etsyTaxonomyMap ?? {},
+        etsyShippingProfileId: data?.etsyShippingProfileId ?? null,
         isLoading,
         updateSettings: updateMutation.mutateAsync,
         recalculate: recalculateMutation.mutateAsync,

--- a/packages/web/src/pages/Settings/index.tsx
+++ b/packages/web/src/pages/Settings/index.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 
 import { useEtsyConnection } from '../../hooks/useEtsyConnection';
+import { useEtsyShippingProfiles } from '../../hooks/useEtsyShippingProfiles';
 import { useEtsyTaxonomy } from '../../hooks/useEtsyTaxonomy';
 import { useUserSettings } from '../../hooks/useUserSettings';
 
@@ -36,11 +37,13 @@ const Settings = () => {
         hourlyRate,
         etsyDescriptionTemplate,
         etsyTaxonomyMap,
+        etsyShippingProfileId,
         updateSettings,
         recalculate,
         isLoading: pricingLoading,
     } = useUserSettings();
     const { options: taxonomyOptions, isLoading: taxonomyLoading } = useEtsyTaxonomy(connected);
+    const { profiles: shippingProfiles, isLoading: shippingProfilesLoading } = useEtsyShippingProfiles(connected);
 
     const [localWage, setLocalWage] = useState<number | ''>(hourlyWage);
     const [localMargin, setLocalMargin] = useState<number | ''>(profitMargin);
@@ -48,6 +51,7 @@ const Settings = () => {
     const [localHourlyRate, setLocalHourlyRate] = useState<number | ''>(hourlyRate);
     const [localEtsyDescriptionTemplate, setLocalEtsyDescriptionTemplate] = useState(etsyDescriptionTemplate);
     const [localEtsyTaxonomyMap, setLocalEtsyTaxonomyMap] = useState<Record<string, number>>(etsyTaxonomyMap);
+    const [localEtsyShippingProfileId, setLocalEtsyShippingProfileId] = useState<number | null>(etsyShippingProfileId);
     const [pricingStatus, setPricingStatus] = useState<'idle' | 'saving' | 'recalculating' | 'success' | 'error'>(
         'idle'
     );
@@ -63,7 +67,16 @@ const Settings = () => {
         setLocalHourlyRate(hourlyRate);
         setLocalEtsyDescriptionTemplate(etsyDescriptionTemplate);
         setLocalEtsyTaxonomyMap(etsyTaxonomyMap);
-    }, [hourlyWage, profitMargin, markupMultiplier, hourlyRate, etsyDescriptionTemplate, etsyTaxonomyMap]);
+        setLocalEtsyShippingProfileId(etsyShippingProfileId);
+    }, [
+        hourlyWage,
+        profitMargin,
+        markupMultiplier,
+        hourlyRate,
+        etsyDescriptionTemplate,
+        etsyTaxonomyMap,
+        etsyShippingProfileId,
+    ]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount to strip the ?etsy param from the URL
     useEffect(() => {
@@ -94,6 +107,7 @@ const Settings = () => {
                 hourlyRate: Number(localHourlyRate),
                 etsyDescriptionTemplate: localEtsyDescriptionTemplate,
                 etsyTaxonomyMap: localEtsyTaxonomyMap,
+                etsyShippingProfileId: localEtsyShippingProfileId,
             });
             if (thenRecalculate) {
                 setPricingStatus('recalculating');
@@ -321,6 +335,35 @@ const Settings = () => {
                                     </select>
                                 </div>
                             ))}
+                        </div>
+
+                        <div className="space-y-1.5">
+                            <Label>Shipping profile</Label>
+                            <select
+                                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+                                disabled={shippingProfilesLoading}
+                                value={localEtsyShippingProfileId ?? ''}
+                                onChange={(e) =>
+                                    setLocalEtsyShippingProfileId(e.target.value === '' ? null : Number(e.target.value))
+                                }
+                            >
+                                <option value="">
+                                    {shippingProfiles.length > 1
+                                        ? 'Select a shipping profile…'
+                                        : "Auto (use the shop's only profile)"}
+                                </option>
+                                {shippingProfiles.map((profile) => (
+                                    <option key={profile.shippingProfileId} value={profile.shippingProfileId}>
+                                        {profile.title}
+                                    </option>
+                                ))}
+                            </select>
+                            {shippingProfiles.length > 1 && (
+                                <p className="text-xs text-muted-foreground">
+                                    Your shop has multiple shipping profiles — pick one, otherwise sending to Etsy will
+                                    fail.
+                                </p>
+                            )}
                         </div>
                     </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary
Third and final part of the Etsy push debugging chain (#39, #41):
- #41 made `EtsyPushService` auto-detect the shop's shipping profile when creating a listing, but hard-errors if the shop has zero or more than one profile (no way to choose).
- Prod logs showed Mari's shop hits exactly that: `400: "Multiple Etsy shipping profiles found — selecting one isn't supported yet."`
- This PR adds the missing picker:
  - `GET /api/etsy/shipping-profiles` — new endpoint, lists the connected shop's shipping profiles via `EtsyClient.getShopShippingProfiles`.
  - `UserSettings.etsyShippingProfileId` (nullable) — new setting.
  - `EtsyPushService.push` uses the saved setting when present; falls back to the existing "auto-use if exactly one" behavior when unset, so single-profile shops need zero configuration.
  - Settings page: new "Shipping profile" dropdown under "Etsy Defaults", populated from the new endpoint.

Once deployed, Mari needs to open Settings → Etsy Defaults → pick her shipping profile → save, then retry the push.

## Test plan
- [x] `bun test` (api package) — 227 pass, 0 fail
- [x] `bun run lint` — clean
- [ ] Deploy, have Mari pick a shipping profile in Settings, retry the push

🤖 Generated with [Claude Code](https://claude.com/claude-code)