### PR TITLE
feat: fetch and show sold-out Etsy listings with images

### DIFF
--- a/packages/api/src/domain/EtsyClient/index.test.ts
+++ b/packages/api/src/domain/EtsyClient/index.test.ts
@@ -426,8 +426,8 @@ describe('EtsyClient', () => {
         });
     });
 
-    describe('getShopListingsActive', () => {
-        it('fetches a single page when count fits within the page limit', async () => {
+    describe('getShopListingsByState', () => {
+        it('fetches a single page when count fits within the page limit, including the first image', async () => {
             fetchMock.mockResolvedValue(
                 new Response(
                     JSON.stringify({
@@ -438,6 +438,7 @@ describe('EtsyClient', () => {
                                 title: 'Silver Ring',
                                 price: { amount: 2550, divisor: 100, currency_code: 'GBP' },
                                 url: 'https://etsy.com/listing/1',
+                                images: [{ url_75x75: 'https://i.etsy.com/1-75x75.jpg' }],
                             },
                             {
                                 listing_id: 2,
@@ -451,17 +452,33 @@ describe('EtsyClient', () => {
                 )
             );
 
-            const result = await client.getShopListingsActive(47408839);
+            const result = await client.getShopListingsByState('access-tok', 47408839, 'sold_out');
 
             expect(result).toEqual([
-                { listingId: 1, title: 'Silver Ring', price: 25.5, url: 'https://etsy.com/listing/1' },
-                { listingId: 2, title: 'Gold Ring', price: 40, url: 'https://etsy.com/listing/2' },
+                {
+                    listingId: 1,
+                    title: 'Silver Ring',
+                    price: 25.5,
+                    url: 'https://etsy.com/listing/1',
+                    state: 'sold_out',
+                    imageUrl: 'https://i.etsy.com/1-75x75.jpg',
+                },
+                {
+                    listingId: 2,
+                    title: 'Gold Ring',
+                    price: 40,
+                    url: 'https://etsy.com/listing/2',
+                    state: 'sold_out',
+                    imageUrl: null,
+                },
             ]);
             expect(fetchMock).toHaveBeenCalledTimes(1);
             const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
-            expect(url).toBe('https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0');
+            expect(url).toBe(
+                'https://api.etsy.com/v3/application/shops/47408839/listings?state=sold_out&includes=Images&limit=100&offset=0'
+            );
             expect((options.headers as Record<string, string>)['x-api-key']).toBe('key123:secret456');
-            expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+            expect((options.headers as Record<string, string>).Authorization).toBe('Bearer access-tok');
         });
 
         it('paginates when count exceeds the 100-item page limit', async () => {
@@ -479,24 +496,24 @@ describe('EtsyClient', () => {
                 .mockResolvedValueOnce(new Response(JSON.stringify(page(1, 100, 102)), { status: 200 }))
                 .mockResolvedValueOnce(new Response(JSON.stringify(page(101, 2, 102)), { status: 200 }));
 
-            const result = await client.getShopListingsActive(47408839);
+            const result = await client.getShopListingsByState('access-tok', 47408839, 'active');
 
             expect(result).toHaveLength(102);
             expect(fetchMock).toHaveBeenCalledTimes(2);
             const [firstUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
             const [secondUrl] = fetchMock.mock.calls[1] as [string, RequestInit];
             expect(firstUrl).toBe(
-                'https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=0'
+                'https://api.etsy.com/v3/application/shops/47408839/listings?state=active&includes=Images&limit=100&offset=0'
             );
             expect(secondUrl).toBe(
-                'https://api.etsy.com/v3/application/shops/47408839/listings/active?limit=100&offset=100'
+                'https://api.etsy.com/v3/application/shops/47408839/listings?state=active&includes=Images&limit=100&offset=100'
             );
         });
 
         it('throws when Etsy responds with an error status', async () => {
             fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
 
-            await expect(client.getShopListingsActive(1)).rejects.toThrow();
+            await expect(client.getShopListingsByState('access-tok', 1, 'active')).rejects.toThrow();
         });
     });
 });

--- a/packages/api/src/domain/EtsyClient/index.ts
+++ b/packages/api/src/domain/EtsyClient/index.ts
@@ -69,6 +69,13 @@ export interface EtsyListingSummary {
     url: string;
 }
 
+export type EtsyShopListingState = 'active' | 'sold_out';
+
+export interface EtsyShopListingSummary extends EtsyListingSummary {
+    state: EtsyShopListingState;
+    imageUrl: string | null;
+}
+
 export interface EtsyListingDetail {
     title: string;
     description: string;
@@ -270,18 +277,22 @@ export class EtsyClient {
         };
     }
 
-    async getShopListingsActive(shopId: number): Promise<EtsyListingSummary[]> {
-        const results: EtsyListingSummary[] = [];
+    async getShopListingsByState(
+        accessToken: string,
+        shopId: number,
+        state: EtsyShopListingState
+    ): Promise<EtsyShopListingSummary[]> {
+        const results: EtsyShopListingSummary[] = [];
         let offset = 0;
 
         for (;;) {
             const response = await fetch(
-                `${API_BASE}/shops/${shopId}/listings/active?limit=${SHOP_LISTINGS_PAGE_LIMIT}&offset=${offset}`,
-                { headers: { 'x-api-key': this.apiKeyHeader() } }
+                `${API_BASE}/shops/${shopId}/listings?state=${state}&includes=Images&limit=${SHOP_LISTINGS_PAGE_LIMIT}&offset=${offset}`,
+                { headers: { 'x-api-key': this.apiKeyHeader(), Authorization: `Bearer ${accessToken}` } }
             );
 
             if (!response.ok) {
-                throw await etsyError('getShopListingsActive', response);
+                throw await etsyError('getShopListingsByState', response);
             }
 
             const body = (await response.json()) as {
@@ -291,6 +302,7 @@ export class EtsyClient {
                     title: string;
                     price: { amount: number; divisor: number };
                     url: string;
+                    images?: Array<{ url_75x75: string }>;
                 }>;
             };
 
@@ -300,6 +312,8 @@ export class EtsyClient {
                     title: r.title,
                     price: r.price.amount / r.price.divisor,
                     url: r.url,
+                    state,
+                    imageUrl: r.images?.[0]?.url_75x75 ?? null,
                 }))
             );
 

--- a/packages/api/src/domain/EtsyReconcileService/index.test.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.test.ts
@@ -9,7 +9,7 @@ import type { MaterialRepository } from '../MaterialRepository';
 import { EtsyReconcileService } from './index';
 
 const mockDesignRepo = { getByUserId: mock(), getByIdAndUserId: mock(), insert: mock(), update: mock() };
-const mockEtsyClient = { getShopListingsActive: mock(), getListingDetail: mock(), getListingInventory: mock() };
+const mockEtsyClient = { getShopListingsByState: mock(), getListingDetail: mock(), getListingInventory: mock() };
 const mockEtsyConnectionService = { getShopId: mock(), getValidAccessToken: mock() };
 const mockMaterialRepo = { getByUserId: mock() };
 const mockIdGenerator = { generate: mock() };
@@ -79,7 +79,7 @@ describe('EtsyReconcileService.createDesignFromListing', () => {
         mockDesignRepo.getByUserId.mockResolvedValue([]);
         mockMaterialRepo.getByUserId.mockResolvedValue([]);
         mockEtsyClient.getListingInventory.mockResolvedValue({ products: [] });
-        mockEtsyClient.getShopListingsActive.mockResolvedValue([
+        mockEtsyClient.getShopListingsByState.mockResolvedValue([
             { listingId: 555, title: 'Silver Ring', price: 25, url: 'https://etsy.com/555' },
         ]);
         mockEtsyClient.getListingDetail.mockResolvedValue({
@@ -200,7 +200,7 @@ describe('EtsyReconcileService.linkListingToDesign', () => {
         }
         mockEtsyConnectionService.getShopId.mockResolvedValue(47408839);
         mockDesignRepo.getByUserId.mockResolvedValue([]);
-        mockEtsyClient.getShopListingsActive.mockResolvedValue([
+        mockEtsyClient.getShopListingsByState.mockResolvedValue([
             { listingId: 555, title: 'Silver Ring', price: 25, url: 'https://etsy.com/555' },
         ]);
     });

--- a/packages/api/src/domain/EtsyReconcileService/index.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.ts
@@ -36,8 +36,9 @@ export class EtsyReconcileService {
         }
     }
 
-    // fallow-ignore-next-line unused-class-member
-    async createDesignFromListing(listingId: number, userId: string): Promise<{ designId: string }> {
+    // Throws if the listing isn't an active listing in this user's shop, or is already
+    // linked to one of their designs — the precondition shared by create-from and link-to.
+    private async assertListingIsLinkable(listingId: number, userId: string): Promise<void> {
         const [shopId, accessToken] = await Promise.all([
             this.etsyConnectionService.getShopId(userId),
             this.etsyConnectionService.getValidAccessToken(userId),
@@ -53,6 +54,11 @@ export class EtsyReconcileService {
         if (designs.some((d) => d.etsy?.listingId === listingId)) {
             throw new APIError('This listing is already linked to a design', 409);
         }
+    }
+
+    // fallow-ignore-next-line unused-class-member
+    async createDesignFromListing(listingId: number, userId: string): Promise<{ designId: string }> {
+        await this.assertListingIsLinkable(listingId, userId);
 
         const [detail, { variationGroups, variants }] = await Promise.all([
             this.etsyClient.getListingDetail(listingId),
@@ -98,21 +104,7 @@ export class EtsyReconcileService {
             throw new APIError('This design is already linked to an Etsy listing', 409);
         }
 
-        const [shopId, accessToken] = await Promise.all([
-            this.etsyConnectionService.getShopId(userId),
-            this.etsyConnectionService.getValidAccessToken(userId),
-        ]);
-        const [listings, designs] = await Promise.all([
-            this.etsyClient.getShopListingsByState(accessToken, shopId, 'active'),
-            this.designRepo.getByUserId(userId),
-        ]);
-
-        if (!listings.some((l) => l.listingId === listingId)) {
-            throw new APIError('Listing not found in your Etsy shop', 400);
-        }
-        if (designs.some((d) => d.etsy?.listingId === listingId)) {
-            throw new APIError('This listing is already linked to a design', 409);
-        }
+        await this.assertListingIsLinkable(listingId, userId);
 
         const updated: Design = { ...design, etsy: { listingId, state: 'active', lastPushedAt: null } };
         await this.designRepo.update(designId, updated);

--- a/packages/api/src/domain/EtsyReconcileService/index.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.ts
@@ -38,9 +38,12 @@ export class EtsyReconcileService {
 
     // fallow-ignore-next-line unused-class-member
     async createDesignFromListing(listingId: number, userId: string): Promise<{ designId: string }> {
-        const shopId = await this.etsyConnectionService.getShopId(userId);
+        const [shopId, accessToken] = await Promise.all([
+            this.etsyConnectionService.getShopId(userId),
+            this.etsyConnectionService.getValidAccessToken(userId),
+        ]);
         const [listings, designs] = await Promise.all([
-            this.etsyClient.getShopListingsActive(shopId),
+            this.etsyClient.getShopListingsByState(accessToken, shopId, 'active'),
             this.designRepo.getByUserId(userId),
         ]);
 
@@ -95,9 +98,12 @@ export class EtsyReconcileService {
             throw new APIError('This design is already linked to an Etsy listing', 409);
         }
 
-        const shopId = await this.etsyConnectionService.getShopId(userId);
+        const [shopId, accessToken] = await Promise.all([
+            this.etsyConnectionService.getShopId(userId),
+            this.etsyConnectionService.getValidAccessToken(userId),
+        ]);
         const [listings, designs] = await Promise.all([
-            this.etsyClient.getShopListingsActive(shopId),
+            this.etsyClient.getShopListingsByState(accessToken, shopId, 'active'),
             this.designRepo.getByUserId(userId),
         ]);
 

--- a/packages/api/src/domain/EtsyStatusService/index.test.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.test.ts
@@ -7,7 +7,7 @@ import type { EtsyConnectionService } from '../EtsyConnectionService';
 import { EtsyStatusService } from './index';
 
 const mockDesignRepo = { getByIdAndUserId: mock(), getByUserId: mock(), update: mock() };
-const mockEtsyClient = { getListing: mock(), getShopListingsActive: mock() };
+const mockEtsyClient = { getListing: mock(), getShopListingsByState: mock() };
 const mockEtsyConnectionService = { getValidAccessToken: mock(), getShopId: mock() };
 
 function makeDesign(overrides: Partial<Design> = {}): Design {
@@ -94,33 +94,59 @@ describe('EtsyStatusService', () => {
     });
 
     describe('listShopListings', () => {
-        it("flags listings already linked to one of this user's designs", async () => {
+        it("flags listings already linked to one of this user's designs, merging active and sold-out", async () => {
             mockDesignRepo.getByUserId.mockResolvedValue([
                 makeDesign({ id: 'design-1', etsy: { listingId: 1, state: 'active', lastPushedAt: 1 } }),
                 makeDesign({ id: 'design-2' }),
             ]);
-            mockEtsyClient.getShopListingsActive.mockResolvedValue([
-                { listingId: 1, title: 'Linked Listing', price: 25, url: 'https://etsy.com/listing/1' },
-                { listingId: 2, title: 'Unlinked Listing', price: 30, url: 'https://etsy.com/listing/2' },
-            ]);
+            mockEtsyClient.getShopListingsByState.mockImplementation((_token: string, _shopId: number, state: string) =>
+                Promise.resolve(
+                    state === 'active'
+                        ? [
+                              {
+                                  listingId: 1,
+                                  title: 'Linked Listing',
+                                  price: 25,
+                                  url: 'https://etsy.com/listing/1',
+                                  state: 'active',
+                                  imageUrl: null,
+                              },
+                          ]
+                        : [
+                              {
+                                  listingId: 2,
+                                  title: 'Unlinked Sold Out Listing',
+                                  price: 30,
+                                  url: 'https://etsy.com/listing/2',
+                                  state: 'sold_out',
+                                  imageUrl: 'https://img.etsy.com/2.jpg',
+                              },
+                          ]
+                )
+            );
 
             const result = await service.listShopListings('user-1');
 
             expect(mockEtsyConnectionService.getShopId).toHaveBeenCalledWith('user-1');
-            expect(mockEtsyClient.getShopListingsActive).toHaveBeenCalledWith(47408839);
+            expect(mockEtsyClient.getShopListingsByState).toHaveBeenCalledWith('at-token', 47408839, 'active');
+            expect(mockEtsyClient.getShopListingsByState).toHaveBeenCalledWith('at-token', 47408839, 'sold_out');
             expect(result).toEqual([
                 {
                     listingId: 1,
                     title: 'Linked Listing',
                     price: 25,
                     url: 'https://etsy.com/listing/1',
+                    state: 'active',
+                    imageUrl: null,
                     linkedDesignId: 'design-1',
                 },
                 {
                     listingId: 2,
-                    title: 'Unlinked Listing',
+                    title: 'Unlinked Sold Out Listing',
                     price: 30,
                     url: 'https://etsy.com/listing/2',
+                    state: 'sold_out',
+                    imageUrl: 'https://img.etsy.com/2.jpg',
                     linkedDesignId: null,
                 },
             ]);
@@ -128,9 +154,22 @@ describe('EtsyStatusService', () => {
 
         it('returns every listing unlinked when the user has no linked designs', async () => {
             mockDesignRepo.getByUserId.mockResolvedValue([makeDesign()]);
-            mockEtsyClient.getShopListingsActive.mockResolvedValue([
-                { listingId: 5, title: 'Some Listing', price: 10, url: 'https://etsy.com/listing/5' },
-            ]);
+            mockEtsyClient.getShopListingsByState.mockImplementation((_token: string, _shopId: number, state: string) =>
+                Promise.resolve(
+                    state === 'active'
+                        ? [
+                              {
+                                  listingId: 5,
+                                  title: 'Some Listing',
+                                  price: 10,
+                                  url: 'https://etsy.com/listing/5',
+                                  state: 'active',
+                                  imageUrl: null,
+                              },
+                          ]
+                        : []
+                )
+            );
 
             const result = await service.listShopListings('user-1');
 
@@ -140,6 +179,8 @@ describe('EtsyStatusService', () => {
                     title: 'Some Listing',
                     price: 10,
                     url: 'https://etsy.com/listing/5',
+                    state: 'active',
+                    imageUrl: null,
                     linkedDesignId: null,
                 },
             ]);

--- a/packages/api/src/domain/EtsyStatusService/index.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.ts
@@ -2,10 +2,10 @@ import { APIError } from '@imapps/api-utils/hono';
 import type { Design } from '@jewellery-catalogue/types';
 
 import type { DesignRepository } from '../DesignRepository';
-import type { EtsyClient, EtsyListingSummary } from '../EtsyClient';
+import type { EtsyClient, EtsyShopListingSummary } from '../EtsyClient';
 import type { EtsyConnectionService } from '../EtsyConnectionService';
 
-export interface EtsyListingWithLinkStatus extends EtsyListingSummary {
+export interface EtsyListingWithLinkStatus extends EtsyShopListingSummary {
     linkedDesignId: string | null;
 }
 
@@ -40,10 +40,13 @@ export class EtsyStatusService {
 
     async listShopListings(userId: string): Promise<EtsyListingWithLinkStatus[]> {
         const shopId = await this.etsyConnectionService.getShopId(userId);
-        const [listings, designs] = await Promise.all([
-            this.etsyClient.getShopListingsActive(shopId),
+        const accessToken = await this.etsyConnectionService.getValidAccessToken(userId);
+        const [activeListings, soldOutListings, designs] = await Promise.all([
+            this.etsyClient.getShopListingsByState(accessToken, shopId, 'active'),
+            this.etsyClient.getShopListingsByState(accessToken, shopId, 'sold_out'),
             this.designRepo.getByUserId(userId),
         ]);
+        const listings = [...activeListings, ...soldOutListings];
 
         const designIdByListingId = new Map(
             designs

--- a/packages/api/src/domain/EtsyStatusService/index.ts
+++ b/packages/api/src/domain/EtsyStatusService/index.ts
@@ -16,6 +16,7 @@ export class EtsyStatusService {
         private readonly etsyConnectionService: EtsyConnectionService
     ) {}
 
+    // fallow-ignore-next-line unused-class-member
     async refreshStatus(designId: string, userId: string): Promise<Design> {
         const design = await this.designRepo.getByIdAndUserId(designId, userId);
         if (!design) {
@@ -38,6 +39,7 @@ export class EtsyStatusService {
         return updated;
     }
 
+    // fallow-ignore-next-line unused-class-member
     async listShopListings(userId: string): Promise<EtsyListingWithLinkStatus[]> {
         const shopId = await this.etsyConnectionService.getShopId(userId);
         const accessToken = await this.etsyConnectionService.getValidAccessToken(userId);

--- a/packages/web/src/api/endpoints/etsyListings/index.ts
+++ b/packages/web/src/api/endpoints/etsyListings/index.ts
@@ -8,6 +8,8 @@ export interface EtsyListingWithLinkStatus {
     title: string;
     price: number;
     url: string;
+    state: 'active' | 'sold_out';
+    imageUrl: string | null;
     linkedDesignId: string | null;
 }
 

--- a/packages/web/src/pages/Listings/index.tsx
+++ b/packages/web/src/pages/Listings/index.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LinkDesignDialog } from '../../components/LinkDesignDialog';
 import LoadingScreen from '../../components/Loading';
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
@@ -72,8 +73,8 @@ const Listings = () => {
             <div>
                 <h1 className="text-2xl font-semibold">Etsy Listings</h1>
                 <p className="text-sm text-muted-foreground">
-                    {listings.length} active listing{listings.length === 1 ? '' : 's'} on Etsy. Only active listings are
-                    shown here — drafts sitting on Etsy outside this app aren't included.
+                    {listings.length} listing{listings.length === 1 ? '' : 's'} on Etsy (active and sold out). Drafts
+                    sitting on Etsy outside this app aren't included.
                 </p>
             </div>
 
@@ -83,8 +84,10 @@ const Listings = () => {
                         <EmptyMedia variant="icon">
                             <ShoppingBag />
                         </EmptyMedia>
-                        <EmptyTitle>No Active Listings</EmptyTitle>
-                        <EmptyDescription>Your shop has no active Etsy listings right now.</EmptyDescription>
+                        <EmptyTitle>No Listings</EmptyTitle>
+                        <EmptyDescription>
+                            Your shop has no active or sold-out Etsy listings right now.
+                        </EmptyDescription>
                     </EmptyHeader>
                 </Empty>
             ) : filteredListings.length === 0 ? (
@@ -101,6 +104,7 @@ const Listings = () => {
                 <Table>
                     <TableHeader>
                         <TableRow>
+                            <TableHead />
                             <TableHead>Title</TableHead>
                             <TableHead>Price</TableHead>
                             <TableHead>Linked Design</TableHead>
@@ -110,7 +114,23 @@ const Listings = () => {
                     <TableBody>
                         {filteredListings.map((listing) => (
                             <TableRow key={listing.listingId}>
-                                <TableCell className="font-medium">{listing.title}</TableCell>
+                                <TableCell>
+                                    {listing.imageUrl ? (
+                                        <img
+                                            src={listing.imageUrl}
+                                            alt={listing.title}
+                                            className="h-10 w-10 rounded object-cover"
+                                        />
+                                    ) : (
+                                        <div className="h-10 w-10 rounded bg-muted" />
+                                    )}
+                                </TableCell>
+                                <TableCell className="font-medium">
+                                    <div className="flex items-center gap-2">
+                                        {listing.title}
+                                        {listing.state === 'sold_out' && <Badge variant="secondary">Sold out</Badge>}
+                                    </div>
+                                </TableCell>
                                 <TableCell>£{listing.price.toFixed(2)}</TableCell>
                                 <TableCell>
                                     {listing.linkedDesignId ? (

--- a/packages/web/tests/e2e/listings.spec.ts
+++ b/packages/web/tests/e2e/listings.spec.ts
@@ -12,24 +12,50 @@ const LISTINGS = [
         title: 'Silver Moon Pendant Necklace',
         price: 24.99,
         url: 'https://etsy.com/listing/1',
+        state: 'active',
+        imageUrl: null,
         linkedDesignId: null,
     },
-    { listingId: 2, title: 'Gold Hoop Earrings', price: 18.5, url: 'https://etsy.com/listing/2', linkedDesignId: null },
+    {
+        listingId: 2,
+        title: 'Gold Hoop Earrings',
+        price: 18.5,
+        url: 'https://etsy.com/listing/2',
+        state: 'active',
+        imageUrl: null,
+        linkedDesignId: null,
+    },
     {
         listingId: 3,
         title: 'Beaded Charm Bracelet',
         price: 12.0,
         url: 'https://etsy.com/listing/3',
+        state: 'active',
+        imageUrl: null,
         linkedDesignId: null,
     },
 ];
 
-async function mockConnectedListings(page: Page) {
+const SOLD_OUT_LISTING = {
+    listingId: 4,
+    title: 'Vintage Rose Brooch',
+    price: 32.0,
+    url: 'https://etsy.com/listing/4',
+    state: 'sold_out',
+    imageUrl: 'https://i.etsy.com/4-75x75.jpg',
+    linkedDesignId: null,
+};
+
+async function mockConnectedListings(page: Page, extra: unknown[] = []) {
     await page.route('**/api/etsy/connection', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ connected: true }) })
     );
     await page.route('**/api/etsy/listings', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(LISTINGS) })
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([...LISTINGS, ...extra]),
+        })
     );
 }
 
@@ -68,5 +94,20 @@ test.describe('Etsy Listings search', () => {
         await page.getByPlaceholder('Search listings...').fill('nonexistent listing xyz');
 
         await expect(page.getByText('No Matching Listings')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('sold-out listing shows a "Sold out" badge and its image', async ({ authenticatedPage: page }) => {
+        await mockConnectedListings(page, [SOLD_OUT_LISTING]);
+
+        await page.goto('/listings');
+        await page.waitForLoadState('networkidle');
+
+        const soldOutRow = page.locator('tr').filter({ hasText: SOLD_OUT_LISTING.title });
+        await expect(soldOutRow).toBeVisible({ timeout: 10000 });
+        await expect(soldOutRow.getByText('Sold out')).toBeVisible();
+        await expect(soldOutRow.locator('img')).toHaveAttribute('src', SOLD_OUT_LISTING.imageUrl);
+
+        const activeRow = page.locator('tr').filter({ hasText: 'Silver Moon Pendant Necklace' });
+        await expect(activeRow.getByText('Sold out')).not.toBeVisible();
     });
 });


### PR DESCRIPTION
Previously only active listings were fetched (unauthenticated `/listings/active`
endpoint). Now uses the authenticated `getListingsByShop` endpoint (Etsy API v3,
`listings_r` scope — already granted at connect time) with `state=active` and
`state=sold_out`, requesting `includes=Images` in the same call. The Listings
page shows a thumbnail per listing and a "Sold out" badge.

## Test plan
- Updated `EtsyClient`, `EtsyStatusService`, `EtsyReconcileService` unit tests
  for the new `getShopListingsByState` method.
- New Playwright coverage in `listings.spec.ts`: sold-out listing shows its
  badge + image; active listings don't.