### PR TITLE
test: verify editing a design never triggers an Etsy publish

### DIFF
--- a/packages/web/tests/e2e/design-edit-no-etsy-push.spec.ts
+++ b/packages/web/tests/e2e/design-edit-no-etsy-push.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from './fixtures';
+import { MOCK_TOKEN_DESIGN_EDIT_NO_PUSH } from './mocks/auth';
+import { apiCreateBead, apiCreateDesign, apiGetDesigns } from './utils/api-helpers';
+
+const TOKEN = MOCK_TOKEN_DESIGN_EDIT_NO_PUSH;
+const API_URL = process.env.E2E_API_SERVICE_URL || 'http://localhost:3001';
+
+test.use({ authToken: TOKEN });
+
+test.describe('Editing a design never publishes to Etsy', () => {
+    test('saving description changes on an Etsy-linked design does not call etsy-push', async ({
+        authenticatedPage: page,
+    }) => {
+        const bead = await apiCreateBead(TOKEN, { name: 'Draft Test Bead' });
+        const design = await apiCreateDesign(TOKEN, {
+            name: 'Etsy Linked Draft',
+            price: 12.0,
+            materials: [{ ...bead, requiredQuantity: 1 }],
+            totalMaterialCosts: (bead as { pricePerBead: number }).pricePerBead,
+        });
+        // designType is required by the edit form's validation but isn't part of apiCreateDesign's
+        // input shape, so set it (along with the etsy link) via a follow-up PUT.
+        const linkRes = await fetch(`${API_URL}/api/designs/${design.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+            body: JSON.stringify({
+                designType: 'RING',
+                etsy: { listingId: 999, state: 'active', lastPushedAt: null },
+            }),
+        });
+        expect(linkRes.ok).toBe(true);
+
+        const etsyPushRequests: string[] = [];
+        page.on('request', (req) => {
+            if (req.url().includes('/etsy-push')) etsyPushRequests.push(req.url());
+        });
+
+        await page.goto(`/designs/${design.id}`);
+        await page.waitForLoadState('networkidle');
+
+        await page.getByRole('button', { name: 'Edit Details' }).click();
+        await expect(page.getByText('Edit Design Properties')).toBeVisible({ timeout: 10000 });
+
+        await page.locator('.ProseMirror').click();
+        await page.keyboard.type('Updated maker description, not yet ready for Etsy.');
+        // Required by the form's validation despite being labeled optional — unrelated
+        // pre-existing quirk, just needs a value so the save isn't blocked.
+        await page.getByRole('spinbutton', { name: 'Low Stock Threshold (Optional)' }).fill('5');
+
+        const patchResponse = page.waitForResponse(
+            (res) => res.url().includes(`/api/designs/${design.id}`) && res.request().method() === 'PATCH'
+        );
+        await page.getByRole('button', { name: 'Save Changes' }).click();
+        await patchResponse;
+
+        await expect(page.getByText('Design updated successfully!')).toBeVisible({ timeout: 10000 });
+
+        expect(etsyPushRequests).toEqual([]);
+
+        const designs = await apiGetDesigns(TOKEN);
+        const updated = designs.find((d) => d.id === design.id);
+        expect((updated as { description?: string })?.description).toContain(
+            'Updated maker description, not yet ready for Etsy.'
+        );
+        expect((updated as { etsy?: { lastPushedAt: number | null } })?.etsy?.lastPushedAt).toBeNull();
+    });
+});

--- a/packages/web/tests/e2e/mocks/auth.ts
+++ b/packages/web/tests/e2e/mocks/auth.ts
@@ -17,6 +17,7 @@ export const MOCK_TOKEN_MATERIALS_CRUD = makeMockToken('68c6f0f5b97c946129015119
 export const MOCK_TOKEN_DESIGN_INVENTORY = makeMockToken('68c6f0f5b97c946129015120'); // design-inventory.spec
 export const MOCK_TOKEN_LISTINGS = makeMockToken('68c6f0f5b97c946129015121'); // listings.spec
 export const MOCK_TOKEN_DESIGN_ETSY_IMAGE = makeMockToken('68c6f0f5b97c946129015122'); // design-etsy-image.spec
+export const MOCK_TOKEN_DESIGN_EDIT_NO_PUSH = makeMockToken('68c6f0f5b97c946129015123'); // design-edit-no-etsy-push.spec
 
 export const MOCK_USER = { id: '68c6f0f5b97c946129015116', username: 'testuser' };
 


### PR DESCRIPTION
Investigated: \`DesignService\` has no dependency on \`EtsyClient\`/
\`EtsyConnectionService\` at all, and neither \`editDesignProperties\` nor
\`updateDesign\` reference Etsy anywhere — a plain design save is already
structurally incapable of publishing to Etsy. Publishing only ever happens
through the explicit "Send to Etsy" dialog (\`POST .../etsy-push\`), which the
user must open and confirm separately. No application bug found, so no
application code changed.

This PR adds a regression test pinning that invariant down at the network
level, per the acceptance criteria ask to verify it with a test.

## Test plan
- New Playwright spec: edits an Etsy-linked design's description via
  "Edit Details" → Save, asserts zero requests to \`etsy-push\` fired, and
  that the description change did persist via \`PATCH /api/designs/:id\`.