### PR TITLE
feat: import Etsy listing variations into new designs

### DIFF
--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -222,7 +222,8 @@ export const registerDepdendencies = () => {
                     dependencyContainer.resolve(DependencyToken.DesignRepository),
                     dependencyContainer.resolve(DependencyToken.EtsyClient),
                     dependencyContainer.resolve(DependencyToken.EtsyConnectionService),
-                    dependencyContainer.resolve(DependencyToken.IdGenerator)
+                    dependencyContainer.resolve(DependencyToken.IdGenerator),
+                    dependencyContainer.resolve(DependencyToken.MaterialRepository)
                 );
             }
         } as any

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -76,6 +76,26 @@ export interface EtsyListingDetail {
     imageUrls: string[];
 }
 
+export interface EtsyInventoryProductOffering {
+    price: number;
+    quantity: number;
+    isEnabled: boolean;
+}
+
+export interface EtsyInventoryPropertyValue {
+    propertyName: string;
+    values: string[];
+}
+
+export interface EtsyInventoryProductResult {
+    offerings: EtsyInventoryProductOffering[];
+    propertyValues: EtsyInventoryPropertyValue[];
+}
+
+export interface EtsyListingInventory {
+    products: EtsyInventoryProductResult[];
+}
+
 const mapListingState = (state: string): EtsyListingState =>
     state === 'draft' || state === 'active' ? state : 'inactive';
 
