### PR TITLE
fix: wrap design card title instead of growing the card unbounded

### DIFF
--- a/packages/web/src/components/DesignCard/index.tsx
+++ b/packages/web/src/components/DesignCard/index.tsx
@@ -76,7 +76,7 @@ export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated 
             <Item
                 key={id}
                 variant="outline"
-                className="w-fit max-w-max flex-col items-start bg-card relative cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02]"
+                className="w-64 flex-col items-start bg-card relative cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02]"
                 onClick={handleCardClick}
             >
                 <div className="absolute top-2 right-2 z-10 flex gap-1">
@@ -108,7 +108,7 @@ export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated 
                     </div>
                 </ItemHeader>
                 <ItemContent className="flex-none items-start text-left w-full">
-                    <ItemTitle className="text-lg font-semibold">{name}</ItemTitle>
+                    <ItemTitle className="text-lg font-semibold w-full whitespace-normal break-words">{name}</ItemTitle>
                     <ItemFooter className="flex items-center gap-1 w-full">
                         <div className="flex items-center justify-between w-full">
                             <div className="flex items-center gap-1">

--- a/packages/web/src/pages/Designs/index.tsx
+++ b/packages/web/src/pages/Designs/index.tsx
@@ -54,7 +54,7 @@ const DraftCard: React.FC<{ draft: Draft; onDeleted: () => void }> = ({ draft, o
         <>
             <Item
                 variant="outline"
-                className="w-fit max-w-max flex-col items-start bg-card relative cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02]"
+                className="w-64 flex-col items-start bg-card relative cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02]"
                 onClick={handleCardClick}
             >
                 <div className="absolute top-2 right-2 z-10 flex gap-1">
@@ -80,7 +80,9 @@ const DraftCard: React.FC<{ draft: Draft; onDeleted: () => void }> = ({ draft, o
                             Draft
                         </Badge>
                     </div>
-                    <ItemTitle className="text-lg font-semibold">{draft.name}</ItemTitle>
+                    <ItemTitle className="text-lg font-semibold w-full whitespace-normal break-words">
+                        {draft.name}
+                    </ItemTitle>
                     <ItemFooter className="flex items-center gap-1 w-full">
                         <span className="text-xs text-muted-foreground">
                             {new Date(draft.updatedAt).toLocaleString()}

--- a/packages/web/tests/e2e/design-inventory.spec.ts
+++ b/packages/web/tests/e2e/design-inventory.spec.ts
@@ -17,6 +17,30 @@ test.describe
             await expect(page.getByText('Listed Design')).toBeVisible({ timeout: 10000 });
         });
 
+        test('long design title wraps instead of overflowing the card', async ({ authenticatedPage: page }) => {
+            const longName = 'A Very Long Design Title That Should Wrap Onto Multiple Lines Instead Of Overflowing';
+            await apiCreateDesign(TOKEN, { name: longName, price: 5.0 });
+
+            await page.goto('/designs');
+            await page.waitForLoadState('networkidle');
+
+            const title = page.locator('[data-slot="item-title"]').filter({ hasText: longName });
+            await expect(title).toBeVisible({ timeout: 10000 });
+
+            const card = page.locator('[data-slot="item"]').filter({ has: title });
+            const cardBox = await card.boundingBox();
+            const titleBox = await title.boundingBox();
+
+            expect(cardBox).not.toBeNull();
+            expect(titleBox).not.toBeNull();
+            // The card stays a fixed width instead of growing to fit the long title on one line.
+            expect(cardBox!.width).toBeLessThan(300);
+            // The title wraps within the card instead of overflowing sideways past it.
+            expect(titleBox!.width).toBeLessThanOrEqual(cardBox!.width);
+            // Wrapped onto more than one line, so it's taller than a single line of this text would be.
+            expect(titleBox!.height).toBeGreaterThan(20);
+        });
+
         test('delete design from designs page', async ({ authenticatedPage: page }) => {
             await apiCreateDesign(TOKEN, { name: 'Deletable Design', price: 2.0 });
 


### PR DESCRIPTION
## Summary
- `DesignCard` and the design-drafts card on the Designs page both used `w-fit max-w-max` on the card container, and the `Item` UI kit's `ItemTitle` defaults to `w-fit` — so a long design/draft name grew the whole card wider instead of wrapping, breaking the card grid.
- Give both cards a consistent fixed width (`w-64`, matching the 256px image) and override the title to `w-full whitespace-normal break-words` so long titles wrap onto multiple lines within that width instead.

## Test plan
- [x] New e2e spec `long design title wraps instead of overflowing the card` (design-inventory.spec.ts) — creates a design with a long name and asserts the card stays under a fixed width while the title wraps (height > one line) instead of overflowing sideways
- [x] Ran the full `design-inventory.spec.ts` file locally — 5/5 passing
- [x] `bun run tsc --noEmit`, `bun run lint`
- [x] Relying on CI's `e2e` job for the full-suite gate per the updated loop policy