### PR TITLE
feat: add search to Etsy Listings page

### DIFF
--- a/packages/web/src/components/MainLayout/index.tsx
+++ b/packages/web/src/components/MainLayout/index.tsx
@@ -24,6 +24,7 @@ const MainLayoutContent = ({ children }: MainLayoutProps) => {
     const { status: draftStatus } = useDraftStatus();
     const isDesignsPage = location.pathname === '/designs';
     const isMaterialsPage = location.pathname === '/materials';
+    const isListingsPage = location.pathname === '/listings';
     const isViewDesignPage = location.pathname.startsWith('/designs/') && location.pathname !== '/designs';
 
     useEffect(() => {
@@ -59,12 +60,18 @@ const MainLayoutContent = ({ children }: MainLayoutProps) => {
                             )}
                         </span>
                     )}
-                    {(isDesignsPage || isMaterialsPage) && (
+                    {(isDesignsPage || isMaterialsPage || isListingsPage) && (
                         <div className="relative max-w-md">
                             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                             <Input
                                 type="text"
-                                placeholder={isDesignsPage ? 'Search designs...' : 'Search materials...'}
+                                placeholder={
+                                    isDesignsPage
+                                        ? 'Search designs...'
+                                        : isMaterialsPage
+                                          ? 'Search materials...'
+                                          : 'Search listings...'
+                                }
                                 value={searchQuery}
                                 onChange={handleSearchChange}
                                 className="pl-9 bg-card"

--- a/packages/web/src/pages/Listings/index.tsx
+++ b/packages/web/src/pages/Listings/index.tsx
@@ -1,5 +1,6 @@
+import Fuse from 'fuse.js';
 import { ExternalLink, ShoppingBag } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LinkDesignDialog } from '../../components/LinkDesignDialog';
 import LoadingScreen from '../../components/Loading';
@@ -7,6 +8,7 @@ import { Button } from '../../components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
 import { SETTINGS_PAGE, VIEW_DESIGN_PAGE } from '../../constants/routes';
+import { useSearch } from '../../context/SearchContext';
 import { useEtsyConnection } from '../../hooks/useEtsyConnection';
 import { useEtsyListings } from '../../hooks/useEtsyListings';
 import { useEtsyReconcile } from '../../hooks/useEtsyReconcile';
@@ -17,6 +19,17 @@ const Listings = () => {
     const navigate = useNavigate();
     const { createFromListing, isCreating } = useEtsyReconcile();
     const [linkDialogListingId, setLinkDialogListingId] = useState<number | null>(null);
+    const { searchQuery } = useSearch();
+
+    const fuse = useMemo(() => {
+        return new Fuse(listings, {
+            keys: ['title'],
+            threshold: 0.4,
+            includeScore: true,
+        });
+    }, [listings]);
+
+    const filteredListings = searchQuery ? fuse.search(searchQuery).map((result) => result.item) : listings;
 
     const handleCreate = async (listingId: number) => {
         const { designId } = await createFromListing(listingId);
@@ -74,6 +87,16 @@ const Listings = () => {
                         <EmptyDescription>Your shop has no active Etsy listings right now.</EmptyDescription>
                     </EmptyHeader>
                 </Empty>
+            ) : filteredListings.length === 0 ? (
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                            <ShoppingBag />
+                        </EmptyMedia>
+                        <EmptyTitle>No Matching Listings</EmptyTitle>
+                        <EmptyDescription>Try adjusting your search query.</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
             ) : (
                 <Table>
                     <TableHeader>
@@ -85,7 +108,7 @@ const Listings = () => {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {listings.map((listing) => (
+                        {filteredListings.map((listing) => (
                             <TableRow key={listing.listingId}>
                                 <TableCell className="font-medium">{listing.title}</TableCell>
                                 <TableCell>£{listing.price.toFixed(2)}</TableCell>

--- a/packages/web/tests/e2e/listings.spec.ts
+++ b/packages/web/tests/e2e/listings.spec.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { MOCK_TOKEN_LISTINGS } from './mocks/auth';
+
+const TOKEN = MOCK_TOKEN_LISTINGS;
+
+test.use({ authToken: TOKEN });
+
+const LISTINGS = [
+    {
+        listingId: 1,
+        title: 'Silver Moon Pendant Necklace',
+        price: 24.99,
+        url: 'https://etsy.com/listing/1',
+        linkedDesignId: null,
+    },
+    { listingId: 2, title: 'Gold Hoop Earrings', price: 18.5, url: 'https://etsy.com/listing/2', linkedDesignId: null },
+    {
+        listingId: 3,
+        title: 'Beaded Charm Bracelet',
+        price: 12.0,
+        url: 'https://etsy.com/listing/3',
+        linkedDesignId: null,
+    },
+];
+
+async function mockConnectedListings(page: Page) {
+    await page.route('**/api/etsy/connection', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ connected: true }) })
+    );
+    await page.route('**/api/etsy/listings', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(LISTINGS) })
+    );
+}
+
+test.describe('Etsy Listings search', () => {
+    test('search filters listings by title, clearing restores full list @smoke', async ({
+        authenticatedPage: page,
+    }) => {
+        await mockConnectedListings(page);
+
+        await page.goto('/listings');
+        await page.waitForLoadState('networkidle');
+
+        for (const listing of LISTINGS) {
+            await expect(page.getByText(listing.title)).toBeVisible({ timeout: 10000 });
+        }
+
+        await page.getByPlaceholder('Search listings...').fill('Hoop');
+
+        await expect(page.getByText('Gold Hoop Earrings')).toBeVisible();
+        await expect(page.getByText('Silver Moon Pendant Necklace')).not.toBeVisible();
+        await expect(page.getByText('Beaded Charm Bracelet')).not.toBeVisible();
+
+        await page.getByPlaceholder('Search listings...').fill('');
+
+        for (const listing of LISTINGS) {
+            await expect(page.getByText(listing.title)).toBeVisible({ timeout: 10000 });
+        }
+    });
+
+    test('search with no matches shows empty state', async ({ authenticatedPage: page }) => {
+        await mockConnectedListings(page);
+
+        await page.goto('/listings');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByPlaceholder('Search listings...').fill('nonexistent listing xyz');
+
+        await expect(page.getByText('No Matching Listings')).toBeVisible({ timeout: 10000 });
+    });
+});

--- a/packages/web/tests/e2e/mocks/auth.ts
+++ b/packages/web/tests/e2e/mocks/auth.ts
@@ -15,6 +15,7 @@ export function makeMockToken(userId: string, username = 'testuser'): string {
 export const MOCK_TOKEN = makeMockToken('68c6f0f5b97c946129015116'); // materials-designs.spec
 export const MOCK_TOKEN_MATERIALS_CRUD = makeMockToken('68c6f0f5b97c946129015119'); // materials-crud.spec
 export const MOCK_TOKEN_DESIGN_INVENTORY = makeMockToken('68c6f0f5b97c946129015120'); // design-inventory.spec
+export const MOCK_TOKEN_LISTINGS = makeMockToken('68c6f0f5b97c946129015121'); // listings.spec
 
 export const MOCK_USER = { id: '68c6f0f5b97c946129015116', username: 'testuser' };
 


### PR DESCRIPTION
Wires the existing header search box (already used on Designs/Materials pages)
into the Etsy Listings page, filtering listings by title via Fuse.js.

## Test plan
- New Playwright spec `listings.spec.ts` (mocks `/api/etsy/connection` and
  `/api/etsy/listings`, since real Etsy calls aren't available in CI): search
  filters by title and clearing restores the full list; no-match search shows
  the empty state.