@@ -219,6 +239,34 @@ export class EtsyClient {
             description: body.description,
             price: body.price.amount / body.price.divisor,
             imageUrls: (body.images ?? []).map((img) => img.url_fullxfull),
+        };
+    }
+
+    async getListingInventory(accessToken: string, listingId: number): Promise<EtsyListingInventory> {
+        const response = await fetch(`${API_BASE}/listings/${listingId}/inventory`, {
+            headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw await etsyError('getListingInventory', response);
+        }
+
+        const body = (await response.json()) as {
+            products: Array<{
+                offerings: Array<{ price: { amount: number; divisor: number }; quantity: number; is_enabled: boolean }>;
+                property_values: Array<{ property_name: string; values: string[] }>;
+            }>;
+        };
+
+        return {
+            products: body.products.map((p) => ({
+                offerings: p.offerings.map((o) => ({
+                    price: o.price.amount / o.price.divisor,
+                    quantity: o.quantity,
+                    isEnabled: o.is_enabled,
+                })),
+                propertyValues: p.property_values.map((pv) => ({ propertyName: pv.property_name, values: pv.values })),
+            })),
         };
     }
 

--- a/packages/api/src/domain/EtsyReconcileService/index.test.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.test.ts
@@ -1,16 +1,37 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
-import type { Design } from '@jewellery-catalogue/types';
+import { type Design, type Material, MaterialType } from '@jewellery-catalogue/types';
 
 import type { DesignRepository } from '../DesignRepository';
 import type { EtsyClient } from '../EtsyClient';
 import type { EtsyConnectionService } from '../EtsyConnectionService';
 import type { IdGenerator } from '../IdGenerator';
+import type { MaterialRepository } from '../MaterialRepository';
 import { EtsyReconcileService } from './index';
 
 const mockDesignRepo = { getByUserId: mock(), getByIdAndUserId: mock(), insert: mock(), update: mock() };
-const mockEtsyClient = { getShopListingsActive: mock(), getListingDetail: mock() };
-const mockEtsyConnectionService = { getShopId: mock() };
+const mockEtsyClient = { getShopListingsActive: mock(), getListingDetail: mock(), getListingInventory: mock() };
+const mockEtsyConnectionService = { getShopId: mock(), getValidAccessToken: mock() };
+const mockMaterialRepo = { getByUserId: mock() };
 const mockIdGenerator = { generate: mock() };
+
+function makeMaterial(overrides: Partial<Material> = {}): Material {
+    return {
+        type: MaterialType.BEAD,
+        id: 'material-1',
+        userId: 'user-1',
+        name: 'Red',
+        brand: '',
+        purchaseUrl: '',
+        dateAdded: new Date().toISOString(),
+        diameter: 6,
+        colour: 'red',
+        quantityPerPack: 100,
+        pricePerPack: 5,
+        totalQuantity: 100,
+        pricePerBead: 0.05,
+        ...overrides,
+    } as Material;
+}
 
 function makeDesign(overrides: Partial<Design> = {}): Design {
     return {
@@ -36,7 +57,8 @@ function makeService() {
         mockDesignRepo as unknown as DesignRepository,
         mockEtsyClient as unknown as EtsyClient,
         mockEtsyConnectionService as unknown as EtsyConnectionService,
-        mockIdGenerator as unknown as IdGenerator
+        mockIdGenerator as unknown as IdGenerator,
+        mockMaterialRepo as unknown as MaterialRepository
     );
 }
 
@@ -46,13 +68,17 @@ describe('EtsyReconcileService.createDesignFromListing', () => {
             ...Object.values(mockDesignRepo),
             ...Object.values(mockEtsyClient),
             ...Object.values(mockEtsyConnectionService),
+            ...Object.values(mockMaterialRepo),
             ...Object.values(mockIdGenerator),
         ]) {
             m.mockClear();
         }
         mockEtsyConnectionService.getShopId.mockResolvedValue(47408839);
+        mockEtsyConnectionService.getValidAccessToken.mockResolvedValue('access-token');
         mockIdGenerator.generate.mockReturnValue('new-design-1');
         mockDesignRepo.getByUserId.mockResolvedValue([]);
+        mockMaterialRepo.getByUserId.mockResolvedValue([]);
+        mockEtsyClient.getListingInventory.mockResolvedValue({ products: [] });
         mockEtsyClient.getShopListingsActive.mockResolvedValue([
             { listingId: 555, title: 'Silver Ring', price: 25, url: 'https://etsy.com/555' },
         ]);
@@ -99,6 +125,53 @@ describe('EtsyReconcileService.createDesignFromListing', () => {
         expect(result).toEqual({ designId: 'new-design-1' });
         const inserted = mockDesignRepo.insert.mock.calls[0]![0] as Design;
         expect(inserted.description).toBe('<p>Line one.<br>Line two.</p><p>Second paragraph.</p>');
+    });
+
+    it('imports variations for property values that match an existing material by name', async () => {
+        let counter = 0;
+        mockIdGenerator.generate.mockImplementation(() => `id-${++counter}`);
+        mockMaterialRepo.getByUserId.mockResolvedValue([
+            makeMaterial({ id: 'material-red', name: 'Red' }),
+            makeMaterial({ id: 'material-blue', name: 'Blue' }),
+        ]);
+        mockEtsyClient.getListingInventory.mockResolvedValue({
+            products: [
+                {
+                    offerings: [{ price: 20, quantity: 3, isEnabled: true }],
+                    propertyValues: [{ propertyName: 'Color', values: ['Red'] }],
+                },
+                {
+                    offerings: [{ price: 22, quantity: 2, isEnabled: true }],
+                    propertyValues: [{ propertyName: 'Color', values: ['Blue'] }],
+                },
+                {
+                    // "Green" has no matching material in the catalogue and must be dropped.
+                    offerings: [{ price: 24, quantity: 1, isEnabled: true }],
+                    propertyValues: [{ propertyName: 'Color', values: ['Green'] }],
+                },
+            ],
+        });
+
+        await makeService().createDesignFromListing(555, 'user-1');
+
+        const inserted = mockDesignRepo.insert.mock.calls[0]![0] as Design;
+        expect(inserted.variationGroups).toHaveLength(1);
+        expect(inserted.variationGroups![0].name).toBe('Color');
+        expect(inserted.variationGroups![0].options.map((o) => o.material.name)).toEqual(['Red', 'Blue']);
+        expect(inserted.variants).toHaveLength(2);
+        expect(inserted.variants!.map((v) => v.name)).toEqual(['Red', 'Blue']);
+        expect(inserted.variants!.map((v) => v.price)).toEqual([20, 22]);
+    });
+
+    it('does not fail design creation when the inventory fetch errors', async () => {
+        mockEtsyClient.getListingInventory.mockRejectedValue(new Error('no inventory record'));
+
+        const result = await makeService().createDesignFromListing(555, 'user-1');
+
+        expect(result).toEqual({ designId: 'new-design-1' });
+        const inserted = mockDesignRepo.insert.mock.calls[0]![0] as Design;
+        expect(inserted.variationGroups).toBeUndefined();
+        expect(inserted.variants).toBeUndefined();
     });
 
     it('rejects with 400 when the listing is not in the shop', async () => {

--- a/packages/api/src/domain/EtsyReconcileService/index.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.ts
@@ -1,18 +1,40 @@
 import { APIError } from '@imapps/api-utils/hono';
-import { type Design, plainTextToHtml } from '@jewellery-catalogue/types';
+import { type Design, type DesignVariant, plainTextToHtml, type VariationGroup } from '@jewellery-catalogue/types';
 
 import type { DesignRepository } from '../DesignRepository';
 import type { EtsyClient } from '../EtsyClient';
 import type { EtsyConnectionService } from '../EtsyConnectionService';
 import type { IdGenerator } from '../IdGenerator';
+import type { MaterialRepository } from '../MaterialRepository';
+import { mapEtsyInventoryToVariations } from './mappers';
 
 export class EtsyReconcileService {
     constructor(
         private readonly designRepo: DesignRepository,
         private readonly etsyClient: EtsyClient,
         private readonly etsyConnectionService: EtsyConnectionService,
-        private readonly idGenerator: IdGenerator
+        private readonly idGenerator: IdGenerator,
+        private readonly materialRepo: MaterialRepository
     ) {}
+
+    // Best-effort: a listing may have no inventory record at all (Etsy 404s), or the
+    // token may lack scope — either way this must never block design creation itself.
+    private async importVariations(
+        listingId: number,
+        userId: string
+    ): Promise<{ variationGroups: VariationGroup[]; variants: DesignVariant[] }> {
+        try {
+            const [accessToken, materials] = await Promise.all([
+                this.etsyConnectionService.getValidAccessToken(userId),
+                this.materialRepo.getByUserId(userId),
+            ]);
+            const inventory = await this.etsyClient.getListingInventory(accessToken, listingId);
+            const { variationGroups, variants } = mapEtsyInventoryToVariations(inventory, materials, this.idGenerator);
+            return { variationGroups, variants };
+        } catch {
+            return { variationGroups: [], variants: [] };
+        }
+    }
 
     // fallow-ignore-next-line unused-class-member
     async createDesignFromListing(listingId: number, userId: string): Promise<{ designId: string }> {
@@ -29,7 +51,10 @@ export class EtsyReconcileService {
             throw new APIError('This listing is already linked to a design', 409);
         }
 
-        const detail = await this.etsyClient.getListingDetail(listingId);
+        const [detail, { variationGroups, variants }] = await Promise.all([
+            this.etsyClient.getListingDetail(listingId),
+            this.importVariations(listingId, userId),
+        ]);
         const designId = this.idGenerator.generate();
 
         const design: Design = {
@@ -46,6 +71,7 @@ export class EtsyReconcileService {
             totalMaterialCosts: 0,
             dateAdded: new Date(),
             totalQuantity: 0,
+            ...(variationGroups.length > 0 ? { variationGroups, variants } : {}),
             etsy: {
                 listingId,
                 state: 'active',

--- a/packages/api/src/domain/EtsyReconcileService/mappers.test.ts
+++ b/packages/api/src/domain/EtsyReconcileService/mappers.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'bun:test';
+import { type Material, MaterialType } from '@jewellery-catalogue/types';
+
+import type { IdGenerator } from '../IdGenerator';
+import { mapEtsyInventoryToVariations } from './mappers';
+
+function makeMaterial(overrides: Partial<Material> = {}): Material {
+    return {
+        type: MaterialType.BEAD,
+        id: 'material-1',
+        userId: 'user-1',
+        name: 'Red',
+        brand: '',
+        purchaseUrl: '',
+        dateAdded: new Date().toISOString(),
+        diameter: 6,
+        colour: 'red',
+        quantityPerPack: 100,
+        pricePerPack: 5,
+        totalQuantity: 100,
+        pricePerBead: 0.05,
+        ...overrides,
+    } as Material;
+}
+
+function makeIdGenerator(): IdGenerator {
+    let counter = 0;
+    return { generate: () => `id-${++counter}` };
+}
+
+describe('mapEtsyInventoryToVariations', () => {
+    it('creates a variation group and variants for matched property values', () => {
+        const materials = [makeMaterial({ id: 'red', name: 'Red' }), makeMaterial({ id: 'blue', name: 'Blue' })];
+        const result = mapEtsyInventoryToVariations(
+            {
+                products: [
+                    {
+                        offerings: [{ price: 20, quantity: 3, isEnabled: true }],
+                        propertyValues: [{ propertyName: 'Color', values: ['Red'] }],
+                    },
+                    {
+                        offerings: [{ price: 22, quantity: 2, isEnabled: true }],
+                        propertyValues: [{ propertyName: 'Color', values: ['Blue'] }],
+                    },
+                ],
+            },
+            materials,
+            makeIdGenerator()
+        );
+
+        expect(result.variationGroups).toHaveLength(1);
+        expect(result.variationGroups[0]!.name).toBe('Color');
+        expect(result.variationGroups[0]!.options).toHaveLength(2);
+        expect(result.variants).toHaveLength(2);
+        expect(result.variants[0]).toMatchObject({ name: 'Red', totalQuantity: 3, price: 20 });
+        expect(result.unmatchedPropertyValues).toEqual([]);
+    });
+
+    it('matches material names case-insensitively and trims whitespace', () => {
+        const materials = [makeMaterial({ id: 'red', name: '  red  ' })];
+        const result = mapEtsyInventoryToVariations(
+            {
+                products: [
+                    {
+                        offerings: [{ price: 20, quantity: 3, isEnabled: true }],
+                        propertyValues: [{ propertyName: 'Color', values: ['RED'] }],
+                    },
+                ],
+            },
+            materials,
+            makeIdGenerator()
+        );
+
+        expect(result.variationGroups[0]!.options).toHaveLength(1);
+        expect(result.unmatchedPropertyValues).toEqual([]);
+    });
+
+    it('drops property values with no matching material instead of fabricating one', () => {
+        const result = mapEtsyInventoryToVariations(
+            {
+                products: [
+                    {
+                        offerings: [{ price: 20, quantity: 3, isEnabled: true }],
+                        propertyValues: [{ propertyName: 'Color', values: ['Chartreuse'] }],
+                    },
+                ],
+            },
+            [],
+            makeIdGenerator()
+        );
+
+        expect(result.variationGroups).toEqual([]);
+        expect(result.variants).toEqual([]);
+        expect(result.unmatchedPropertyValues).toEqual(['Color: Chartreuse']);
+    });
+
+    it('drops a variant when only some of its property values matched', () => {
+        const materials = [makeMaterial({ id: 'red', name: 'Red' })];
+        const result = mapEtsyInventoryToVariations(
+            {
+                products: [
+                    {
+                        offerings: [{ price: 20, quantity: 3, isEnabled: true }],
+                        propertyValues: [
+                            { propertyName: 'Color', values: ['Red'] },
+                            { propertyName: 'Size', values: ['XL'] },
+                        ],
+                    },
+                ],
+            },
+            materials,
+            makeIdGenerator()
+        );
+
+        expect(result.variants).toEqual([]);
+        expect(result.unmatchedPropertyValues).toEqual(['Size: XL']);
+    });
+
+    it('returns nothing for a listing with no inventory products', () => {
+        const result = mapEtsyInventoryToVariations({ products: [] }, [], makeIdGenerator());
+
+        expect(result).toEqual({ variationGroups: [], variants: [], unmatchedPropertyValues: [] });
+    });
+});

--- a/packages/api/src/domain/EtsyReconcileService/mappers.ts
+++ b/packages/api/src/domain/EtsyReconcileService/mappers.ts
@@ -1,0 +1,113 @@
+import {
+    type DesignVariant,
+    type Material,
+    MaterialType,
+    type RequiredMaterial,
+    type VariationGroup,
+} from '@jewellery-catalogue/types';
+
+import type { EtsyListingInventory } from '../EtsyClient';
+import type { IdGenerator } from '../IdGenerator';
+
+const DEFAULT_REQUIRED_AMOUNT = 1;
+
+const toRequiredMaterial = (material: Material, amount: number): RequiredMaterial => {
+    switch (material.type) {
+        case MaterialType.WIRE:
+        case MaterialType.CHAIN:
+            return { ...material, requiredLength: amount };
+        case MaterialType.BEAD:
+        case MaterialType.EAR_HOOK:
+            return { ...material, requiredQuantity: amount };
+    }
+};
+
+export interface ImportedVariations {
+    variationGroups: VariationGroup[];
+    variants: DesignVariant[];
+    // Etsy property values (e.g. "Size: XL") that don't match an existing catalogue
+    // material by name, and so couldn't be imported — surfaced for the caller to log.
+    unmatchedPropertyValues: string[];
+}
+
+// Etsy's listing variations are free-text property/value pairs with no link to this
+// catalogue's materials. We can only safely import a value when it matches an
+// existing material's name exactly (case-insensitively) — anything else would mean
+// fabricating a fake material with made-up cost/stock data, so it's skipped instead.
+export const mapEtsyInventoryToVariations = (
+    inventory: EtsyListingInventory,
+    existingMaterials: Material[],
+    idGenerator: IdGenerator
+): ImportedVariations => {
+    const materialByName = new Map(existingMaterials.map((m) => [m.name.trim().toLowerCase(), m]));
+    const groupOptions = new Map<string, Map<string, { id: string; material: RequiredMaterial }>>();
+    const unmatchedPropertyValues: string[] = [];
+
+    for (const product of inventory.products) {
+        for (const propertyValue of product.propertyValues) {
+            let optionsForGroup = groupOptions.get(propertyValue.propertyName);
+            if (!optionsForGroup) {
+                optionsForGroup = new Map();
+                groupOptions.set(propertyValue.propertyName, optionsForGroup);
+            }
+
+            for (const value of propertyValue.values) {
+                if (optionsForGroup.has(value)) continue;
+
+                const material = materialByName.get(value.trim().toLowerCase());
+                if (!material) {
+                    unmatchedPropertyValues.push(`${propertyValue.propertyName}: ${value}`);
+                    continue;
+                }
+
+                optionsForGroup.set(value, {
+                    id: idGenerator.generate(),
+                    material: toRequiredMaterial(material, DEFAULT_REQUIRED_AMOUNT),
+                });
+            }
+        }
+    }
+
+    const variationGroups: VariationGroup[] = Array.from(groupOptions.entries())
+        .filter(([, options]) => options.size > 0)
+        .map(([propertyName, options]) => ({
+            id: idGenerator.generate(),
+            name: propertyName,
+            required: 1,
+            options: Array.from(options.values()),
+        }));
+
+    const variants: DesignVariant[] = [];
+    for (const product of inventory.products) {
+        const optionIds: string[] = [];
+        const nameParts: string[] = [];
+        let allMatched = product.propertyValues.length > 0;
+
+        for (const propertyValue of product.propertyValues) {
+            const value = propertyValue.values[0];
+            const option = value === undefined ? undefined : groupOptions.get(propertyValue.propertyName)?.get(value);
+            if (!option) {
+                allMatched = false;
+                break;
+            }
+            optionIds.push(option.id);
+            nameParts.push(value);
+        }
+
+        if (!allMatched) continue;
+
+        const offering = product.offerings.find((o) => o.isEnabled) ?? product.offerings[0];
+        if (!offering) continue;
+
+        variants.push({
+            id: idGenerator.generate(),
+            optionIds,
+            name: nameParts.join(' / '),
+            totalQuantity: offering.quantity,
+            totalMaterialCosts: 0,
+            price: offering.price,
+        });
+    }
+
+    return { variationGroups, variants, unmatchedPropertyValues };
+};

--- a/packages/web/tests/e2e/startpage.spec.ts
+++ b/packages/web/tests/e2e/startpage.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { waitForAuthServices } from './utils/auth-helpers';
 
 test.describe('Given Start Page', () => {
-    test('When the start page is loaded', async ({ page }) => {
+    test('When the start page is loaded @smoke', async ({ page }) => {
         await page.goto('/');
 
         await page.waitForLoadState('networkidle');
@@ -21,7 +21,7 @@ test.describe('Given Start Page', () => {
         await expect(page.locator('body')).not.toContainText('Something went wrong');
     });
 
-    test('should verify page loads without console errors', async ({ page }) => {
+    test('should verify page loads without console errors @smoke', async ({ page }) => {
         const consoleErrors: Array<string> = [];
         const networkErrors: Array<string> = [];
 


### PR DESCRIPTION
## Summary
- `EtsyReconcileService.createDesignFromListing` never touched variations at all (`materials` always `[]`, no `variationGroups`/`variants`) despite the listing possibly having size/color/etc. options on Etsy.
- Fetch the listing's Etsy inventory record (`getListingInventory`, needs `listings_r`, already in our OAuth scopes) and map each property/value pair (e.g. `Color: Red`) onto an existing catalogue material by exact case-insensitive name match, building `variationGroups`/`variants` from the matches.
- Etsy variation values are free text with no link to this catalogue's materials — a value that doesn't match an existing material name is dropped rather than fabricating a fake material with made-up cost/stock data (documented in `mapEtsyInventoryToVariations`). A whole product/variant is dropped if any of its property values didn't match.
- Inventory-fetch failures (e.g. a listing with no inventory record, which Etsy 404s, or a token missing scope) degrade to no variations rather than blocking design creation — verified by a dedicated test.
- Scoped to the create-from-listing path only, not link-existing-design, to avoid overwriting an existing design's own variation data.

## Test plan
- [x] `bun run --filter @jewellery-catalogue/api test EtsyReconcileService` — new tests for matched/unmatched property values, partial-match variant dropping, and inventory-fetch-failure graceful degrade
- [x] `bun test` on the new `mappers.test.ts` (matching, case-insensitivity, unmatched drop, partial-match drop, empty input)
- [x] `bun run tsc --noEmit`, `bun run lint`
- [x] Relying on CI's `e2e` job as the local-e2e gate per the updated loop policy (no app-behavior/UI change in this PR; existing e2e suite is the regression check).