### PR TITLE
chore: tag two start-page e2e specs @smoke

### DIFF
--- a/packages/web/tests/e2e/startpage.spec.ts
+++ b/packages/web/tests/e2e/startpage.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { waitForAuthServices } from './utils/auth-helpers';
 
 test.describe('Given Start Page', () => {
-    test('When the start page is loaded', async ({ page }) => {
+    test('When the start page is loaded @smoke', async ({ page }) => {
         await page.goto('/');
 
         await page.waitForLoadState('networkidle');
@@ -21,7 +21,7 @@ test.describe('Given Start Page', () => {
         await expect(page.locator('body')).not.toContainText('Something went wrong');
     });
 
-    test('should verify page loads without console errors', async ({ page }) => {
+    test('should verify page loads without console errors @smoke', async ({ page }) => {
         const consoleErrors: Array<string> = [];
         const networkErrors: Array<string> = [];
 


### PR DESCRIPTION
## Summary
- kanban-cli's post-deploy live smoke check runs `pw:e2e:local --grep @smoke`, but no spec was tagged `@smoke`, so it silently matched zero tests every time.
- Tag the two `startpage.spec.ts` tests that need no auth and don't hardcode `localhost` service URLs (safe to run against a real deployed environment): page load + no-console-errors.

## Test plan
- [x] `npx playwright test --grep "@smoke"` locally — 2/2 passing
- [x] `bun run tsc --noEmit`, `bun run lint`
- [x] Full local e2e suite already verified clean for this exact config in #46 moments earlier; this change only appends test-title tags, no logic touched — relying on CI's e2e job as the gate here rather than re-running the full suite locally again.