### PR TITLE
fix: strip TipTap HTML from design descriptions before sending to Etsy

### DIFF
--- a/packages/api/src/domain/EtsyPushService/mappers.test.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.test.ts
@@ -28,6 +28,15 @@ describe('renderDescriptionTemplate', () => {
         });
         expect(result).toBe('A ring. ()');
     });
+
+    it('strips the TipTap HTML design descriptions are authored in, rather than sending raw tags to Etsy', () => {
+        const result = renderDescriptionTemplate('{description}', {
+            description: '<p>A <strong>lovely</strong> ring.</p><p>Second paragraph.</p>',
+            materials: [],
+        });
+
+        expect(result).toBe('A lovely ring.\n\nSecond paragraph.');
+    });
 });
 
 describe('buildDraftListingInput', () => {

--- a/packages/api/src/domain/EtsyPushService/mappers.ts
+++ b/packages/api/src/domain/EtsyPushService/mappers.ts
@@ -1,4 +1,10 @@
-import type { Design, DesignVariant, RequiredMaterial, VariationGroup } from '@jewellery-catalogue/types';
+import {
+    type Design,
+    type DesignVariant,
+    htmlToPlainText,
+    type RequiredMaterial,
+    type VariationGroup,
+} from '@jewellery-catalogue/types';
 
 import type { EtsyDraftListingInput, EtsyInventoryProduct } from '../EtsyClient';
 
@@ -7,7 +13,9 @@ export const renderDescriptionTemplate = (
     design: { description: string; materials: RequiredMaterial[] }
 ): string => {
     const materialsList = design.materials.map((m) => m.name).join(', ');
-    return template.replace(/\{description\}/g, design.description).replace(/\{materials\}/g, materialsList);
+    return template
+        .replace(/\{description\}/g, htmlToPlainText(design.description))
+        .replace(/\{materials\}/g, materialsList);
 };
 
 export const buildDraftListingInput = (args: {

--- a/packages/types/src/util/index.ts
+++ b/packages/types/src/util/index.ts
@@ -33,3 +33,27 @@ export const isWireMaterial = (material: Material): material is Wire => {
 export const isBeadMaterial = (material: Material): material is Bead => {
     return material.type === 'BEAD';
 };
+
+// Design descriptions are authored as TipTap HTML. Third parties like Etsy's
+// listing description field are plain text only, so block-level tags become
+// paragraph breaks, <br> becomes a single line break, and everything else is
+// stripped rather than shown as raw markup.
+const HTML_PARAGRAPH_BREAKS = /<\/(p|div|h[1-6]|li)>/gi;
+const HTML_LINE_BREAKS = /<br\s*\/?>/gi;
+const HTML_ENTITIES: Record<string, string> = {
+    '&nbsp;': ' ',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+};
+
+export const htmlToPlainText = (html: string): string =>
+    html
+        .replace(HTML_PARAGRAPH_BREAKS, '\n\n')
+        .replace(HTML_LINE_BREAKS, '\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;/g, (entity) => HTML_ENTITIES[entity])
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();

--- a/packages/web/src/components/EtsyPushDialog/index.tsx
+++ b/packages/web/src/components/EtsyPushDialog/index.tsx
@@ -1,4 +1,4 @@
-import type { Design } from '@jewellery-catalogue/types';
+import { type Design, htmlToPlainText } from '@jewellery-catalogue/types';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -25,7 +25,7 @@ interface EtsyPushDialogProps {
 
 const renderTemplate = (template: string, description: string, materials: Array<{ name: string }>): string =>
     template
-        .replace(/\{description\}/g, description)
+        .replace(/\{description\}/g, htmlToPlainText(description))
         .replace(/\{materials\}/g, materials.map((m) => m.name).join(', '));
 
 const EtsyPushDialog: React.FC<EtsyPushDialogProps> = ({ design, open, onOpenChange }) => {


### PR DESCRIPTION
## Summary
Follow-up to #43 (already merged) — after the push started succeeding, the description on Etsy came through with raw HTML markup instead of formatted text.

Design descriptions are authored via the `RichTextEditor` (TipTap) and stored as HTML (e.g. `<p>A <strong>lovely</strong> ring.</p>`). Etsy's listing `description` field is plain text only — there's no API to set a rich/HTML description — so the raw markup was being sent straight through and showing up as literal tags on the listing.

- New shared `htmlToPlainText` helper in `packages/types` — turns block-level tags (`<p>`, `<div>`, headings, `<li>`) into paragraph breaks, `<br>` into a line break, strips everything else, decodes basic entities.
- Applied everywhere a description reaches Etsy:
  - `EtsyPushService.renderDescriptionTemplate` (server-side fallback, used when no description override is sent in the request)
  - `EtsyPushDialog`'s local `renderTemplate` — this is what the user actually sees/edits in the "Send to Etsy" dialog's textarea, and whatever they submit from there bypasses the server-side template entirely. Previously this textarea itself showed raw HTML tags.

## Test plan
- [x] `bun test` (api package) — 234 pass, 0 fail
- [x] Verified `EtsyPushDialog` and `mappers.ts` compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)