### PR TITLE
fix: preserve new lines when importing Etsy listing descriptions

### DIFF
--- a/packages/api/src/domain/EtsyReconcileService/index.test.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.test.ts
@@ -73,7 +73,7 @@ describe('EtsyReconcileService.createDesignFromListing', () => {
         expect(inserted.id).toBe('new-design-1');
         expect(inserted.userId).toBe('user-1');
         expect(inserted.name).toBe('Silver Ring');
-        expect(inserted.description).toBe('A lovely ring.');
+        expect(inserted.description).toBe('<p>A lovely ring.</p>');
         expect(inserted.price).toBe(25);
         expect(inserted.materials).toEqual([]);
         expect(inserted.imageIds).toEqual([]);
@@ -84,6 +84,21 @@ describe('EtsyReconcileService.createDesignFromListing', () => {
             pushIncomplete: true,
             imageUrls: ['https://i.etsy.com/1.jpg'],
         });
+    });
+
+    it('preserves new lines from the listing description as HTML paragraphs/breaks', async () => {
+        mockEtsyClient.getListingDetail.mockResolvedValue({
+            title: 'Silver Ring',
+            description: 'Line one.\nLine two.\n\nSecond paragraph.',
+            price: 25,
+            imageUrls: ['https://i.etsy.com/1.jpg'],
+        });
+
+        const result = await makeService().createDesignFromListing(555, 'user-1');
+
+        expect(result).toEqual({ designId: 'new-design-1' });
+        const inserted = mockDesignRepo.insert.mock.calls[0]![0] as Design;
+        expect(inserted.description).toBe('<p>Line one.<br>Line two.</p><p>Second paragraph.</p>');
     });
 
     it('rejects with 400 when the listing is not in the shop', async () => {

--- a/packages/api/src/domain/EtsyReconcileService/index.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.ts
@@ -1,5 +1,5 @@
 import { APIError } from '@imapps/api-utils/hono';
-import type { Design } from '@jewellery-catalogue/types';
+import { type Design, plainTextToHtml } from '@jewellery-catalogue/types';
 
 import type { DesignRepository } from '../DesignRepository';
 import type { EtsyClient } from '../EtsyClient';
@@ -36,7 +36,7 @@ export class EtsyReconcileService {
             id: designId,
             userId,
             name: detail.title,
-            description: detail.description,
+            description: plainTextToHtml(detail.description),
             timeRequired: '00:00',
             materials: [],
             imageIds: [],

--- a/packages/types/src/util/index.test.ts
+++ b/packages/types/src/util/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+
+import { htmlToPlainText, plainTextToHtml } from './index';
+
+describe('plainTextToHtml', () => {
+    it('wraps a single paragraph in <p>', () => {
+        expect(plainTextToHtml('Hello world.')).toBe('<p>Hello world.</p>');
+    });
+
+    it('converts single new lines to <br>', () => {
+        expect(plainTextToHtml('Line one.\nLine two.')).toBe('<p>Line one.<br>Line two.</p>');
+    });
+
+    it('converts blank-line-separated text into separate paragraphs', () => {
+        expect(plainTextToHtml('Para one.\n\nPara two.')).toBe('<p>Para one.</p><p>Para two.</p>');
+    });
+
+    it('escapes HTML-significant characters', () => {
+        expect(plainTextToHtml('A & B < C > D')).toBe('<p>A &amp; B &lt; C &gt; D</p>');
+    });
+
+    it('returns an empty paragraph for blank input', () => {
+        expect(plainTextToHtml('   ')).toBe('<p></p>');
+    });
+
+    it('round-trips through htmlToPlainText for a multi-paragraph, multi-line input', () => {
+        const original = 'Para one line one.\nPara one line two.\n\nPara two.';
+        expect(htmlToPlainText(plainTextToHtml(original))).toBe(original);
+    });
+});

--- a/packages/types/src/util/index.ts
+++ b/packages/types/src/util/index.ts
@@ -57,3 +57,19 @@ export const htmlToPlainText = (html: string): string =>
         .replace(/&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;/g, (entity) => HTML_ENTITIES[entity])
         .replace(/\n{3,}/g, '\n\n')
         .trim();
+
+const escapeHtml = (text: string): string => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Inverse of htmlToPlainText: third-party plain text (e.g. an Etsy listing
+// description) becomes TipTap-compatible HTML, so blank-line-separated
+// paragraphs and single line breaks survive instead of collapsing to one line.
+export const plainTextToHtml = (text: string): string => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+        return '<p></p>';
+    }
+    return trimmed
+        .split(/\n{2,}/)
+        .map((paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, '<br>')}</p>`)
+        .join('');
+};

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -3,6 +3,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 const isStaging = process.env.NODE_ENV === 'staging' || !!process.env.STAGING_BASE_URL;
+// True whenever tests target an already-running, real backend (staging/prod),
+// as opposed to a locally-started app that has no auth backend of its own.
+const isRemoteTarget = isStaging || !!process.env.E2E_BASE_URL;
 
 if (isCI || isStaging) {
     process.env.E2E_API_SERVICE_URL = process.env.E2E_API_SERVICE_URL || 'http://localhost:3001';
@@ -28,7 +31,9 @@ export default defineConfig({
     retries: process.env.CI ? 2 : 0,
     workers: isCI ? 3 : 5,
     reporter: 'html',
-    globalSetup: isCI ? './tests/e2e/global-setup.ts' : undefined,
+    // Mock auth server: needed whenever there's no real auth backend to talk to.
+    // Skip it only when pointed at a real (staging/prod) environment.
+    globalSetup: isRemoteTarget ? undefined : './tests/e2e/global-setup.ts',
     use: {
         baseURL: getBaseURL(),
         trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- `EtsyReconcileService.createDesignFromListing` stored the Etsy listing's plain-text description verbatim into the design's TipTap-HTML description field, so line breaks collapsed to a single line once rendered.
- Add `plainTextToHtml` (inverse of the existing `htmlToPlainText` used when pushing to Etsy) and use it on import.
- Also: `playwright.config.ts` only started the local mock auth server (`global-setup.ts`) under `CI=true`, so a plain local e2e run had no auth backend and every auth-dependent spec failed regardless of app changes. Now it runs whenever the target isn't a real remote (staging/prod) backend — needed to actually gate this and future changes on a green local e2e run.

## Test plan
- [x] `bun run --filter @jewellery-catalogue/api test EtsyReconcileService` — new regression test asserting newlines survive import
- [x] `bun test src/util/index.test.ts` (packages/types) — new `plainTextToHtml` unit tests incl. round-trip with `htmlToPlainText`
- [x] `bun run tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run --filter @jewellery-catalogue/web pw:e2e:local` — 29/29 passing locally (previously 13 failing due to the auth-server gap above, unrelated to this fix)