### PR TITLE
feat: show linked Etsy listing image on design cards

### DIFF
--- a/packages/api/src/domain/EtsyReconcileService/index.test.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.test.ts
@@ -203,9 +203,15 @@ describe('EtsyReconcileService.linkListingToDesign', () => {
         mockEtsyClient.getShopListingsByState.mockResolvedValue([
             { listingId: 555, title: 'Silver Ring', price: 25, url: 'https://etsy.com/555' },
         ]);
+        mockEtsyClient.getListingDetail.mockResolvedValue({
+            title: 'Silver Ring',
+            description: 'A lovely ring.',
+            price: 25,
+            imageUrls: ['https://i.etsy.com/555.jpg'],
+        });
     });
 
-    it('writes the etsy link onto an existing unlinked design', async () => {
+    it('writes the etsy link (with the listing image) onto an existing unlinked design', async () => {
         mockDesignRepo.getByIdAndUserId.mockResolvedValue(makeDesign({ id: 'design-9' }));
 
         await makeService().linkListingToDesign(555, 'design-9', 'user-1');
@@ -213,7 +219,12 @@ describe('EtsyReconcileService.linkListingToDesign', () => {
         expect(mockDesignRepo.update).toHaveBeenCalledTimes(1);
         const [id, updated] = mockDesignRepo.update.mock.calls[0]! as [string, Design];
         expect(id).toBe('design-9');
-        expect(updated.etsy).toEqual({ listingId: 555, state: 'active', lastPushedAt: null });
+        expect(updated.etsy).toEqual({
+            listingId: 555,
+            state: 'active',
+            lastPushedAt: null,
+            imageUrls: ['https://i.etsy.com/555.jpg'],
+        });
     });
 
     it('rejects with 404 when the design does not belong to the user', async () => {

--- a/packages/api/src/domain/EtsyReconcileService/index.ts
+++ b/packages/api/src/domain/EtsyReconcileService/index.ts
@@ -106,7 +106,11 @@ export class EtsyReconcileService {
 
         await this.assertListingIsLinkable(listingId, userId);
 
-        const updated: Design = { ...design, etsy: { listingId, state: 'active', lastPushedAt: null } };
+        const detail = await this.etsyClient.getListingDetail(listingId);
+        const updated: Design = {
+            ...design,
+            etsy: { listingId, state: 'active', lastPushedAt: null, imageUrls: detail.imageUrls },
+        };
         await this.designRepo.update(designId, updated);
     }
 }

--- a/packages/web/src/components/DesignCard/index.tsx
+++ b/packages/web/src/components/DesignCard/index.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '@imapps/web-utils';
 import type { Design } from '@jewellery-catalogue/types';
-import { Clock, Heart, PackageOpen, Trash2 } from 'lucide-react';
+import { Clock, Heart, PackageOpen, ShoppingBag, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import makeDeleteDesignRequest from '../../api/endpoints/deleteDesign';
@@ -28,6 +28,7 @@ export interface DesignCardProps {
 
 export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated }) => {
     const { name, timeRequired, id, imageIds, totalQuantity } = design;
+    const etsyImageUrl = design.etsy?.imageUrls?.[0];
     const [isFavorite, setIsFavorite] = useState(false);
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -103,8 +104,21 @@ export const DesignCard: React.FC<DesignCardProps> = ({ design, onDesignUpdated 
                     </Button>
                 </div>
                 <ItemHeader className="basis-auto justify-start">
-                    <div className="w-64 h-64">
+                    <div className="w-64 h-64 relative">
                         <Image imageId={imageIds?.[0] ?? ''} />
+                        {etsyImageUrl && (
+                            <div
+                                className="absolute bottom-2 left-2 h-10 w-10 rounded-md border-2 border-background bg-muted overflow-hidden shadow"
+                                title="Linked Etsy listing image"
+                            >
+                                <img
+                                    src={etsyImageUrl}
+                                    alt="Linked Etsy listing"
+                                    className="h-full w-full object-cover"
+                                />
+                                <ShoppingBag className="absolute -top-1 -right-1 h-3.5 w-3.5 text-primary bg-background rounded-full p-0.5" />
+                            </div>
+                        )}
                     </div>
                 </ItemHeader>
                 <ItemContent className="flex-none items-start text-left w-full">

--- a/packages/web/tests/e2e/design-etsy-image.spec.ts
+++ b/packages/web/tests/e2e/design-etsy-image.spec.ts
@@ -1,0 +1,56 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { MOCK_TOKEN_DESIGN_ETSY_IMAGE } from './mocks/auth';
+import { apiCreateDesign } from './utils/api-helpers';
+
+const TOKEN = MOCK_TOKEN_DESIGN_ETSY_IMAGE;
+
+test.use({ authToken: TOKEN });
+
+async function apiLinkDesignToEtsyListing(designId: string, imageUrl: string) {
+    const res = await fetch(`${process.env.E2E_API_SERVICE_URL || 'http://localhost:3001'}/api/designs/${designId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+        body: JSON.stringify({
+            etsy: { listingId: 123, state: 'active', lastPushedAt: null, imageUrls: [imageUrl] },
+        }),
+    });
+    if (!res.ok) throw new Error(`apiLinkDesignToEtsyListing failed: ${await res.text()}`);
+}
+
+function findDesignCard(page: Page, designName: string) {
+    const title = page.locator('[data-slot="item-title"]').filter({ hasText: designName });
+    return page.locator('[data-slot="item"]').filter({ has: title });
+}
+
+test.describe
+    .serial('Design card Etsy image', () => {
+        test('shows the linked listing image on a design linked to Etsy @smoke', async ({
+            authenticatedPage: page,
+        }) => {
+            const design = await apiCreateDesign(TOKEN, { name: 'Etsy Linked Design', price: 15.0 });
+            await apiLinkDesignToEtsyListing(design.id, 'https://i.etsy.com/123-fullxfull.jpg');
+
+            await page.goto('/designs');
+            await page.waitForLoadState('networkidle');
+
+            const card = findDesignCard(page, 'Etsy Linked Design');
+            await expect(card).toBeVisible({ timeout: 10000 });
+            await expect(card.getByTitle('Linked Etsy listing image')).toBeVisible();
+            await expect(card.getByTitle('Linked Etsy listing image').locator('img')).toHaveAttribute(
+                'src',
+                'https://i.etsy.com/123-fullxfull.jpg'
+            );
+        });
+
+        test('design with no linked Etsy listing shows no Etsy image badge', async ({ authenticatedPage: page }) => {
+            await apiCreateDesign(TOKEN, { name: 'Unlinked Design', price: 8.0 });
+
+            await page.goto('/designs');
+            await page.waitForLoadState('networkidle');
+
+            const card = findDesignCard(page, 'Unlinked Design');
+            await expect(card).toBeVisible({ timeout: 10000 });
+            await expect(card.getByTitle('Linked Etsy listing image')).not.toBeVisible();
+        });
+    });

--- a/packages/web/tests/e2e/mocks/auth.ts
+++ b/packages/web/tests/e2e/mocks/auth.ts
@@ -16,6 +16,7 @@ export const MOCK_TOKEN = makeMockToken('68c6f0f5b97c946129015116'); // material
 export const MOCK_TOKEN_MATERIALS_CRUD = makeMockToken('68c6f0f5b97c946129015119'); // materials-crud.spec
 export const MOCK_TOKEN_DESIGN_INVENTORY = makeMockToken('68c6f0f5b97c946129015120'); // design-inventory.spec
 export const MOCK_TOKEN_LISTINGS = makeMockToken('68c6f0f5b97c946129015121'); // listings.spec
+export const MOCK_TOKEN_DESIGN_ETSY_IMAGE = makeMockToken('68c6f0f5b97c946129015122'); // design-etsy-image.spec
 
 export const MOCK_USER = { id: '68c6f0f5b97c946129015116', username: 'testuser' };
 


### PR DESCRIPTION
Design cards for a design linked to an Etsy listing now show a small
thumbnail badge of the listing's image. Also populates \`etsy.imageUrls\`
when linking an existing design to a listing (previously only set on
create-from-listing), so the badge shows up for both reconcile paths.

## Test plan
- Updated \`EtsyReconcileService.linkListingToDesign\` unit test to assert
  \`imageUrls\` is persisted.
- New Playwright spec \`design-etsy-image.spec.ts\`: linked design shows the
  badge+image; unlinked design does not.